### PR TITLE
Check current value not empty for required rules

### DIFF
--- a/client/src/components/ProjectWizard/WizardRuleInput.js
+++ b/client/src/components/ProjectWizard/WizardRuleInput.js
@@ -173,12 +173,18 @@ const WizardRuleInput = ({
     updateRequiredInput(e);
   };
 
+  const isEmpty = value => {
+    return value === null || value.length === 0;
+  };
+
   const updateInput = useCallback(() => {
-    const input = { [code]: isRequired };
+    const input = {
+      [code]: isRequired && isEmpty(value)
+    };
     if (isRequired) {
       setUnfilledRequired(inputs => ({ ...inputs, ...input }));
     }
-  }, [code, isRequired, setUnfilledRequired]);
+  }, [code, isRequired, setUnfilledRequired, value]);
 
   useEffect(() => {
     updateInput();


### PR DESCRIPTION
This fixes the problem of the forward button being disabled when viewing
existing projects with the required values filled in.

Fix for #218 