### PR TITLE
added tooltip for Citywide Parking Baseline

### DIFF
--- a/client/src/components/ProjectWizard/RuleCalculation/RuleCalculation.js
+++ b/client/src/components/ProjectWizard/RuleCalculation/RuleCalculation.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
+import ToolTip from "./ToolTip";
 import clsx from "clsx";
 
 const useStyles = createUseStyles({
@@ -151,6 +152,7 @@ const useStyles = createUseStyles({
 
 const RuleCalculation = ({
   rule: {
+    id,
     code,
     name,
     dataType,
@@ -164,7 +166,8 @@ const RuleCalculation = ({
     required,
     minStringLength,
     maxStringLength,
-    validationErrors
+    validationErrors,
+    description
   },
   onPropInputChange
 }) => {
@@ -311,8 +314,17 @@ const RuleCalculation = ({
         </div>
       ) : (
         <div className={clsx(classes.field, classes.miscFieldWrapper)}>
-          <label htmlFor={code} className={classes.miscFieldLabel}>
+          <label
+            htmlFor={code}
+            className={classes.miscFieldLabel}
+            data-for={"main" + id}
+            data-tip={description}
+            data-iscapture="true"
+            data-html="true"
+            data-class={classes.tooltip}
+          >
             {name}
+            <ToolTip tipText={description} />
           </label>
           <div className={classes.codeWrapper} name={code} id={code} />
           <div className={classes.unitsCaption}>{units}</div>
@@ -338,6 +350,7 @@ const RuleCalculation = ({
 
 RuleCalculation.propTypes = {
   rule: PropTypes.shape({
+    id: PropTypes.number.isRequired,
     code: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     dataType: PropTypes.string.isRequired,
@@ -351,7 +364,8 @@ RuleCalculation.propTypes = {
     required: PropTypes.bool,
     minStringLength: PropTypes.number,
     maxStringLength: PropTypes.number,
-    validationErrors: PropTypes.array
+    validationErrors: PropTypes.array,
+    description: PropTypes.string
   }),
   onPropInputChange: PropTypes.func
 };

--- a/client/src/components/ProjectWizard/RuleCalculation/ToolTip.js
+++ b/client/src/components/ProjectWizard/RuleCalculation/ToolTip.js
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { createUseStyles } from "react-jss";
+import clsx from "clsx";
+import ToolTipIcon from "./ToolTipIcon";
+
+const useStyles = createUseStyles({
+  tipIcon: {
+    fontFamily: "Calibri",
+    fontWeight: "bold",
+    color: "white",
+    fontSize: 12,
+    backgroundColor: "#A7C539",
+    borderRadius: "50%",
+    textAlign: "center",
+    verticalAlign: "top",
+    border: "none",
+    "&:hover": {
+      cursor: "pointer"
+    }
+  },
+  tipText: {
+    display: "none",
+    padding: "15px",
+    backgroundColor: "rgb(230, 234, 239)",
+    width: "200px",
+    fontFamily: "Arial",
+    textAlign: "center",
+    fontSize: 12,
+    lineHeight: "16px",
+    marginLeft: 20,
+    fontWeight: "bold",
+    "-webkit-box-shadow": "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    "-moz-box-shadow": "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    boxShadow: "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    "-webkit-border-radius": 2,
+    "-moz-border-radius": 2,
+    borderRadius: 2,
+    visibility: "hidden",
+    opacity: 0,
+    transition: "opacity 0.3s",
+    "z-index": 1,
+    "&.show": {
+      display: "inline-block",
+      position: "absolute !important",
+      visibility: "visible !important",
+      opacity: "1 !important"
+    }
+  }
+});
+
+const ToolTip = ({ tipText }) => {
+  const [tipVisibility, setTipVisibility] = useState(false);
+  const classes = useStyles();
+  /*eslint-disable */
+  const handleHover = () => {
+    setTipVisibility(!tipVisibility);
+  };
+  /*eslint-enable */
+  const showTip = tipVisibility ? "show" : "";
+
+  return (
+    <React.Fragment>
+      {tipText ? (
+        <span onMouseEnter={handleHover} onMouseLeave={handleHover}>
+          <ToolTipIcon
+            containerStyle={{
+              fontSize: 16,
+              verticalAlign: "top",
+              "&:hover": { cursor: "pointer" }
+            }}
+            place="right"
+            type="info"
+            effect="float"
+            multiline={true}
+            style={{
+              width: "25vw"
+            }}
+            textColor="#32578A"
+            backgroundColor="#F7F9FA"
+            border={true}
+            borderColor="#B2C0D3"
+            offset={{ right: 20 }}
+          />{" "}
+        </span>
+      ) : null}
+
+      <span className={clsx(classes.tipText, showTip)}>{tipText}</span>
+    </React.Fragment>
+  );
+};
+
+ToolTip.propTypes = {
+  tipText: PropTypes.string.isRequired
+};
+
+export default ToolTip;

--- a/client/src/components/ProjectWizard/RuleCalculation/ToolTipIcon.js
+++ b/client/src/components/ProjectWizard/RuleCalculation/ToolTipIcon.js
@@ -1,0 +1,47 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCircle, faQuestion } from "@fortawesome/free-solid-svg-icons";
+import { createUseStyles } from "react-jss";
+import clsx from "clsx";
+
+const useStyles = createUseStyles({
+  questionStyle: styles => ({
+    ...styles.questionStyle
+  }),
+  circleStyle: styles => ({
+    ...styles.circleStyle
+  }),
+  containerStyle: styles => ({
+    fontSize: 25,
+    verticalAlign: "-.25em",
+    ...styles.containerStyle
+  })
+});
+
+const ToolTipIcon = ({ containerStyle, circleStyle, questionStyle }) => {
+  const classes = useStyles({ containerStyle, circleStyle, questionStyle });
+  return (
+    <span className={clsx("fa-layers", "fa-fw", classes.containerStyle)}>
+      <FontAwesomeIcon
+        icon={faCircle}
+        color="#a7c539"
+        className={classes.circleStyle}
+      />
+      <FontAwesomeIcon
+        icon={faQuestion}
+        color="white"
+        className={classes.questionStyle}
+        transform="shrink-5"
+      />
+    </span>
+  );
+};
+
+ToolTipIcon.propTypes = {
+  circleStyle: PropTypes.object,
+  containerStyle: PropTypes.object,
+  questionStyle: PropTypes.object
+};
+
+export default ToolTipIcon;


### PR DESCRIPTION
I added a tooltip message with the Project Wizard for "Citywide Parking Baseline” within the "Calculate TDM Target Points" page.
#434 

![ToolTip](https://user-images.githubusercontent.com/40730303/88847322-b54bc800-d19b-11ea-9e84-b2abafd9dfd6.png)