### PR TITLE
Bug: The toast to notify users after login information has timed out is displayed twice #506 

### DIFF
--- a/client/src/components/Projects.js
+++ b/client/src/components/Projects.js
@@ -261,7 +261,7 @@ const Projects = ({ account, history }) => {
       }
     };
     getProjects();
-  }, [email, toastAdd, historyPush]);
+  }, [email, historyPush]);
 
   const toggleDuplicateModal = async project => {
     if (project) {

--- a/client/src/components/TermsAndConditionsModal.js
+++ b/client/src/components/TermsAndConditionsModal.js
@@ -39,11 +39,6 @@ const useStyles = createUseStyles({
       padding: "16px",
       border: "1px solid #979797",
       marginTop: "8px"
-    },
-    "& .scroll": {
-      overflowY: "scroll",
-      width: "auto",
-      height: "300px"
     }
   },
   modalActions: {
@@ -89,6 +84,20 @@ const useStyles = createUseStyles({
     height: "20px !important",
     position: "relative",
     marginRight: "10px !important"
+  },
+  scroll: {
+    "&::-webkit-scrollbar": {
+      webkitappearance: "none",
+      width: "7px"
+    },
+    "&::-webkit-scrollbar-thumb": {
+      borderRadius: "4px",
+      backgroundColor: "rgba(0, 0, 0, .5)",
+      webkitBoxShadow: "0 0 1px rgba(255, 255, 255, .5)"
+    },
+    overflowY: "scroll",
+    width: "auto",
+    height: "300px"
   }
 });
 
@@ -141,7 +150,7 @@ const TermsAndConditionsModal = () => {
       className={classes.modal}
     >
       <h2>TDM Calculator User Terms and Conditions</h2>
-      <div className="scroll">
+      <div className={classes.scroll}>
         <p>
           PLEASE READ THIS AGREEMENT CAREFULLY BEFORE USING THIS WEB SITE. BY
           USING THIS WEB SITE, YOU ARE CONSENTING TO BE OBLIGATED AND BECOME A


### PR DESCRIPTION
Edited the toast to only display once in order to notify users after login information has timed out. #506

![1](https://user-images.githubusercontent.com/40730303/97125298-b9cb4280-16f0-11eb-846d-5ddcc19d24d3.jpg)

Also included styling changes to scrollbar for the Terms and Conditions Modal per request.

![2](https://user-images.githubusercontent.com/40730303/97125443-352cf400-16f1-11eb-9736-c59776183f37.jpg)
