### PR TITLE
Change escaping of database name in JDBC connection string for Flyway

### DIFF
--- a/db/flyway-config.js
+++ b/db/flyway-config.js
@@ -19,7 +19,7 @@ module.exports = function () {
 
   return {
     flywayArgs: {
-      url: `jdbc:sqlserver://${origin};databaseName="${databaseName}"`,
+      url: `jdbc:sqlserver://${origin};databaseName={${databaseName}}`,
       locations: `filesystem:${__dirname}/migration`,
       user: username,
       password: password,


### PR DESCRIPTION
In a JDBC connection string the correct way to escape a database name which might have special characters in it (in this case the production environment has a database name with spaces in it), is to enclosed the database name in braces.

It seemed to work fine escaping the database name with double-quotes on Windows, but caused problems on a Mac.