### PR TITLE
First cut - need better styling of tooltip

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18072,6 +18072,22 @@
         "prop-types": "^15.6.0"
       }
     },
+    "react-tooltip": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.2.tgz",
+      "integrity": "sha512-bd/nQQFQByzqNz1W1Lni3qzvMHqZCuKUNvhApk29WZ5JlEFEsitFp2SxugVM53JQ6hNaocdGwwtCEzk5wQo64g==",
+      "requires": {
+        "prop-types": "^15.7.2",
+        "uuid": "^7.0.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
+      }
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "react-router-dom": "^5.1.2",
     "react-scripts": "^3.4.0",
     "react-string-replace": "^0.4.4",
+    "react-tooltip": "^4.2.2",
     "yup": "^0.28.3"
   },
   "scripts": {

--- a/client/src/components/ProjectWizard/RuleStrategy/RuleStrategy.js
+++ b/client/src/components/ProjectWizard/RuleStrategy/RuleStrategy.js
@@ -2,6 +2,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
+import ReactTooltip from "react-tooltip";
 
 const useStyles = createUseStyles({
   strategyContainer: {
@@ -77,6 +78,7 @@ const RuleStrategy = ({
     calcUnits,
     calcMinValue,
     calcMaxValue,
+    description,
     displayComment,
     comment
   },
@@ -116,7 +118,14 @@ const RuleStrategy = ({
     <React.Fragment>
       {dataType === "number" ? (
         <div className={classes.strategyContainer}>
-          <label htmlFor={code} className={classes.strategyName}>
+          <label
+            htmlFor={code}
+            className={classes.strategyName}
+            data-for="main"
+            data-tip={description}
+            data-iscapture="true"
+            data-html="true"
+          >
             {" "}
             {name}{" "}
           </label>
@@ -136,7 +145,14 @@ const RuleStrategy = ({
         </div>
       ) : dataType === "boolean" ? (
         <div className={classes.strategyContainer}>
-          <label htmlFor={code} className={classes.strategyName}>
+          <label
+            htmlFor={code}
+            className={classes.strategyName}
+            data-for="main"
+            data-tip={description}
+            data-iscapture="true"
+            data-html="true"
+          >
             {" "}
             {name}{" "}
           </label>
@@ -154,7 +170,14 @@ const RuleStrategy = ({
         </div>
       ) : dataType === "choice" ? (
         <div className={classes.strategyContainer}>
-          <label htmlFor={code} className={classes.strategyName}>
+          <label
+            htmlFor={code}
+            className={classes.strategyName}
+            data-for="main"
+            data-tip={description}
+            data-iscapture="true"
+            data-html="true"
+          >
             {" "}
             {name}{" "}
           </label>
@@ -177,7 +200,14 @@ const RuleStrategy = ({
         </div>
       ) : dataType === "string" ? (
         <div className={classes.strategyContainer}>
-          <label htmlFor={code} className={classes.strategyName}>
+          <label
+            htmlFor={code}
+            className={classes.strategyName}
+            data-for="main"
+            data-tip={description}
+            data-iscapture="true"
+            data-html="true"
+          >
             {" "}
             {name}{" "}
           </label>
@@ -191,7 +221,13 @@ const RuleStrategy = ({
           />
         </div>
       ) : (
-        <div className={classes.strategyContainer}>
+        <div
+          className={classes.strategyContainer}
+          data-for="main"
+          data-tip={description}
+          data-iscapture="true"
+          data-html="true"
+        >
           <label htmlFor={code} className={classes.strategyName}>
             {" "}
             {name}{" "}
@@ -215,6 +251,14 @@ const RuleStrategy = ({
           </div>
         </div>
       ) : null}
+      <ReactTooltip
+        id="main"
+        place="top"
+        type="info"
+        effect="float"
+        multiline={true}
+        style={{ width: "25vw" }}
+      />
     </React.Fragment>
   );
 };
@@ -242,6 +286,7 @@ RuleStrategy.propTypes = {
     calcUnits: PropTypes.string,
     calcMinValue: PropTypes.number,
     calcMaxValue: PropTypes.number,
+    description: PropTypes.string,
     displayComment: PropTypes.bool,
     comment: PropTypes.string
   }),


### PR DESCRIPTION
Partial Implementation of Issue #318. The strategy descriptions are available and currently displayed in a tooltip, but the tooltip style can use improvement. Also descriptions are missing from Rose's spreadsheet for Electiric Vehicle Bonus and Applicant-Defined STrategy.