### PR TITLE
NavConfirmationModal shows up when attempting to navigate away from /calculation

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -20,8 +20,8 @@ import FaqView from "./components/Faq/FaqView";
 import ResetPassword from "./components/Authorization/ResetPassword";
 import ResetPasswordRequest from "./components/Authorization/ResetPasswordRequest";
 import "./styles/App.scss";
-import axios from "axios";
 import PublicComment from "./components/PublicComment/PublicCommentPage";
+import NavConfirmationModal from "./components/NavConfirmationModal";
 
 const useStyles = createUseStyles({
   root: {
@@ -35,6 +35,8 @@ const App = () => {
   const classes = useStyles();
   const [account, setAccount] = useState({});
   const [isCreatingNewProject, setIsCreatingNewProject] = useState(false);
+  const [confirmCallback, setConfirmCallback] = useState(null);
+  const [openNavModal, setOpenNavConfirmationModal] = useState(false);
 
   useEffect(() => {
     const currentUser = localStorage.getItem("currentUser");
@@ -58,26 +60,20 @@ const App = () => {
     localStorage.setItem("currentUser", JSON.stringify(loggedInUser));
   };
 
-  //TODO: This doesn't seem like it's getting used anymore. Don't see token in local storage. Check on authorization flow to see if token is still needed.
-  const setTokenInHeaders = () => {
-    axios.interceptors.request.use(
-      config => {
-        let token = localStorage.getItem("token");
-        if (token) {
-          config.headers["Authorization"] = `Bearer ${token}`;
-        }
-        return config;
-      },
-      error => Promise.reject(error)
-    );
+  const getUserConfirmation = (message, callback) => {
+    setConfirmCallback(() => callback);
+    setOpenNavConfirmationModal(!openNavModal);
   };
-
-  setTokenInHeaders();
 
   return (
     <React.Fragment>
       <UserContext.Provider value={account}>
-        <Router>
+        <Router getUserConfirmation={getUserConfirmation}>
+          <NavConfirmationModal
+            confirmCallback={confirmCallback}
+            setOpenNavModal={setOpenNavConfirmationModal}
+            openNavModal={openNavModal}
+          />
           <Header
             account={account}
             setAccount={setAccount}
@@ -95,6 +91,7 @@ const App = () => {
                 <TdmCalculationContainer
                   account={account}
                   setIsCreatingNewProject={setIsCreatingNewProject}
+                  setOpenNavConfirmationModal={setOpenNavConfirmationModal}
                 />
               )}
             />

--- a/client/src/components/NavConfirmationModal.js
+++ b/client/src/components/NavConfirmationModal.js
@@ -1,0 +1,71 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Modal from "react-modal";
+import Button from "./Button/Button";
+
+const modalStyles = {
+  overlay: {
+    backgroundColor: "rgba(0, 0, 0, 0.05)",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    zIndex: "100"
+  },
+  content: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    flexDirection: "column",
+    position: "relative",
+    boxSizing: "border-box",
+    padding: "60px",
+    backgroundColor: "#ffffff",
+    boxShadow: "0px 5px 10px rgba(0, 46, 109, 0.2)"
+  }
+};
+const NavConfirmationModal = ({
+  setOpenNavModal,
+  openNavModal,
+  confirmCallback
+}) => {
+  function allowTransition() {
+    setOpenNavModal(false);
+    confirmCallback(true);
+  }
+
+  function blockTransition() {
+    setOpenNavModal(false);
+    confirmCallback(false);
+  }
+
+  return (
+    <React.Fragment>
+      <Modal
+        isOpen={openNavModal}
+        onRequestClose={() => setOpenNavModal(false)}
+        contentLabel="Navigation Confirmation"
+        style={modalStyles}
+      >
+        <h2>Are you sure you want to navigate away?</h2>
+        <h4>Your data will not be saved.</h4>
+        <br />
+        <div>
+          <Button variant="outlined" onClick={blockTransition}>
+            Cancel
+          </Button>
+          <Button color="colorPrimary" onClick={allowTransition}>
+            Proceed
+          </Button>
+        </div>
+      </Modal>
+    </React.Fragment>
+  );
+};
+
+NavConfirmationModal.propTypes = {
+  setOpenNavModal: PropTypes.func.isRequired,
+  confirmCallback: PropTypes.func,
+  openNavModal: PropTypes.bool.isRequired
+};
+
+export default NavConfirmationModal;

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -152,7 +152,7 @@ const TdmCalculationWizard = props => {
     };
 
     if (projectId) getDateModified();
-  });
+  }, []);
 
   const context = useContext(ToastContext);
   const classes = useStyles();
@@ -384,7 +384,10 @@ const TdmCalculationWizard = props => {
                     </Button>
                     <Button
                       isDisplayed={page !== 1}
-                      onClick={() => window.location.assign("/calculation")}
+                      onClick={() => {
+                        // TODO setOpenNavConfirmationModal(true);
+                        window.location.assign("/calculation/");
+                      }}
                       variant="outlined"
                     >
                       Start Over


### PR DESCRIPTION
This PR addresses part of issue #595. I'm still working on issue but wanted to get some work sent in for Tuesday's meeting.

- A NavConfirmationModal shows up when attempting to navigate away from /calculation (e.g. /about, /login, etc.) when form is filled out and new updates have not been saved; Added react-router Prompt component
- Modal does not yet show up when user clicks on Start Over - Still working on this

Did some minor refactoring/code clean up:
- deconstructed all props in TdmCalculationContainer.js
- deleted unused functions (setTokenInHeaders in App.js)
- made usage of Toast and History consistent; deleted repetitive ToastContext and opted for useToast instead


![image](https://user-images.githubusercontent.com/45305029/97142758-84d5e480-171e-11eb-9f41-9268462d1852.png)



