### PR TITLE
Fix token expiration handling for Issue #351

### DIFF
--- a/client/src/components/TdmCalculationContainer.js
+++ b/client/src/components/TdmCalculationContainer.js
@@ -9,6 +9,7 @@ import * as projectService from "../services/project.service";
 import Engine from "../services/tdm-engine";
 import ToastContext from "../contexts/Toast/ToastContext";
 import injectSheet from "react-jss";
+import { useToast } from "../contexts/Toast";
 
 const styles = {
   root: {
@@ -28,6 +29,7 @@ const resultRuleCodes = [
 ];
 
 export function TdmCalculationContainer(props) {
+  const { history } = props;
   const context = useContext(ToastContext);
   const [engine, setEngine] = useState(null);
   const [rules, setRules] = useState([]);
@@ -35,6 +37,7 @@ export function TdmCalculationContainer(props) {
   const [projectId, setProjectId] = useState(null);
   const [loginId, setLoginId] = useState(0);
   const [view, setView] = useState("w");
+  const toast = useToast();
 
   // Get the rules for the calculation. Runs once when
   // component is loaded.
@@ -230,6 +233,18 @@ export function TdmCalculationContainer(props) {
         await projectService.put(requestBody);
         context.add("Saved Project Changes");
       } catch (err) {
+        if (err.response) {
+          if (err.response.status === 401) {
+            toast.add(
+              "For your security, your session has expired. Please log in again."
+            );
+            history.push(`/login/${encodeURIComponent(account.email)}`);
+          } else {
+            console.error(err.response);
+          }
+        } else if (err.request) {
+          console.error(err.request);
+        }
         console.error(err);
       }
     } else {
@@ -239,6 +254,18 @@ export function TdmCalculationContainer(props) {
         setLoginId(props.account.id);
         context.add("Saved New Project");
       } catch (err) {
+        if (err.response) {
+          if (err.response.status === 401) {
+            toast.add(
+              "For your security, your session has expired. Please log in again."
+            );
+            history.push(`/login/${encodeURIComponent(account.email)}`);
+          } else {
+            console.error(err.response);
+          }
+        } else if (err.request) {
+          console.error(err.request);
+        }
         console.error(err);
       }
     }
@@ -326,4 +353,5 @@ TdmCalculationContainer.propTypes = {
     search: PropTypes.string
   })
 };
+
 export default withRouter(injectSheet(styles)(TdmCalculationContainer));

--- a/client/src/services/project.service.js
+++ b/client/src/services/project.service.js
@@ -3,7 +3,11 @@ import axios from "axios";
 const baseUrl = "/api/projects";
 
 export function get() {
-  return axios.get(baseUrl);
+  try {
+    return axios.get(baseUrl);
+  } catch (error) {
+    return new Promise.reject(error);
+  }
 }
 
 export function getById(id) {

--- a/middleware/jwt-session.js
+++ b/middleware/jwt-session.js
@@ -1,14 +1,12 @@
 const jwt = require("jsonwebtoken");
 
-// const autoCatch = require("./lib/auto-catch");
-
 const jwtSecret = process.env.JWT_SECRET || "mark it zero";
+// Session time-ut set to two weeks, could be shorted for
+// more security
 const jwtOpts = { algorithm: "HS256", expiresIn: "14d" };
 
 module.exports = {
-  //login: autoCatch(login),
   login,
-  //ensureUser: autoCatch(ensureUser),
   validateUser
 };
 
@@ -40,12 +38,8 @@ async function validateUser(req, res, next) {
       req.user = payload;
       return next();
     }
-
-    const err = new Error("Unauthorized");
-    err.statusCode = 401;
-    next(err);
   } catch (er) {
-    next(er);
+    res.status("401").send("Login session expired");
   }
 }
 
@@ -58,12 +52,5 @@ async function sign(payload) {
 // Helper function to validate the JWT token
 async function verify(jwtString = "") {
   jwtString = jwtString.replace(/^Bearer /i, "");
-
-  try {
-    const payload = await jwt.verify(jwtString, jwtSecret);
-    return payload;
-  } catch (err) {
-    err.statusCode = 401;
-    throw err;
-  }
+  return jwt.verify(jwtString, jwtSecret);
 }

--- a/server.js
+++ b/server.js
@@ -14,7 +14,11 @@ const app = express();
 
 if (process.env.NODE_ENV === "production") {
   app.use((req, res, next) => {
-    if (req.secure || req.header("x-forwarded-proto") !== "https")
+    // Most wweb servers will set the secure property of the
+    // request, but Heroku sets x-forwarded-proto to http if
+    // not secure
+    if (!req.secure || req.header("x-forwarded-proto") !== "https")
+      // redirect to https with same host & url
       res.redirect(`https://${req.header("host")}${req.url}`);
     else next();
   });


### PR DESCRIPTION
Closes #351 and #348.
A logged-in user's session expires after 14 days (instead of 1 day), and when it does expire, they see a toast telling them that their session expired, and re-directing them to the login page. This happens for the Project page initial fetch, and potentially when trying to save a project (in which case the user will lose any work they have done on the project).

Also force redirect of http server requests to https. 