### PR TITLE
Project measures top row spacing

### DIFF
--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -58,7 +58,7 @@ const useStyles = createUseStyles({
   },
   unSelectContainer: {
     display: "grid",
-    gridTemplateColumns: "20% auto 20%",
+    gridTemplateColumns: "[h-start] 20% [h-mid] auto [h-end] 20%",
     alignItems: "center",
     justifyContent: "space-between",
     position: "relative",
@@ -67,11 +67,14 @@ const useStyles = createUseStyles({
   unSelectButton: {
     marginLeft: "auto",
     marginRight: "1em",
-    gridColumn: 3,
+    gridColumn: "h-end",
     backgroundColor: "transparent",
     border: "0",
     cursor: "pointer",
     textDecoration: "underline"
+  },
+  alignMid: {
+    gridColumn: "h-mid"
   }
 });
 

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -61,8 +61,7 @@ const useStyles = createUseStyles({
     gridTemplateColumns: "[h-start] 20% [h-mid] auto [h-end] 20%",
     alignItems: "center",
     justifyContent: "space-between",
-    position: "relative",
-    height: "32px"
+    position: "relative"
   },
   unSelectButton: {
     marginLeft: "auto",
@@ -74,7 +73,9 @@ const useStyles = createUseStyles({
     textDecoration: "underline"
   },
   alignMid: {
-    gridColumn: "h-mid"
+    gridColumn: "h-mid",
+    display: "flex",
+    justifyContent: "center"
   }
 });
 

--- a/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.js
@@ -102,24 +102,26 @@ function ProjectMeasure(props) {
             handleClick={() => setDisplayInfoBox(false)}
           />
         </button>
-        {showResidentialPkg ? (
-          <button
-            className="tdm-wizard-pkg-button"
-            onClick={() => onPkgSelect("Residential")}
-            disabled={disabledResidentialPkg}
-          >
-            Select Residential Package
-          </button>
-        ) : null}
-        {showEmploymentPkg ? (
-          <button
-            className="tdm-wizard-pkg-button"
-            onClick={() => onPkgSelect("Employment")}
-            disabled={disabledEmploymentPkg}
-          >
-            Select Employment Package
-          </button>
-        ) : null}
+        <div className={classes.alignMid}>
+          {showResidentialPkg ? (
+            <button
+              className="tdm-wizard-pkg-button"
+              onClick={() => onPkgSelect("Residential")}
+              disabled={disabledResidentialPkg}
+            >
+              Select Residential Package
+            </button>
+          ) : null}
+          {showEmploymentPkg ? (
+            <button
+              className="tdm-wizard-pkg-button"
+              onClick={() => onPkgSelect("Employment")}
+              disabled={disabledEmploymentPkg}
+            >
+              Select Employment Package
+            </button>
+          ) : null}
+        </div>
         <button className={classes.unSelectButton} onClick={uncheckAll}>
           Reset Page
         </button>


### PR DESCRIPTION
Fixes issue with the spacing of the Residential and Employment Pkg Select buttons on the Project Measures page when both are selected.

finishes the first element of issue #386 

![issue-386-top-row](https://user-images.githubusercontent.com/32402365/82277581-1013a880-993d-11ea-85f7-7f2da53f7f9f.jpg)

![issue-386-top-row2](https://user-images.githubusercontent.com/32402365/82277579-0f7b1200-993d-11ea-90cd-3cdb5ba85340.jpg)
