### PR TITLE
Validations and wizard routing

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -83,7 +83,7 @@ const App = () => {
           <div className={classes.root}>
             <Route exact path="/" component={LandingPage} />
             <Route
-              path="/calculation/:page?"
+              path="/calculation/:page/:projectId?"
               render={() => (
                 <TdmCalculationContainer
                   account={account}

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -83,7 +83,7 @@ const App = () => {
           <div className={classes.root}>
             <Route exact path="/" component={LandingPage} />
             <Route
-              path="/calculation/:projectId?"
+              path="/calculation/:page?"
               render={() => (
                 <TdmCalculationContainer
                   account={account}

--- a/client/src/components/LandingPage/LandingPageSectionEnd.js
+++ b/client/src/components/LandingPage/LandingPageSectionEnd.js
@@ -43,7 +43,7 @@ const LandingPageSectionEnd = () => {
     <div className={classes.root}>
       <h2 className={classes.heading}>Preparing for a new project?</h2>
       <p className={classes.paragraph}>Let us help you get started right.</p>
-      <Link to="/calculation?pageNo=1&view=w" className={classes.startButton}>
+      <Link to="/calculation/1" className={classes.startButton}>
         Get Started
       </Link>
     </div>

--- a/client/src/components/LandingPage/LandingPageSectionHeroImage.js
+++ b/client/src/components/LandingPage/LandingPageSectionHeroImage.js
@@ -59,10 +59,7 @@ const LandingPageSectionHeroImage = () => {
           <br />
           Better for LA.
         </h2>
-        <Link
-          to={"/calculation?pageNo=1&view=w"}
-          className={classes.startButton}
-        >
+        <Link to={"/calculation/1"} className={classes.startButton}>
           Start Your Project
         </Link>
       </div>

--- a/client/src/components/NavBar.js
+++ b/client/src/components/NavBar.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { createUseStyles } from "react-jss";
-import { Link } from "react-router-dom";
+import { Link, withRouter } from "react-router-dom";
 import NavBarLogin from "./NavBarLogin";
 import PropTypes from "prop-types";
 
@@ -39,13 +39,13 @@ const useStyles = createUseStyles({
 });
 
 const NavBar = props => {
-  const { account, setLoggedOutAccount, isCreatingNewProject } = props;
+  const { account, setLoggedOutAccount, location } = props;
   const classes = useStyles();
 
   const showNewProjectLink = () => {
-    return isCreatingNewProject ? null : (
+    return location.pathname.split("/")[1] === "calculation" ? null : (
       <li>
-        <Link className={classes.link} to="/calculation?pageNo=1&view=w">
+        <Link className={classes.link} to="/calculation/1">
           New Project
         </Link>
       </li>
@@ -122,7 +122,10 @@ NavBar.propTypes = {
     isSecurityAdmin: PropTypes.bool
   }),
   setLoggedOutAccount: PropTypes.func,
-  isCreatingNewProject: PropTypes.bool
+  isCreatingNewProject: PropTypes.bool,
+  location: PropTypes.shape({
+    pathname: PropTypes.string
+  })
 };
 
-export default NavBar;
+export default withRouter(NavBar);

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -101,7 +101,7 @@ const TdmCalculationWizard = props => {
       history.push(`/calculation/6/${projectId}`);
       // setPage(6);
     }
-  }, [projectId, account, loginId, pageNo]);
+  }, [projectId, account, loginId, pageNo, history]);
 
   const projectDescriptionRules =
     rules && rules.filter(filters.projectDescriptionRules);

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
 import clsx from "clsx";
@@ -7,6 +7,7 @@ import SidebarPointsPanel from "./SidebarPoints/SidebarPointsPanel";
 import NavButton from "./NavButton";
 import SwitchViewButton from "../SwitchViewButton";
 import Sidebar from "../Sidebar";
+import { Switch, Route, withRouter } from "react-router-dom";
 import {
   ProjectDescriptions,
   ProjectUse,
@@ -81,22 +82,24 @@ const TdmCalculationWizard = props => {
     onSave,
     onPageChange,
     onViewChange,
-    pageNo
+    pageNo,
+    history,
+    match
   } = props;
-  const [page, setPage] = useState(0);
+  const { page } = match.params;
 
   useEffect(() => {
     if (
-      !projectId ||
-      (account && (account.isAdmin || account.id === loginId))
+      !(!projectId || (account && (account.isAdmin || account.id === loginId)))
     ) {
       // Project Calculation is editable if it is not saved
       // or the project was created by the current logged in
       // user, or the logged in user is admin.
-      setPage(pageNo || 1);
-    } else {
+      //   history.push(`/calculation/${pageNo || 1}/`)
+      // } else {
       // read-only users can only see the summary page.
-      setPage(6);
+      history.push(`/calculation/6/${projectId}`);
+      // setPage(6);
     }
   }, [projectId, account, loginId, pageNo]);
 
@@ -122,67 +125,59 @@ const TdmCalculationWizard = props => {
     disablePageNavigation = true;
   }
 
-  const renderSwitch = () => {
-    switch (page) {
-      case 2:
-        return (
-          <ProjectUse
-            rules={landUseRules}
-            onInputChange={onInputChange}
-            classes={classes}
-            uncheckAll={() => onUncheckAll(filters.landUseRules)}
-          />
-        );
-      case 3:
-        return (
-          <ProjectSpecifications
-            rules={specificationRules}
-            onInputChange={onInputChange}
-            classes={classes}
-            uncheckAll={() => onUncheckAll(filters.specificationRules)}
-          />
-        );
-      case 4:
-        return (
-          <ProjectTargetPoints
-            rules={targetPointRules}
-            onInputChange={onInputChange}
-            classes={classes}
-          />
-        );
-      case 5:
-        return (
-          <ProjectMeasures
-            rules={strategyRules}
-            landUseRules={landUseRules}
-            onInputChange={onInputChange}
-            classes={classes}
-            onPkgSelect={onPkgSelect}
-            uncheckAll={() => onUncheckAll(filters.strategyRules)}
-          />
-        );
-      case 6:
-        return (
-          <ProjectSummary
-            rules={rules}
-            account={account}
-            projectId={projectId}
-            loginId={loginId}
-            onSave={onSave}
-          />
-        );
-      case 1:
-      default:
-        return (
-          <ProjectDescriptions
-            rules={projectDescriptionRules}
-            onInputChange={onInputChange}
-            classes={classes}
-          />
-        );
-    }
-  };
-
+  const routes = (
+    <Switch>
+      <Route path="/calculation/1/:projectId?">
+        <ProjectDescriptions
+          rules={projectDescriptionRules}
+          onInputChange={onInputChange}
+          classes={classes}
+        />
+      </Route>
+      <Route path="/calculation/2/:projectId?">
+        <ProjectUse
+          rules={landUseRules}
+          onInputChange={onInputChange}
+          classes={classes}
+          uncheckAll={() => onUncheckAll(filters.landUseRules)}
+        />
+      </Route>
+      <Route path="/calculation/3/:projectId?">
+        <ProjectSpecifications
+          rules={specificationRules}
+          onInputChange={onInputChange}
+          classes={classes}
+          uncheckAll={() => onUncheckAll(filters.specificationRules)}
+        />
+      </Route>
+      <Route path="/calculation/4/:projectId?">
+        <ProjectTargetPoints
+          rules={targetPointRules}
+          onInputChange={onInputChange}
+          classes={classes}
+        />
+      </Route>
+      <Route path="/calculation/5/:projectId?">
+        <ProjectMeasures
+          rules={strategyRules}
+          onInputChange={onInputChange}
+          classes={classes}
+          onPkgSelect={onPkgSelect}
+          uncheckAll={() => onUncheckAll(filters.strategyRules)}
+        />
+      </Route>
+      <Route path="/calculation/6/:projectId?">
+        <ProjectSummary
+          rules={rules}
+          account={account}
+          projectId={projectId}
+          loginId={loginId}
+          onSave={onSave}
+        />
+      </Route>
+    </Switch>
+  );
+  console.log("params", props.match.params);
   return (
     <React.Fragment>
       <div className={clsx("tdm-wizard", classes.root)}>
@@ -202,35 +197,33 @@ const TdmCalculationWizard = props => {
             classes.contentContainer
           )}
         >
-          <div>{renderSwitch()}</div>
-          {!projectId ||
-          (account &&
-            account.id &&
-            (account.id === loginId || account.isAdmin)) ? (
-            <div className={classes.navButtonsWrapper}>
-              <NavButton
-                disabled={page === 1}
-                onClick={() => {
-                  onPageChange(page - 1);
-                }}
-              >
-                &lt;
-              </NavButton>
-              <NavButton
-                disabled={page === 6 || disablePageNavigation}
-                onClick={() => {
-                  onPageChange(page + 1);
-                }}
-              >
-                &gt;
-              </NavButton>
-            </div>
-          ) : null}
+          <div>{routes}</div>
+          {/* {!projectId || (account && account.id && account.id === loginId) ? ( */}
+          <div className={classes.navButtonsWrapper}>
+            <NavButton
+              disabled={Number(page) === 1}
+              onClick={() => {
+                onPageChange(Number(page) - 1);
+              }}
+            >
+              &lt;
+            </NavButton>
+            <NavButton
+              disabled={page === 6 || disablePageNavigation}
+              onClick={() => {
+                onPageChange(Number(page) + 1);
+              }}
+            >
+              &gt;
+            </NavButton>
+          </div>
+          {/* ) : null} */}
         </div>
       </div>
     </React.Fragment>
   );
 };
+
 TdmCalculationWizard.propTypes = {
   rules: PropTypes.arrayOf(
     PropTypes.shape({
@@ -242,7 +235,7 @@ TdmCalculationWizard.propTypes = {
       minValue: PropTypes.number,
       maxValue: PropTypes.number,
       choices: PropTypes.array,
-      calcValue: PropTypes.any,
+      calcValue: PropTypes.number,
       calcUnits: PropTypes.string,
       required: PropTypes.bool,
       minStringLength: PropTypes.number,
@@ -250,6 +243,14 @@ TdmCalculationWizard.propTypes = {
       validationErrors: PropTypes.array
     })
   ).isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      page: PropTypes.number
+    })
+  }),
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired
+  }),
   onInputChange: PropTypes.func.isRequired,
   onPkgSelect: PropTypes.func.isRequired,
   onUncheckAll: PropTypes.func.isRequired,
@@ -264,4 +265,4 @@ TdmCalculationWizard.propTypes = {
   pageNo: PropTypes.number.isRequired
 };
 
-export default TdmCalculationWizard;
+export default withRouter(TdmCalculationWizard);

--- a/client/src/components/ProjectWizard/WizardPages/ProjectDescriptions.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectDescriptions.js
@@ -4,7 +4,7 @@ import RuleInputPanels from "../RuleInput/RuleInputPanels";
 
 function ProjectDescriptions(props) {
   const { rules, onInputChange } = props;
-
+  console.log("rules", rules);
   return (
     <div>
       <h1 className="tdm-wizard-page-title">

--- a/client/src/components/Projects.js
+++ b/client/src/components/Projects.js
@@ -178,7 +178,7 @@ const Projects = () => {
               <tr key={project.id}>
                 <td className={classes.td}>
                   <Link
-                    to={`/calculation/${project.id}`}
+                    to={`/calculation/1/${project.id}`}
                     className={classes.link}
                   >
                     {project.name}

--- a/client/src/components/TdmCalculationContainer.js
+++ b/client/src/components/TdmCalculationContainer.js
@@ -66,14 +66,14 @@ export function TdmCalculationContainer(props) {
           resultRuleCodes
         );
         setRules(TdmCalculationContainer.engine.showRulesArray());
-        // });
       } catch (err) {
         console.log(JSON.stringify(err, null, 2));
         getRules();
       }
     };
     initiateEngine();
-  }, []);
+  }, [getRules, props.match, resultRuleCodes]);
+
   const onPkgSelect = pkgType => {
     let pkgRules = [];
     if (pkgType === "Residential") {

--- a/client/src/components/TdmCalculationContainer.js
+++ b/client/src/components/TdmCalculationContainer.js
@@ -1,6 +1,7 @@
-import React from "react";
+/* eslint-disable linebreak-style */
+import React, { useEffect, useState, useContext } from "react";
+import PropTypes from "prop-types";
 import { withRouter } from "react-router-dom";
-import queryString from "query-string";
 import TdmCalculation from "./ProjectSinglePage/TdmCalculation";
 import TdmCalculationWizard from "./ProjectWizard/TdmCalculationWizard";
 import * as ruleService from "../services/rule.service";
@@ -17,99 +18,75 @@ const styles = {
   }
 };
 
-class TdmCalculationContainer extends React.Component {
-  engine = null;
-
-  static contextType = ToastContext;
+export function TdmCalculationContainer(props) {
+  const context = useContext(ToastContext);
 
   // These are the calculation results we want to calculate
   // and display on the main page.
-  resultRuleCodes = [
+  const resultRuleCodes = [
     "PROJECT_LEVEL",
     "CALC_PARK_RATIO",
     "TARGET_POINTS_PARK",
     "PTS_EARNED"
   ];
 
-  state = {
-    rules: [],
-    formInputs: {},
-    projectId: 0,
-    loginId: 0, // Project creator's loginId
-    view: "w", // "w" for wizard view, "d" for old default
-    pageNo: 1
+  const [rules, setRules] = useState([]);
+  const [formInputs, setFormInputs] = useState({});
+  const [projectId, setProjectId] = useState("");
+  const [loginId, setLoginId] = useState(0);
+  const [view, setView] = useState("w");
+  const [pageNo, setPageNo] = useState(1);
+
+  const pushHistory = () => {
+    props.history.push(`/calculation/${pageNo}/${projectId}`);
   };
 
-  pushHistory = () => {
-    const qs = queryString.stringify({
-      view: this.state.view,
-      pageNo: this.state.pageNo
-    });
-    const url = this.props.location.pathname + "?" + qs;
-    this.props.history.push(url);
+  const getRules = async () => {
+    const ruleResponse = await ruleService.getByCalculationId(
+      TdmCalculationContainer.calculationId
+    );
+    TdmCalculationContainer.engine = new Engine(ruleResponse.data);
+    TdmCalculationContainer.engine.run(formInputs, resultRuleCodes);
+    setRules(TdmCalculationContainer.engine.showRulesArray());
   };
 
-  async componentDidMount() {
-    const { pageNo, view } = queryString.parse(this.props.location.search);
-    if (pageNo) {
-      this.setState({ pageNo: Number(pageNo) });
-    }
-    if (view && view === "d") {
-      this.setState({ view });
-    }
-    try {
-      if (this.props.match.params.projectId) {
-        const projectId = this.props.match.params.projectId;
-        const projectResponse = await projectService.getById(projectId);
-        this.setState({
-          projectId: projectId ? Number(projectId) : null,
-          loginId: projectResponse.data.loginId,
-          formInputs: JSON.parse(projectResponse.data.formInputs)
-        });
+  useEffect(() => {
+    const initiateEngine = async () => {
+      const { params } = props.match;
+      try {
+        if (params.projectId) {
+          const projectId = props.match.params.projectId;
+          const projectResponse = await projectService.getById(projectId);
+          setProjectId(projectId ? Number(projectId) : null);
+          setLoginId(projectResponse.data.loginId);
+          setFormInputs(JSON.parse(projectResponse.data.formInputs));
+        }
+
+        const ruleResponse = await ruleService.getByCalculationId(
+          TdmCalculationContainer.calculationId
+        );
+        TdmCalculationContainer.engine = new Engine(ruleResponse.data);
+        TdmCalculationContainer.engine.run(formInputs, resultRuleCodes);
+        setRules(TdmCalculationContainer.engine.showRulesArray());
+        // });
+      } catch (err) {
+        console.log(JSON.stringify(err, null, 2));
       }
+      getRules();
+    };
+    initiateEngine();
+  }, []);
 
-      const ruleResponse = await ruleService.getByCalculationId(
-        TdmCalculationContainer.calculationId
-      );
-      this.engine = new Engine(ruleResponse.data);
-      // console.log("Calculation Rules:");
-      // console.log(JSON.stringify(ruleResponse.data, null, 2));
-      this.engine.run(this.state.formInputs, this.resultRuleCodes);
-      this.setState({
-        rules: this.engine.showRulesArray()
-      });
-    } catch (err) {
-      console.log(JSON.stringify(err, null, 2));
-    }
-  }
-
-  componentDidUpdate = async prevProps => {
-    if (prevProps.location.search !== this.props.location.search) {
-      let query = queryString.parse(this.props.location.search);
-      if (query.pageNo) {
-        this.setState({
-          pageNo: parseInt(query.pageNo)
-        });
-      }
-    }
-
-    this.props.setIsCreatingNewProject(true);
-  };
-
-  componentWillUnmount = () => {
-    this.props.setIsCreatingNewProject(false);
-  };
-
-  onPkgSelect = pkgType => {
+  const onPkgSelect = pkgType => {
     let pkgRules = [];
     if (pkgType === "Residential") {
-      pkgRules = this.state.rules.filter(rule =>
+      pkgRules = rules.filter(rule =>
         ["STRATEGY_BIKE_4", "STRATEGY_INFO_3", "STRATEGY_PARKING_1"].includes(
           rule.code
         )
       );
     } else {
-      pkgRules = this.state.rules.filter(rule =>
+      pkgRules = rules.filter(rule =>
         ["STRATEGY_BIKE_4", "STRATEGY_INFO_3", "STRATEGY_PARKING_2"].includes(
           rule.code
         )
@@ -120,26 +97,26 @@ class TdmCalculationContainer extends React.Component {
       changedProps[rule.code] = true;
       return changedProps;
     }, {});
-    const formInputs = {
-      ...this.state.formInputs,
+    const newFormInputs = {
+      ...formInputs,
       ...modifiedInputs
     };
-    this.recalculate(formInputs);
+    recalculate(newFormInputs);
   };
 
-  getRuleByCode = ruleCode => {
-    const rule = this.state.rules.find(rule => rule.code === ruleCode);
+  const getRuleByCode = ruleCode => {
+    const rule = rules.find(rule => rule.code === ruleCode);
     if (rule === undefined) {
       throw new Error("Rule not found for code " + ruleCode);
     }
     return rule;
   };
 
-  limitToInt = value => {
+  const limitToInt = value => {
     return value.replace(/\D/g, "");
   };
 
-  limitMinMax = (value, min, max) => {
+  const limitMinMax = (value, min, max) => {
     if (min !== null) {
       value = value < min ? min : value;
     }
@@ -149,7 +126,7 @@ class TdmCalculationContainer extends React.Component {
     return value;
   };
 
-  onInputChange = e => {
+  const onInputChange = e => {
     const ruleCode = e.target.name;
     let value =
       e.target.type === "checkbox" ? e.target.checked : e.target.value;
@@ -157,24 +134,23 @@ class TdmCalculationContainer extends React.Component {
       throw new Error("Input is missing name attribute");
     }
 
-    const rule = this.getRuleByCode(ruleCode);
+    const rule = getRuleByCode(ruleCode);
 
     // Convert value to appropriate Data type
     if (rule.dataType === "number") {
-      value = this.limitToInt(value);
-      value = this.limitMinMax(value, rule.minValue, rule.maxValue);
+      value = limitToInt(value);
+      value = limitMinMax(value, rule.minValue, rule.maxValue);
       value = value === "0" ? "" : value;
     }
 
-    const formInputs = {
-      ...this.state.formInputs,
+    const newFormInputs = {
+      ...formInputs,
       [e.target.name]: value
     };
-    this.recalculate(formInputs);
+    recalculate(newFormInputs);
   };
 
-  onUncheckAll = filterRules => {
-    const { rules, formInputs } = this.state;
+  const onUncheckAll = filterRules => {
     let updateInputs = { ...formInputs };
     for (let i = 0; i < rules.length; i++) {
       if (filterRules(rules[i])) {
@@ -183,17 +159,11 @@ class TdmCalculationContainer extends React.Component {
         }
       }
     }
-    this.recalculate(updateInputs);
+    recalculate(updateInputs);
   };
 
-  onSave = async evt => {
-    if (this.props.account.id !== this.loginId) {
-      console.log(`Failed to save - user is not project owner.`);
-      return;
-    }
-
-    // Only save inputs that have a value
-    const inputsToSave = { ...this.state.formInputs };
+  const onSave = async () => {
+    const inputsToSave = { ...formInputs };
     for (let input in inputsToSave) {
       console.log("input", inputsToSave[input]);
       if (!inputsToSave[input]) {
@@ -202,52 +172,83 @@ class TdmCalculationContainer extends React.Component {
     }
 
     const requestBody = {
-      name: this.state.formInputs.PROJECT_NAME,
-      address: this.state.formInputs.PROJECT_ADDRESS,
-      description: this.state.formInputs.PROJECT_DESCRIPTION,
+      name: formInputs.PROJECT_NAME,
+      address: formInputs.PROJECT_ADDRESS,
+      description: formInputs.PROJECT_DESCRIPTION,
       formInputs: JSON.stringify(inputsToSave),
-      loginId: this.props.account.id,
+      loginId: props.account.id,
       calculationId: TdmCalculationContainer.calculationId
     };
     if (!requestBody.name) {
-      this.context.add("You must give the project a name before saving.");
+      context.add("You must give the project a name before saving.");
       return;
     }
-    if (this.state.projectId) {
-      requestBody.id = this.state.projectId;
+    if (projectId) {
+      requestBody.id = projectId;
       try {
         await projectService.put(requestBody);
-        this.context.add("Saved Project Changes");
+        context.add("Saved Project Changes");
       } catch (err) {
         console.log(err);
       }
     } else {
       try {
         const postResponse = await projectService.post(requestBody);
-        this.setState(
-          {
-            projectId: postResponse.data.id,
-            loginId: this.props.account.id
-          },
-          () => {
-            this.context.add("Saved New Project");
-          }
-        );
+        setProjectId(postResponse.data.id);
+        setLoginId(props.account.id);
+        context.add("Saved New Project");
       } catch (err) {
         console.log(err);
       }
     }
   };
 
-  recalculate = formInputs => {
-    this.engine.run(formInputs, this.resultRuleCodes);
-    const rules = this.engine.showRulesArray();
+  const recalculate = formInputs => {
+    TdmCalculationContainer.engine.run(formInputs, resultRuleCodes);
+    const rules = TdmCalculationContainer.engine.showRulesArray();
     // update state with modified formInputs and rules
     // const showWork = this.engine.showWork("PARK_REQUIREMENT");
-    this.setState({ formInputs, rules });
+    setFormInputs(formInputs);
+    setRules(rules);
   };
 
-  filters = {
+  const handleValidate = () => {
+    const validations = {
+      1: () => true,
+      2: () => {
+        let selected = false;
+        let landUseRules = rules.filter(filters.landUseRules);
+        landUseRules.forEach(val => {
+          if (val.value === true) {
+            selected = true;
+          }
+        });
+        return selected;
+      },
+      3: () => true,
+      4: () => true,
+      5: () => true
+    };
+
+    return validations[props.match.params.page]();
+  };
+
+  const onPageChange = pageNo => {
+    console.log("pageNo", pageNo);
+    const { page, projectId } = props.match.params;
+    const projectIdParam = projectId ? `/${projectId}` : "";
+    if (Number(pageNo) > Number(props.match.params.page)) {
+      if (handleValidate()) {
+        setPageNo(pageNo);
+        props.history.push(`/calculation/${Number(page) + 1}${projectIdParam}`);
+      }
+    } else {
+      setPageNo(pageNo);
+      props.history.push(`/calculation/${Number(page) - 1}${projectIdParam}`);
+    }
+  };
+
+  const filters = {
     projectDescriptionRules: rule =>
       rule.category === "input" &&
       rule.calculationPanelId === 31 &&
@@ -276,51 +277,66 @@ class TdmCalculationContainer extends React.Component {
       rule.calculationPanelId !== 10
   };
 
-  render() {
-    const { rules, view, projectId, loginId, pageNo } = this.state;
-    const { account, classes } = this.props;
-    return (
-      <div className={classes.root}>
-        {view === "w" ? (
-          <TdmCalculationWizard
-            rules={rules}
-            onInputChange={this.onInputChange}
-            onUncheckAll={this.onUncheckAll}
-            filters={this.filters}
-            onPkgSelect={this.onPkgSelect}
-            resultRuleCodes={this.resultRuleCodes}
-            onViewChange={() => this.setState({ view: "d" }, this.pushHistory)}
-            onPageChange={pageNo => this.setState({ pageNo }, this.pushHistory)}
-            account={account}
-            projectId={Number(projectId)}
-            loginId={loginId}
-            onSave={this.onSave}
-            pageNo={pageNo}
-          />
-        ) : (
-          <TdmCalculation
-            rules={rules}
-            onInputChange={this.onInputChange}
-            onUncheckAll={this.onUncheckAll}
-            filters={this.filters}
-            onPkgSelect={this.onPkgSelect}
-            resultRuleCodes={this.resultRuleCodes}
-            onViewChange={() => this.setState({ view: "w" }, this.pushHistory)}
-          />
-        )}
-
-        {/* <pre>
-          {JSON.stringify(
-            rules.filter(r => r.used),
-            null,
-            2
-          )}
-        </pre> */}
-      </div>
-    );
-  }
+  const { account, classes } = props;
+  return (
+    <div className={classes.root}>
+      {view === "w" ? (
+        <TdmCalculationWizard
+          rules={rules}
+          onInputChange={onInputChange}
+          onUncheckAll={onUncheckAll}
+          filters={filters}
+          onPkgSelect={onPkgSelect}
+          resultRuleCodes={resultRuleCodes}
+          onViewChange={() => {
+            setView("d");
+            pushHistory();
+          }}
+          onPageChange={onPageChange}
+          account={account}
+          projectId={Number(projectId)}
+          loginId={loginId}
+          onSave={onSave}
+        />
+      ) : (
+        <TdmCalculation
+          rules={rules}
+          onInputChange={onInputChange}
+          onUncheckAll={onUncheckAll}
+          filters={filters}
+          onPkgSelect={onPkgSelect}
+          resultRuleCodes={resultRuleCodes}
+          onViewChange={() => {
+            setView("w");
+            pushHistory();
+          }}
+        />
+      )}
+    </div>
+  );
 }
 
 TdmCalculationContainer.calculationId = 1;
+TdmCalculationContainer.engine = null;
 
+TdmCalculationContainer.propTypes = {
+  account: PropTypes.shape({
+    firstName: PropTypes.string,
+    lastName: PropTypes.string,
+    id: PropTypes.number
+  }),
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      page: PropTypes.string,
+      projectId: PropTypes.string
+    })
+  }),
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired
+  }),
+  classes: PropTypes.object.isRequired,
+  location: PropTypes.shape({
+    search: PropTypes.string
+  })
+};
 export default withRouter(injectSheet(styles)(TdmCalculationContainer));

--- a/client/src/services/tdm-engine.js
+++ b/client/src/services/tdm-engine.js
@@ -18,6 +18,7 @@ class Engine {
   }
 
   run(formInputs, ruleCodes) {
+    console.log("input", formInputs);
     try {
       for (let i = 0; i < ruleCodes.length; i++) {
         if (!this.initialRules[ruleCodes[i]]) {
@@ -184,7 +185,7 @@ class Engine {
   // dynamically creating functions, but that's what we need.
   buildFunction(body) {
     // eslint-disable-next-line no-new-func
-    return Function('"use strict";' + body);
+    return Function("\"use strict\";" + body);
   }
 
   executeCalc(ruleCode) {
@@ -289,10 +290,12 @@ class Engine {
   // result to database.
   showRulesArray() {
     const rulesArray = [];
+    console.log("engine-show", this.rules);
 
     for (var ruleCode in this.rules) {
       rulesArray.push(this.rules[ruleCode]);
     }
+    console.log("rules array", rulesArray);
     return rulesArray;
   }
 }


### PR DESCRIPTION
- Issue #242 . Validations are now in place for wizard page 2 and are uniform with validations of page 1.
- Wizard routing moved to react-router, allowing for easier page checking through route params rather than state.
- Refreshing/reloading while inside the wizard now reverts the user to either page 1 or page 6 depending on access control.
- "New Project" link in nav bar is now checking route rather than context.
- Issue #266 . babel-eslint was not added to the project, but linter issue that was blocking commits was fixed by converting the TdmCalculationContainer into a functional component, as per @entrotech and @fyliu suggestion. Addition of babel-eslint module will be further discussed.