### PR TITLE
Corrected capitalization of tooltips and made display of tooltips conditional

### DIFF
--- a/client/src/components/ProjectWizard/SidebarPoints/SidebarPoints.js
+++ b/client/src/components/ProjectWizard/SidebarPoints/SidebarPoints.js
@@ -20,6 +20,9 @@ const useStyles = createUseStyles({
   },
   lowOpacity: {
     opacity: 0.4
+  },
+  noDisplay: {
+    display: "none !important"
   }
 });
 
@@ -28,12 +31,16 @@ const SidebarPoints = props => {
   const { rule } = props;
   const opacityTest =
     rule.value && rule.value !== "0" ? "" : classes.lowOpacity;
+  const noToolTip = rule.value === 0 ? classes.noDisplay : "";
+
   return (
     <div className={clsx("tdm-calculation-metrics-panel-item", opacityTest)}>
       <div className={classes.ruleValue}>{rule.value}</div>
       <h3 className={classes.ruleName}>
         {rule.name}
-        <ToolTip tipText={rule.description} />
+        <span className={clsx(classes.projectLevelContainer, noToolTip)}>
+          <ToolTip tipText={rule.description} />
+        </span>
       </h3>
       {/* <div> {rule.units}</div> */}
     </div>

--- a/client/src/components/ProjectWizard/SidebarPoints/SidebarProjectLevel.js
+++ b/client/src/components/ProjectWizard/SidebarPoints/SidebarProjectLevel.js
@@ -27,6 +27,9 @@ const useStyles = createUseStyles({
   },
   lowOpacity: {
     opacity: 0.4
+  },
+  noDisplay: {
+    display: "none !important"
   }
 });
 
@@ -34,12 +37,16 @@ const SidebarProjectLevel = ({ level, rules }) => {
   const classes = useStyles();
   const tipText = rules[0].description;
   const opacityTest = level === 0 ? classes.lowOpacity : "";
+  const noToolTip = level === 0 ? classes.noDisplay : "";
+
   return (
     <div className={clsx(classes.projectLevelContainer, opacityTest)}>
       <p className={classes.projectLevelValue}>{level}</p>
       <h3 className={classes.projectLevelHeader}>
         PROJECT LEVEL
-        <Tooltip tipText={tipText} />
+        <span className={clsx(classes.projectLevelContainer, noToolTip)}>
+          <Tooltip tipText={tipText} />
+        </span>
       </h3>
     </div>
   );

--- a/client/src/components/ProjectWizard/SidebarPoints/ToolTip.js
+++ b/client/src/components/ProjectWizard/SidebarPoints/ToolTip.js
@@ -14,6 +14,7 @@ const useStyles = createUseStyles({
     borderRadius: "50%",
     textAlign: "center",
     verticalAlign: "top",
+    opacity: "1 !important",
     border: "none",
     "&:hover": {
       cursor: "pointer"
@@ -47,7 +48,7 @@ const useStyles = createUseStyles({
       color: "rgb(30, 36, 63) !important",
       backgroundColor: "rgb(230, 234, 239) !important",
       opacity: "1 !important",
-      textTransform: "capitalize !important"
+      textTransform: "none !important"
     }
   }
 });


### PR DESCRIPTION
#524 

I revised the ToolTips within the Sidebar so that only the first word of each sentence would be capitalized along with any pertinent terms that warrant capitalization.

I also added functionality in order to have the Tooltips display conditionally. If "Project Level" or "Target Points" equal zero than the Tooltip icon will not be displayed. Once the value is greater than zero the Tooltip icon will be displayed along with conditionally displayed Tooltip message.

![1](https://user-images.githubusercontent.com/40730303/90966992-dac3ad00-e48d-11ea-949d-6a49588f5d20.jpg)

![2](https://user-images.githubusercontent.com/40730303/90966993-dc8d7080-e48d-11ea-985b-2ea65c51f3a5.jpg)