### PR TITLE
Added toast functionality

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { BrowserRouter as Router, Route } from "react-router-dom";
+import { withToastProvider } from "./contexts/Toast";
 import TdmCalculationContainer from "./components/TdmCalculationContainer";
 import Header from "./components/Header";
 import NavBar from "./components/NavBar";
@@ -99,4 +100,4 @@ function setTokenInHeaders() {
   );
 }
 
-export default App;
+export default withToastProvider(App);

--- a/client/src/components/About.js
+++ b/client/src/components/About.js
@@ -1,6 +1,12 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { useToast } from "../contexts/Toast";
 
 const About = () => {
+  const toast = useToast();
+
+  useEffect(() => {
+    toast.add("hello world");
+  }, []);
   return <>About</>;
 };
 

--- a/client/src/components/ContactUs.js
+++ b/client/src/components/ContactUs.js
@@ -1,7 +1,13 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { useToast } from "../contexts/Toast";
 
 const ContactUs = () => {
-    return <>ContactUs</>
-}
+  const toast = useToast();
+
+  useEffect(() => {
+    toast.add("check it out");
+  }, []);
+  return <>ContactUs</>;
+};
 
 export default ContactUs;

--- a/client/src/contexts/Toast/Toast.js
+++ b/client/src/contexts/Toast/Toast.js
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef } from "react";
+
+const Toast = ({ children, remove }) => {
+  const removeRef = useRef();
+  removeRef.current = remove;
+
+  useEffect(() => {
+    const duration = 5000;
+    const id = setTimeout(() => removeRef.current(), duration);
+
+    return () => clearTimeout(id);
+  }, []);
+
+  return (
+    <div
+      style={{
+        border: "2px solid transparent",
+        backgroundColor: "#fafafa",
+        borderRadius: "4px",
+        maxWidth: "480px",
+        boxShadow: "0px 0px 5px rgba(0, 0, 0, .2)",
+        marginTop: "16px",
+        display: "flex",
+        position: "relative",
+        cursor: "pointer"
+      }}
+    >
+      <div
+        style={{
+          padding: "16px 24px",
+          lineHeight: "1.4"
+        }}
+      >
+        {children}
+      </div>
+      <div>
+        <button
+          onClick={remove}
+          style={{
+            border: "none",
+            backgroundColor: "transparent",
+            fontSize: "16px",
+            marginTop: "8px",
+            marginRight: "8px",
+            cursor: "pointer"
+          }}
+        >
+          x
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Toast;

--- a/client/src/contexts/Toast/ToastContext.js
+++ b/client/src/contexts/Toast/ToastContext.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+const ToastContext = React.createContext(null);
+
+export default ToastContext;

--- a/client/src/contexts/Toast/index.js
+++ b/client/src/contexts/Toast/index.js
@@ -1,0 +1,4 @@
+import withToastProvider from "./withToastProvider";
+import useToast from "./useToast";
+
+export { withToastProvider, useToast };

--- a/client/src/contexts/Toast/useToast.js
+++ b/client/src/contexts/Toast/useToast.js
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import ToastContext from "./ToastContext";
+
+const useToast = () => {
+  const context = useContext(ToastContext);
+
+  return { add: context.add, remove: context.remove };
+};
+
+export default useToast;

--- a/client/src/contexts/Toast/withToastProvider.js
+++ b/client/src/contexts/Toast/withToastProvider.js
@@ -1,0 +1,52 @@
+import React, { useState } from "react";
+import { createPortal } from "react-dom";
+
+import ToastContext from "./ToastContext";
+import Toast from "./Toast";
+
+const generateUEID = () => {
+  let first = (Math.random() * 46656) | 0;
+  let second = (Math.random() * 46656) | 0;
+  first = ("000" + first.toString(36)).slice(-3);
+  second = ("000" + second.toString(36)).slice(-3);
+
+  return first + second;
+};
+
+const withToastProvider = Component => {
+  const WithToastProvider = props => {
+    const [toasts, setToasts] = useState([]);
+    const add = content => {
+      const id = generateUEID();
+      setToasts([...toasts, { id, content }]);
+    };
+
+    const remove = id => setToasts(toasts.filter(t => t.id !== id));
+
+    return (
+      <ToastContext.Provider value={{ add, remove }}>
+        <Component {...props} />
+        {createPortal(
+          <div
+            style={{
+              position: "absolute",
+              bottom: "20px",
+              right: "20px"
+            }}
+          >
+            {toasts.map(t => (
+              <Toast key={t.id} remove={() => remove(t.id)}>
+                {t.content}
+              </Toast>
+            ))}
+          </div>,
+          document.body
+        )}
+      </ToastContext.Provider>
+    );
+  };
+
+  return WithToastProvider;
+};
+
+export default withToastProvider;


### PR DESCRIPTION
Issue #123 

Added a Toast Context (instead of using a library)
- App.js is wrapped in a ToastProvider, which has properties `add` and `delete` for Toast.
- To use, call `const toast = useToast()`,  `import {} from "/src/contexts/Toast"`

To check out how it works, navigate to `/about` and `/contactus` rapidly.

Example of how to use:
- `toast.add("This is a new toast!")`

Note: Styling the toast can be modified.