### PR TITLE
Add conditional rendering of date last saved to top of Project Summary

### DIFF
--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
@@ -293,10 +293,12 @@ const ProjectSummary = props => {
     <div className={clsx("tdm-wizard-review-page", classes.root)}>
       <h1 className="tdm-wizard-page-title">TDM Calculation Summary</h1>
       <div className={classes.lastSavedContainer}>
-        <span className={classes.lastSaved}>
-          <FontAwesomeIcon icon={faClock} /> &nbsp;Last saved:{" "}
-          {props.dateModified}
-        </span>
+        {props.dateModified && (
+          <span className={classes.lastSaved}>
+            <FontAwesomeIcon icon={faClock} /> &nbsp;Last saved:{" "}
+            {props.dateModified}
+          </span>
+        )}
       </div>
       <div className={classes.projectInfoContainer}>
         {projectName && projectName.value ? (


### PR DESCRIPTION
#421 Missed the top of project summary in last commit. I added a conditional rendering of the date last saved so that it does not show when you are creating a project for the first time. 