### PR TITLE
Insert warehouse CalculationPanel again

### DIFF
--- a/db/migration/V0012__put_warehouse_calculation_panel_back_478.sql
+++ b/db/migration/V0012__put_warehouse_calculation_panel_back_478.sql
@@ -1,0 +1,16 @@
+SET IDENTITY_INSERT CalculationPanel ON;
+
+INSERT INTO dbo.CalculationPanel
+           (id, calculationId
+           ,name
+           ,cssClass
+           ,displayOrder)
+     VALUES
+           (33, 1
+           ,'Warehouse Space'
+           ,'landUse'
+           ,350
+           )
+GO
+
+SET IDENTITY_INSERT CalculationPanel OFF;


### PR DESCRIPTION
Migration V0008 deleted the CalculationPanel record for Warehouse, but we need it, so this migration inserts it again.