### PR TITLE
Wizard Sidebar Content is sticky

### DIFF
--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -38,8 +38,13 @@ const useStyles = createUseStyles({
   sidebarContent: {
     zIndex: 1,
     display: "flex",
+    position: "sticky",
+    top: 0,
+    height: "calc(100vh - 103px)",
     flexDirection: "column",
-    height: "100%"
+    "@media (max-width:768px)": {
+      height: "auto"
+    }
   },
   contentContainer: {
     justifyContent: "space-around",

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -19,7 +19,8 @@ export const useStyles = createUseStyles({
     display: "flex",
     flexDirection: "column",
     justifyContent: "flex-start",
-    height: "calc(100vh - 103px)"
+    height: "100%",
+    minHeight: "calc(100vh - 103px)"
   },
   "@media (max-width: 1024px)": {
     "sidebar-container": {
@@ -33,7 +34,8 @@ export const useStyles = createUseStyles({
       backgroundPosition: "15% 44%"
     },
     "sidebar-content": {
-      height: "auto"
+      height: "auto",
+      minHeight: 0
     }
   }
 });


### PR DESCRIPTION
The sidebarContainer element is now sticky. As far as I can tell it all works and there are no adverse effects on the sidebar on other pages or sizes.

![tdm-sticky-scroll](https://user-images.githubusercontent.com/32402365/84339709-ddcc2400-ab53-11ea-8b5d-2f6b1d966f4e.gif)
 
closes #405