### PR TITLE
removed popup action from sidebar tooltips

### DIFF
--- a/client/src/components/ProjectWizard/SidebarPoints/ToolTip.js
+++ b/client/src/components/ProjectWizard/SidebarPoints/ToolTip.js
@@ -45,7 +45,7 @@ const ToolTip = ({ tipText }) => {
   const [tipVisibility, setTipVisibility] = useState(false);
   const classes = useStyles();
   const handleClick = () => {
-    setTipVisibility(!tipVisibility);
+    //setTipVisibility(!tipVisibility);
   };
   const showTip = tipVisibility ? "showTip" : "";
   return (


### PR DESCRIPTION
disabled tooltip popups on sidebar

- involved just commenting out the function block of the click handler.
- left functionality intact for if we want to use this component once we have text for the popups

- I think its likely that this component will need to be refactored using react-tooltip once we do have text

closes #382 for real
replaces #384 