### PR TITLE
Clear Project Data on Logout

### DIFF
--- a/client/src/components/TdmCalculationContainer.js
+++ b/client/src/components/TdmCalculationContainer.js
@@ -65,7 +65,7 @@ export function TdmCalculationContainer(props) {
       try {
         let projectResponse = null;
         let inputs = {};
-        if (Number(projectId) > 0) {
+        if (Number(projectId) > 0 && account.id) {
           projectResponse = await projectService.getById(projectId);
           setLoginId(projectResponse.data.loginId);
           // console.log("inputs", projectResponse);
@@ -85,7 +85,7 @@ export function TdmCalculationContainer(props) {
       }
     };
     initiateEngine();
-  }, [props.match.params.projectId, engine]);
+  }, [props.match.params.projectId, engine, account]);
 
   const recalculate = formInputs => {
     engine.run(formInputs, resultRuleCodes);


### PR DESCRIPTION
To prevent the problem of a user still being able to see their own project data after logging out.

Just made the call to an existing project contigent upon their being a logged in user within the initiateEngine useEffect. And made the useEffect rerun on changes to account. Now when a user logs out the initateEngine will clear its own form inputs.

As mentioned in issue 400, this does not touch the jwt cookie on logout, which could potentially be a security issue.

One potential issue I can see with this solution is that a user will lose all their data if they're working on an unsaved project and log out. However, since a user who isn't logged in can't save a project anyway I'm not sure that this matters.

closes #400