### PR TITLE
conditionally hide unused inputs

### DIFF
--- a/client/src/components/ProjectWizard/WizardRuleInputList.js
+++ b/client/src/components/ProjectWizard/WizardRuleInputList.js
@@ -16,13 +16,18 @@ const WizardRuleInputList = props => {
   return (
     <div className={classes.root}>
       {rules && rules.length > 0
-        ? rules.map(rule => (
+        ? rules.map(rule => {
+          if (rule.id === 38 || rule.id ===39) {
+            return
+          }
+          return (
             <WizardRuleInput
               key={rule.id}
               rule={rule}
               onInputChange={props.onInputChange}
             />
-          ))
+          )
+        })
         : null}
     </div>
   );

--- a/client/src/components/ProjectWizard/WizardRuleInputPanels.js
+++ b/client/src/components/ProjectWizard/WizardRuleInputPanels.js
@@ -1,11 +1,12 @@
 import React from "react";
 
 import WizardRuleInputList from "./WizardRuleInputList";
+import Loader from "react-loader";
 import { createUseStyles } from "react-jss";
 
 const useStyles = createUseStyles({
   panelContainer: {
-      margin: "0.5em"
+    margin: "0.5em"
   },
   strategyContainer: {
     minWidth: "60vw",
@@ -20,7 +21,7 @@ const useStyles = createUseStyles({
   },
   strategyName: {
     flexGrow: "1",
-    flexShrink: "1",
+    flexShrink: "1"
   },
   points: {
     flexBasis: "10%",
@@ -28,7 +29,13 @@ const useStyles = createUseStyles({
     marginRight: "0.5em",
     textAlign: "right",
     flexGrow: "0",
-    flexShrink: "1" 
+    flexShrink: "1"
+  },
+  loaderContainer: {
+    width: "100%",
+    height: "50px",
+    display: "flex",
+    justifyContent: "center"
   }
 });
 
@@ -42,39 +49,41 @@ const WizardRuleInputPanels = props => {
   }, []);
   // Group rules into an array where each element is an array of
   // rules for a particular panel
-  const classes = useStyles()
+  const classes = useStyles();
 
   const panelsRules = panelIds.map(panelId => {
     return rules.filter(rule => rule.calculationPanelId === panelId);
   });
-  
+
   return (
     <React.Fragment>
-      {panelsRules && panelsRules.length > 0
-        ? <>
+      {panelsRules && panelsRules.length > 0 ? (
+        <>
           {panelsRules.map(rules => (
-              <div
+            <div
+              key={rules[0].calculationPanelId}
+              className={classes.panelContainer}
+            >
+              {!suppressHeader ? (
+                <div className={classes.strategyContainer}>
+                  <h4 className={classes.strategyName}>{rules[0].panelName}</h4>
+                </div>
+              ) : null}
+              <WizardRuleInputList
                 key={rules[0].calculationPanelId}
-                className={classes.panelContainer}
-              >
-              {!suppressHeader 
-                ? <div className={classes.strategyContainer}>
-                    <h4 className={classes.strategyName}>{rules[0].panelName}</h4>
-                  </div>
-                : null}
-                <WizardRuleInputList
-                  key={rules[0].calculationPanelId}
-                  rules={rules}
-                  onInputChange={props.onInputChange}
-                />
-              </div>
-            ))}
-          </>
-
-        : null}
+                rules={rules}
+                onInputChange={props.onInputChange}
+              />
+            </div>
+          ))}
+        </>
+      ) : (
+        <div className={classes.loaderContainer}>
+          <Loader loaded={false} className="spinner" left="auto" />
+        </div>
+      )}
     </React.Fragment>
   );
 };
 
 export default WizardRuleInputPanels;
-

--- a/client/src/components/TdmCalculationContainer.js
+++ b/client/src/components/TdmCalculationContainer.js
@@ -188,6 +188,17 @@ class TdmCalculationContainer extends React.Component {
   };
 
   onSave = async evt => {
+
+    // For possible future use. Removes null entries from saved inputs
+
+    // const inputsToSave = {...this.state.formInputs}
+    // for (let input in inputsToSave) {
+    //   console.log('input', inputsToSave[input])
+    //   if (!inputsToSave[input]) {
+    //     delete inputsToSave[input]
+    //   }
+    // }
+
     const requestBody = {
       name: this.state.formInputs.PROJECT_NAME,
       address: this.state.formInputs.PROJECT_ADDRESS,

--- a/client/src/components/TdmCalculationContainer.js
+++ b/client/src/components/TdmCalculationContainer.js
@@ -188,7 +188,6 @@ class TdmCalculationContainer extends React.Component {
   };
 
   onSave = async evt => {
-
     // For possible future use. Removes null entries from saved inputs
 
     // const inputsToSave = { ...this.state.formInputs };
@@ -203,7 +202,7 @@ class TdmCalculationContainer extends React.Component {
       name: this.state.formInputs.PROJECT_NAME,
       address: this.state.formInputs.PROJECT_ADDRESS,
       description: this.state.formInputs.PROJECT_DESCRIPTION,
-      formInputs: JSON.stringify(inputsToSave),
+      formInputs: JSON.stringify(this.state.formInputs),
       loginId: this.props.account.id,
       calculationId: this.calculationId
     };

--- a/client/src/services/tdm-engine.js
+++ b/client/src/services/tdm-engine.js
@@ -78,7 +78,7 @@ class Engine {
         }
       }
       // For debugging
-      console.log(this.rules);
+      // console.log(this.rules);
       return results;
     } catch (err) {
       console.log(err);


### PR DESCRIPTION
Issue #217 

Temporary fix to remove the rendering of 2 inactive inputs. Inputs are still included in the calculation so as not to break the engine, but are not rendered on the page so user can not interact with it. Removal of the rendering is currently hard coded until permanent solution can be resolved. 

![Screenshot from 2020-02-01 13-07-45](https://user-images.githubusercontent.com/43628838/73599023-e6508600-44f3-11ea-987b-f39abdc0c556.png)
