### PR TITLE
Fix alignment of right button on specifications page, when disabled #548

### DIFF
--- a/client/src/styles/Calculation.scss
+++ b/client/src/styles/Calculation.scss
@@ -74,7 +74,7 @@
 .tdm-wizard-nav-button {
   height: 37px;
   margin: 0 1em;
-  padding: .5em 1em;
+  padding: 0.5em 1em;
   background-color: $color-highlight;
   color: #0f2940;
   font-size: 1.5em;
@@ -94,11 +94,10 @@
 .tdm-wizard-nav-button-disabled {
   padding-left: 0.7em;
   padding-right: 0.7em;
-  padding-top: 0.35em;
   padding-bottom: 0.35em;
   display: inline;
   margin: 0.5em;
-  font-size: 2em;
+  font-size: 1.5em;
   text-shadow: 0px 6px 4px rgba(0, 46, 109, 0.3);
   text-align: center;
 }


### PR DESCRIPTION
I corrected the alignment of the right button on the second page of the wizard, the project specifications page. #548 

![1](https://user-images.githubusercontent.com/40730303/92761006-12fc3400-f346-11ea-9c0c-c3e48a8c82b3.png)

![2](https://user-images.githubusercontent.com/40730303/92761032-18f21500-f346-11ea-9a82-0353012c418b.png)
