### PR TITLE
Issue 294 fixes - Tooltip style, and infobox state in localStorage

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -25,14 +25,13 @@ const useStyles = createUseStyles({
   root: {
     flex: "1 0 auto",
     display: "flex",
-    flexDirection: "column",
-  },
+    flexDirection: "column"
+  }
 });
 
 const App = () => {
   const classes = useStyles();
   const [account, setAccount] = useState({});
-  const [hasClosedInfoBox, setHasClosedInfoBox] = useState(false);
   const [isCreatingNewProject, setIsCreatingNewProject] = useState(false);
 
   useEffect(() => {
@@ -52,7 +51,7 @@ const App = () => {
     }
   }, [setAccount]);
 
-  const setLoggedInAccount = (loggedInUser) => {
+  const setLoggedInAccount = loggedInUser => {
     setAccount(loggedInUser);
     localStorage.setItem("currentUser", JSON.stringify(loggedInUser));
   };
@@ -60,14 +59,14 @@ const App = () => {
   //TODO: This doesn't seem like it's getting used anymore. Don't see token in local storage. Check on authorization flow to see if token is still needed.
   const setTokenInHeaders = () => {
     axios.interceptors.request.use(
-      (config) => {
+      config => {
         let token = localStorage.getItem("token");
         if (token) {
           config.headers["Authorization"] = `Bearer ${token}`;
         }
         return config;
       },
-      (error) => Promise.reject(error)
+      error => Promise.reject(error)
     );
   };
 
@@ -88,8 +87,6 @@ const App = () => {
               path="/calculation/:page?/:projectId?"
               render={() => (
                 <TdmCalculationContainer
-                  hasClosedInfoBox={hasClosedInfoBox}
-                  setHasClosedInfoBox={setHasClosedInfoBox}
                   account={account}
                   setIsCreatingNewProject={setIsCreatingNewProject}
                 />

--- a/client/src/components/ProjectWizard/RuleStrategy/RuleStrategy.js
+++ b/client/src/components/ProjectWizard/RuleStrategy/RuleStrategy.js
@@ -64,14 +64,29 @@ const useStyles = createUseStyles({
     marginTop: "4px"
   },
   tooltip: {
-    padding: "10px",
+    padding: "15px",
     minWidth: "200px",
-    maxWidth: "400px"
+    maxWidth: "400px",
+    fontFamily: "Arial",
+    fontSize: 12,
+    lineHeight: "16px",
+    fontWeight: "bold",
+    "-webkit-box-shadow": "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    "-moz-box-shadow": "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    boxShadow: "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    "-webkit-border-radius": 2,
+    "-moz-border-radius": 2,
+    borderRadius: 2,
+    "&.show": {
+      visibility: "visible !important",
+      opacity: "1 !important"
+    }
   }
 });
 
 const RuleStrategy = ({
   rule: {
+    id,
     code,
     name,
     dataType,
@@ -91,10 +106,8 @@ const RuleStrategy = ({
   onCommentChange
 }) => {
   const classes = useStyles();
-
   const possibleAndEarnedPointsContainers = () => {
     const calculationUnits = calcUnits ? calcUnits : "";
-
     return (
       <React.Fragment>
         <div className={classes.points}>
@@ -107,9 +120,9 @@ const RuleStrategy = ({
             : null}
         </div>
         <div className={classes.points}>
-          {`${calcValue ? Math.round(calcValue * 100) / 100 : ""} ${
-            calculationUnits || ""
-          }`}
+          {`${
+            calcValue ? Math.round(calcValue * 100) / 100 : ""
+          } ${calculationUnits || ""}`}
         </div>
       </React.Fragment>
     );
@@ -122,7 +135,7 @@ const RuleStrategy = ({
           <label
             htmlFor={code}
             className={classes.strategyName}
-            data-for="main"
+            data-for={"main" + id}
             data-tip={description}
             data-iscapture="true"
             data-html="true"
@@ -151,7 +164,7 @@ const RuleStrategy = ({
           <label
             htmlFor={code}
             className={classes.strategyName}
-            data-for="main"
+            data-for={"main" + id}
             data-tip={description}
             data-iscapture="true"
             data-html="true"
@@ -177,7 +190,7 @@ const RuleStrategy = ({
           <label
             htmlFor={code}
             className={classes.strategyName}
-            data-for="main"
+            data-for={"main" + id}
             data-tip={description}
             data-iscapture="true"
             data-html="true"
@@ -208,7 +221,7 @@ const RuleStrategy = ({
           <label
             htmlFor={code}
             className={classes.strategyName}
-            data-for="main"
+            data-for={"main" + id}
             data-tip={description}
             data-iscapture="true"
             data-html="true"
@@ -230,7 +243,7 @@ const RuleStrategy = ({
       ) : (
         <div
           className={classes.strategyContainer}
-          data-for="main"
+          data-for={"main" + id}
           data-tip={description}
           data-iscapture="true"
           data-html="true"
@@ -261,12 +274,19 @@ const RuleStrategy = ({
         </div>
       ) : null}
       <ReactTooltip
-        id="main"
-        place="top"
+        id={"main" + id}
+        place="right"
         type="info"
         effect="float"
         multiline={true}
-        style={{ width: "25vw" }}
+        style={{
+          width: "25vw"
+        }}
+        textColor="#32578A"
+        backgroundColor="#F7F9FA"
+        border={true}
+        borderColor="#B2C0D3"
+        offset={{ right: 20 }}
       />
     </React.Fragment>
   );

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -79,8 +79,6 @@ const TdmCalculationWizard = props => {
   const context = useContext(ToastContext);
   const classes = useStyles();
   const {
-    hasClosedInfoBox,
-    setHasClosedInfoBox,
     rules,
     onInputChange,
     onCommentChange,
@@ -178,8 +176,6 @@ const TdmCalculationWizard = props => {
           landUseRules={landUseRules}
           onInputChange={onInputChange}
           onCommentChange={onCommentChange}
-          hasClosedInfoBox={hasClosedInfoBox}
-          setHasClosedInfoBox={setHasClosedInfoBox}
           classes={classes}
           onPkgSelect={onPkgSelect}
           uncheckAll={() => onUncheckAll(filters.strategyRules)}
@@ -347,9 +343,7 @@ TdmCalculationWizard.propTypes = {
   account: PropTypes.object.isRequired,
   loginId: PropTypes.number.isRequired,
   onSave: PropTypes.func.isRequired,
-  onViewChange: PropTypes.func.isRequired,
-  hasClosedInfoBox: PropTypes.bool,
-  setHasClosedInfoBox: PropTypes.func
+  onViewChange: PropTypes.func.isRequired
 };
 
 export default withRouter(TdmCalculationWizard);

--- a/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import RuleStrategyPanels from "../RuleStrategy/RuleStrategyPanels";
 import InfoBox from "../InfoBox";
 import ToolTipIcon from "../SidebarPoints/ToolTipIcon";
+import useLocalStorage from "../../useLocalStorage";
 
 function ProjectMeasure(props) {
   const {
@@ -12,14 +13,16 @@ function ProjectMeasure(props) {
     onCommentChange,
     classes,
     onPkgSelect,
-    uncheckAll,
-    hasClosedInfoBox,
-    setHasClosedInfoBox
+    uncheckAll
   } = props;
-  const [displayInfoBox, setDisplayInfoBox] = useState(!hasClosedInfoBox);
+  const [hasClosedBox, setHasClosedBox] = useLocalStorage(
+    "hasClosedBox",
+    false
+  );
+  const [displayInfoBox, setDisplayInfoBox] = useState(!hasClosedBox);
   const closeInfoBox = () => {
-    setHasClosedInfoBox(true);
     setDisplayInfoBox(false);
+    setHasClosedBox(true);
   };
   const showResidentialPkg = (() => {
     // Only show button if one of the land uses is Residential
@@ -145,9 +148,7 @@ ProjectMeasure.propTypes = {
   onCommentChange: PropTypes.func.isRequired,
   classes: PropTypes.object.isRequired,
   onPkgSelect: PropTypes.func.isRequired,
-  uncheckAll: PropTypes.func.isRequired,
-  hasClosedInfoBox: PropTypes.bool,
-  setHasClosedInfoBox: PropTypes.func
+  uncheckAll: PropTypes.func.isRequired
 };
 
 export default ProjectMeasure;

--- a/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.js
@@ -15,15 +15,11 @@ function ProjectMeasure(props) {
     onPkgSelect,
     uncheckAll
   } = props;
-  const [hasClosedBox, setHasClosedBox] = useLocalStorage(
-    "hasClosedBox",
-    false
+
+  const [displayInfoBox, setDisplayInfoBox] = useLocalStorage(
+    "displayBox",
+    true
   );
-  const [displayInfoBox, setDisplayInfoBox] = useState(!hasClosedBox);
-  const closeInfoBox = () => {
-    setDisplayInfoBox(false);
-    setHasClosedBox(true);
-  };
   const showResidentialPkg = (() => {
     // Only show button if one of the land uses is Residential
     const triggerRule = landUseRules.filter(
@@ -78,7 +74,10 @@ function ProjectMeasure(props) {
       <h3 className="tdm-wizard-page-subtitle">
         Select strategies to earn TDM points
       </h3>
-      <InfoBox displayStatus={displayInfoBox} handleClick={closeInfoBox}>
+      <InfoBox
+        displayStatus={displayInfoBox}
+        handleClick={() => setDisplayInfoBox(false)}
+      >
         <ToolTipIcon /> For detailed information, hover the mouse cursor over
         the terminology.
       </InfoBox>
@@ -102,7 +101,6 @@ function ProjectMeasure(props) {
             circleStyle={{
               filter: "drop-shadow(0px 4px 2px rgba(0, 46, 109, 0.3))"
             }}
-            handleClick={() => setDisplayInfoBox(false)}
           />
         </button>
         {showResidentialPkg ? (

--- a/client/src/components/TdmCalculationContainer.js
+++ b/client/src/components/TdmCalculationContainer.js
@@ -294,7 +294,7 @@ export function TdmCalculationContainer(props) {
       rule.display &&
       rule.calculationPanelId !== 10
   };
-  const { account, classes, hasClosedInfoBox, setHasClosedInfoBox } = props;
+  const { account, classes } = props;
   return (
     <div className={classes.root}>
       {view === "w" ? (
@@ -312,8 +312,6 @@ export function TdmCalculationContainer(props) {
           account={account}
           loginId={loginId}
           onSave={onSave}
-          hasClosedInfoBox={hasClosedInfoBox}
-          setHasClosedInfoBox={setHasClosedInfoBox}
         />
       ) : (
         <TdmCalculation
@@ -353,9 +351,7 @@ TdmCalculationContainer.propTypes = {
   classes: PropTypes.object.isRequired,
   location: PropTypes.shape({
     search: PropTypes.string
-  }),
-  hasClosedInfobox: PropTypes.bool,
-  setHasClosedInfoBox: PropTypes.func
+  })
 };
 
 export default withRouter(injectSheet(styles)(TdmCalculationContainer));

--- a/client/src/components/useLocalStorage.js
+++ b/client/src/components/useLocalStorage.js
@@ -3,8 +3,7 @@ import { useState } from "react";
 // from https://usehooks.com/useLocalStorage/
 // Usage:
 // const [name, setName] = useLocalStorage('name', 'Bob');
-// searches localStorage for 'name' value or sets 'Bob' as the name constant
-// does not set 'name=Bob' in local storage, could probably be configured to
+// searches localStorage for 'name' value or sets 'name=Bob'
 
 const useLocalStorage = (key, initialValue) => {
   // State to store our value

--- a/client/src/components/useLocalStorage.js
+++ b/client/src/components/useLocalStorage.js
@@ -1,0 +1,49 @@
+import { useState } from "react";
+
+// from https://usehooks.com/useLocalStorage/
+// Usage:
+// const [name, setName] = useLocalStorage('name', 'Bob');
+// searches localStorage for 'name' value or sets 'Bob' as the name constant
+// does not set 'name=Bob' in local storage, could probably be configured to
+
+const useLocalStorage = (key, initialValue) => {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // if no item exists, set item to initialValue
+      if (item === null) {
+        window.localStorage.setItem(key, JSON.stringify(initialValue));
+      }
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error);
+      return initialValue;
+    }
+  });
+
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = value => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      window.localStorage.setItem(key, JSON.stringify(valueToStore));
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log("error in local storage", error);
+    }
+  };
+
+  return [storedValue, setValue];
+};
+
+export default useLocalStorage;


### PR DESCRIPTION
- Moved state for whether the display box is open or not to local storage for persistence across sessions
- found useful useLocalStorage hook to manage this simply.
- Styled tooltips on ProjectMeasures page to align on the right and to match the style of the figma

closes #294 

**BEFORE**
![issue-294-tooltip-before](https://user-images.githubusercontent.com/32402365/82101634-de42dd80-96c1-11ea-8c24-5dddd5af6bcf.jpg)

**AFTER**
![issue-294-tooltip](https://user-images.githubusercontent.com/32402365/82101209-c159da80-96c0-11ea-9120-6b1913e8bf40.jpg)



