### PR TITLE
More buttons styling and refactoring

### DIFF
--- a/client/src/components/Button/Button.js
+++ b/client/src/components/Button/Button.js
@@ -40,17 +40,14 @@ const Button = ({
   const theme = useTheme();
   const classes = useStyles({ color, theme });
 
+  if (!isDisplayed) return null;
   return (
-    <>
-      {isDisplayed && (
-        <button
-          className={clsx(classes.root, classes[variant], className)}
-          onClick={onClick}
-        >
-          {children}
-        </button>
-      )}
-    </>
+    <button
+      className={clsx(classes.root, classes[variant], className)}
+      onClick={onClick}
+    >
+      {children}
+    </button>
   );
 };
 

--- a/client/src/components/Button/Button.js
+++ b/client/src/components/Button/Button.js
@@ -1,35 +1,31 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { createUseStyles, useTheme } from "react-jss";
+import clsx from "clsx";
 
 const useStyles = createUseStyles({
-  //TODO: make the switchView button more generic/refactor
-  switchView: {
+  root: {
+    color: ({ theme }) => theme.colorText,
+    cursor: "pointer",
+    fontFamily: "Calibri Bold",
     height: "min-content",
     margin: "0.5em",
     padding: "0.5em 1em",
-    boxShadow: "0px 6px 4px rgba(0,46,109,0.3)",
-    border: "none",
-    cursor: "pointer",
+    textAlign: "center",
     textTransform: "uppercase",
-    fontFamily: "Calibri bold",
-    letterSpacing: "1px"
+    //TODO: Move these when we figure out size-related props
+    letterSpacing: "0.05em",
+    fontSize: "20px"
   },
-  medium: {
-    backgroundColor: ({ theme, backgroundColor }) => theme[backgroundColor],
-    display: "block",
-    width: "240px",
-    height: "60px",
-    marginBottom: "1em",
-    boxShadow: "0px 6px 4px rgba(0, 46, 109, 0.3)",
-    border: "none",
-    color: "#253d52",
-    fontFamily: "Calibri Bold",
-    fontSize: "20px",
-    fontWeight: "bold",
-    textTransform: "uppercase",
-    letterSpacing: "2px",
-    textAlign: "center"
+  contained: {
+    backgroundColor: ({ theme, color }) => theme[color],
+    borderColor: "rgba(0, 0, 0, .05)", //lightest grey
+    boxShadow: "rgba(0, 46, 109, 0.3) 1px 2px 3px"
+  },
+  outlined: {
+    backgroundColor: ({ theme }) => theme.colorWhite,
+    borderColor: "rgba(0, 46, 109, .2)", //medium grey
+    borderWidth: "thin"
   }
 });
 
@@ -38,17 +34,19 @@ const Button = ({
   className,
   isDisplayed = true,
   onClick,
-  size = "medium",
-  backgroundColor = "colorDefault"
+  variant = "contained",
+  color = "colorDefault"
 }) => {
   const theme = useTheme();
-  const styles = useStyles({ backgroundColor, theme });
-  const buttonStyle = size && styles[size];
+  const classes = useStyles({ color, theme });
 
   return (
     <>
       {isDisplayed && (
-        <button className={styles[className] || buttonStyle} onClick={onClick}>
+        <button
+          className={clsx(classes.root, classes[variant], className)}
+          onClick={onClick}
+        >
           {children}
         </button>
       )}
@@ -60,9 +58,10 @@ Button.propTypes = {
   onClick: PropTypes.func,
   children: PropTypes.string,
   size: PropTypes.string,
+  variant: PropTypes.string,
   isDisplayed: PropTypes.bool,
   className: PropTypes.string,
-  backgroundColor: PropTypes.string
+  color: PropTypes.string
 };
 
 export default Button;

--- a/client/src/components/Button/NavButton.js
+++ b/client/src/components/Button/NavButton.js
@@ -34,13 +34,13 @@ const useStyles = createUseStyles({
 const NavButton = ({ id, onClick, navDirection, isVisible, isDisabled }) => {
   const theme = useTheme();
   const classes = useStyles({ theme });
-  const disabledStyle = isDisabled && classes.wizardNavButtonDisabled;
-  const hiddenVisibilityStyle = !isVisible && classes.hidden;
+  const maybeDisabled = isDisabled && classes.wizardNavButtonDisabled;
+  const maybeHiddenVisibility = !isVisible && classes.hidden;
 
   return (
     <button
       id={id}
-      className={clsx(classes.root, disabledStyle, hiddenVisibilityStyle)}
+      className={clsx(classes.root, maybeDisabled, maybeHiddenVisibility)}
       data-testid={id}
       onClick={onClick}
       disabled={isDisabled}

--- a/client/src/components/Button/NavButton.js
+++ b/client/src/components/Button/NavButton.js
@@ -19,7 +19,8 @@ const useStyles = createUseStyles({
     }
   },
   wizardNavButtonDisabled: {
-    backgroundColor: ({ theme }) => theme.colorDisabled
+    backgroundColor: ({ theme }) => theme.colorDisabled,
+    cursor: "default"
   },
   hidden: {
     visibility: "hidden"

--- a/client/src/components/Button/NavButton.js
+++ b/client/src/components/Button/NavButton.js
@@ -1,51 +1,49 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { createUseStyles } from "react-jss";
+import { createUseStyles, useTheme } from "react-jss";
 import { faAngleLeft, faAngleRight } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import clsx from "clsx";
 
 const useStyles = createUseStyles({
-  wizardNavButton: {
+  root: {
+    cursor: "pointer",
     padding: "0.35em 0.7em",
     margin: "0.5em",
     fontSize: "2em",
-    border: "none",
-    backgroundColor: "#a7c539"
+    border: "1px solid rgba(0, 0, 0, 0.1)",
+    boxShadow: "rgba(0, 46, 109, 0.3) 0px 3px 5px",
+    backgroundColor: ({ theme }) => theme.colorPrimary,
+    "&:focus": {
+      borderRadius: "none"
+    }
   },
   wizardNavButtonDisabled: {
-    padding: "0.35em 0.7em",
-    margin: "0.5em",
-    fontSize: "2em",
-    border: "none",
-    textShadow: "0px 6px 4px rgba(0, 46, 109, 0.3)"
+    backgroundColor: ({ theme }) => theme.colorDisabled
   },
   hidden: {
     visibility: "hidden"
   },
   "@media print": {
-    wizardNavButton: {
-      display: "none"
-    },
-    wizardNavButtonDisabled: {
+    root: {
       display: "none"
     }
   }
 });
 
 const NavButton = ({ id, onClick, navDirection, isVisible, isDisabled }) => {
-  const classes = useStyles();
-  const normalOrDisabledStyle = isDisabled
-    ? classes.wizardNavButtonDisabled
-    : classes.wizardNavButton;
+  const theme = useTheme();
+  const classes = useStyles({ theme });
+  const disabledStyle = isDisabled && classes.wizardNavButtonDisabled;
   const hiddenVisibilityStyle = !isVisible && classes.hidden;
 
   return (
     <button
       id={id}
-      className={clsx(normalOrDisabledStyle, hiddenVisibilityStyle)}
+      className={clsx(classes.root, disabledStyle, hiddenVisibilityStyle)}
       data-testid={id}
       onClick={onClick}
+      disabled={isDisabled}
     >
       <FontAwesomeIcon
         icon={navDirection === "previous" ? faAngleLeft : faAngleRight}
@@ -55,6 +53,7 @@ const NavButton = ({ id, onClick, navDirection, isVisible, isDisabled }) => {
 };
 
 NavButton.propTypes = {
+  children: PropTypes.object,
   onClick: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,
   navDirection: PropTypes.string.isRequired,

--- a/client/src/components/Button/SwitchViewButton.js
+++ b/client/src/components/Button/SwitchViewButton.js
@@ -1,0 +1,28 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { createUseStyles, useTheme } from "react-jss";
+import Button from "./Button";
+
+const useStyles = createUseStyles({
+  switchView: {
+    fontSize: "16px"
+  }
+});
+
+const SwitchViewButton = ({ children, onViewChange }) => {
+  const theme = useTheme();
+  const styles = useStyles({ theme });
+
+  return (
+    <Button className={styles.switchView} onClick={onViewChange}>
+      {children}
+    </Button>
+  );
+};
+
+SwitchViewButton.propTypes = {
+  onViewChange: PropTypes.func,
+  children: PropTypes.string
+};
+
+export default SwitchViewButton;

--- a/client/src/components/ProjectSinglePage/TdmCalculation.js
+++ b/client/src/components/ProjectSinglePage/TdmCalculation.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
 import RulePanels from "./RulePanels";
 import ResultList from "./ResultList";
-import Button from "../Button/Button.js";
+import SwitchViewButton from "../Button/SwitchViewButton";
 
 const useStyles = createUseStyles({
   root: {
@@ -116,9 +116,9 @@ const TdmCalculation = props => {
       <div className={classes.container}>
         <div className={classes.switchButtonWrapper}>
           <div className={classes.switchButton}>
-            <Button className="switchView" onClick={props.onViewChange}>
+            <SwitchViewButton onViewChange={props.onViewChange}>
               Switch to Wizard View
-            </Button>
+            </SwitchViewButton>
           </div>
           {rules && rules.length > 0 ? (
             <ResultList rules={resultRules} />

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -9,8 +9,9 @@ import Sidebar from "../Sidebar";
 import { Switch, Route, withRouter } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClock } from "@fortawesome/free-solid-svg-icons";
-import Button from "../Button/Button.js";
+import Button from "../Button/Button";
 import NavButton from "../Button/NavButton";
+import SwitchViewButton from "../Button/SwitchViewButton";
 
 import {
   ProjectDescriptions,
@@ -273,9 +274,9 @@ const TdmCalculationWizard = props => {
         <Sidebar>
           {rules && rules.length > 0 && (
             <div className={classes.sidebarContent}>
-              <Button className="switchView" onClick={onViewChange}>
+              <SwitchViewButton onViewChange={onViewChange}>
                 Switch to Single Page View
-              </Button>
+              </SwitchViewButton>
               <SidebarPointsPanel rules={resultRules} />
             </div>
           )}
@@ -325,15 +326,16 @@ const TdmCalculationWizard = props => {
                         )
                       }
                       onClick={onSave}
-                      backgroundColor="colorPrimary"
+                      color="colorPrimary"
+                      variant="contained"
                     >
                       {projectId ? "Save Project" : "Save As New Project"}
                     </Button>
                     <Button
                       isDisplayed={page !== 1}
                       onClick={() => window.location.assign("/calculation")}
-                      backgroundColor="colorDefault"
-                      size="medium"
+                      color="colorLightGrey"
+                      variant="outlined"
                     >
                       Start Over
                     </Button>

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -334,7 +334,6 @@ const TdmCalculationWizard = props => {
                     <Button
                       isDisplayed={page !== 1}
                       onClick={() => window.location.assign("/calculation")}
-                      color="colorLightGrey"
                       variant="outlined"
                     >
                       Start Over

--- a/client/src/styles/theme.js
+++ b/client/src/styles/theme.js
@@ -3,7 +3,9 @@ module.exports = {
   jssTheme: {
     colorDefault: "#fff", //white
     colorPrimary: "#a7c539", //lime green
-    colorSecondary: "#0F2940", //dark blue
-    colorLADOT: "#002E6D"
+    colorText: "#0F2940", //dark blue
+    colorLADOT: "#002E6D",
+    colorDisabled: "rgba(0, 0, 0, .05)", //lightest grey transparent
+    colorWhite: "#fff" //white
   }
 };


### PR DESCRIPTION
Part of #563: make buttons consistent

- Refactored Button component to make it more reusable (If we need to add custom styles for a component, we can pass it into className)
- Restyled buttons to incorporate recently-learned Material's design best practices (e.g. Less amount of emphasis on "Start Over," more emphasis/drop shadows on nav button, a less emphasis on "save project")
- Add Project and Start Over buttons are inline
- Incorporated contained and outlined variant of buttons
- Add SwitchViewButton back in, but is now using the Button component
- Add a few more colors in theme


Page 1 (disabled -- uses all the same style as the enabled nav button but just greyed out and no pointer; didn't know which grey to use so I arbitrarily chose one):
![image](https://user-images.githubusercontent.com/45305029/93437214-91922d80-f880-11ea-87c2-d062c75039a0.png)
Page 2-4:
![image](https://user-images.githubusercontent.com/45305029/93433755-17f84080-f87c-11ea-9d24-c20ebe768211.png)
Page 5:
![image](https://user-images.githubusercontent.com/45305029/93433816-29414d00-f87c-11ea-9497-fb927c9ed809.png)

