### PR TITLE
Refactor projects page and move duplicate and delete modals into own component

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,7 +4,7 @@ import { createUseStyles } from "react-jss";
 import { withToastProvider } from "./contexts/Toast";
 import { UserContext } from "./components/user-context";
 import TdmCalculationContainer from "./components/TdmCalculationContainer";
-import Projects from "./components/Projects";
+import ProjectsPage from "./components/Projects/ProjectsPage";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import About from "./components/About";
@@ -104,7 +104,7 @@ const App = () => {
             />
             <Route
               path="/projects"
-              render={() => <Projects account={account} />}
+              render={() => <ProjectsPage account={account} />}
             />
             <Route path="/about" component={About} />
             <Route path="/termsandconditions" component={TermsAndConditions} />

--- a/client/src/components/Projects/DeleteProjectModal.js
+++ b/client/src/components/Projects/DeleteProjectModal.js
@@ -1,0 +1,73 @@
+import React from "react";
+import WarningIcon from "../../images/warning-icon.png";
+import { createUseStyles } from "react-jss";
+import * as projectService from "../../services/project.service";
+import { PropTypes } from "prop-types";
+import ProjectActionModal from "./ProjectActionModal";
+
+const useStyles = createUseStyles({
+  instruction: {
+    fontSize: "20px",
+    lineHeight: "32px",
+    textAlign: "center",
+    color: "#B64E38",
+    "& span": {
+      fontStyle: "italic"
+    }
+  },
+  warningIcon: {
+    float: "left",
+    margin: "4px 12px 12px 0"
+  }
+});
+
+const DeleteProjectModal = ({
+  selectedProject,
+  setSelectedProject,
+  handleError,
+  deleteModalOpen,
+  toggleDeleteModal
+}) => {
+  const classes = useStyles();
+
+  const deleteProject = async project => {
+    try {
+      await projectService.del(project.id);
+    } catch (err) {
+      handleError(err);
+    }
+
+    toggleDeleteModal();
+    setSelectedProject(null);
+  };
+
+  return (
+    <ProjectActionModal
+      isOpen={deleteModalOpen}
+      onRequestClose={toggleDeleteModal}
+      contentLabel="Delete Modal"
+      toggleCloseButton={toggleDeleteModal}
+      action="delete"
+      title="Delete Project"
+      submitButtonLabel="Delete"
+      handleSubmit={() => deleteProject(selectedProject)}
+    >
+      <p className={classes.instruction}>
+        <img src={WarningIcon} className={classes.warningIcon} alt="Warning" />
+        Are you sure you want to <span>permanently</span> delete this project,
+        &nbsp;
+        <strong>{selectedProject && selectedProject.name}</strong>?
+      </p>
+    </ProjectActionModal>
+  );
+};
+
+DeleteProjectModal.propTypes = {
+  selectedProject: PropTypes.object.isRequired,
+  setSelectedProject: PropTypes.func.isRequired,
+  toggleDeleteModal: PropTypes.func.isRequired,
+  handleError: PropTypes.func.isRequired,
+  deleteModalOpen: PropTypes.bool.isRequired
+};
+
+export default DeleteProjectModal;

--- a/client/src/components/Projects/DuplicateProjectModal.js
+++ b/client/src/components/Projects/DuplicateProjectModal.js
@@ -1,0 +1,94 @@
+import React from "react";
+import { createUseStyles } from "react-jss";
+import * as projectService from "../../services/project.service";
+import { PropTypes } from "prop-types";
+import ProjectActionModal from "./ProjectActionModal";
+
+const useStyles = createUseStyles({
+  instruction: {
+    fontSize: "20px",
+    lineHeight: "32px",
+    textAlign: "center"
+  },
+  inputField: {
+    boxSizing: "border-box",
+    fontSize: "20px",
+    lineHeight: "24px",
+    padding: "16px",
+    border: "1px solid #979797",
+    marginTop: "8px"
+  }
+});
+
+const DuplicateProjectModal = ({
+  selectedProject,
+  setSelectedProject,
+  handleError,
+  duplicateModalOpen,
+  toggleDuplicateModal,
+  duplicateProjectName,
+  setDuplicateProjectName
+}) => {
+  const classes = useStyles();
+
+  const duplicateProject = async project => {
+    const jsonProject = JSON.parse(project.formInputs);
+    jsonProject.PROJECT_NAME = duplicateProjectName;
+
+    try {
+      await projectService.post({
+        ...project,
+        name: duplicateProjectName,
+        formInputs: JSON.stringify(project)
+      });
+    } catch (err) {
+      handleError(err);
+    }
+
+    toggleDuplicateModal();
+    setSelectedProject(null);
+  };
+
+  const handleDuplicateProjectNameChange = newProjectName => {
+    setDuplicateProjectName(newProjectName);
+  };
+
+  return (
+    <ProjectActionModal
+      isOpen={duplicateModalOpen}
+      onRequestClose={toggleDuplicateModal}
+      contentLabel="Duplicate Modal"
+      toggleCloseButton={toggleDuplicateModal}
+      action="duplicate"
+      title="Duplicate Project"
+      submitButtonLabel="Create a Copy"
+      handleSubmit={() => duplicateProject(selectedProject)}
+    >
+      <p className={classes.instruction}>
+        Type a new name to duplicate the project,&nbsp;
+        <br />
+        <strong>{selectedProject && selectedProject.name}</strong>.
+      </p>
+      <input
+        placeholder="Name of Duplicated Project"
+        type="text"
+        id="duplicateName"
+        name="duplicateName"
+        value={duplicateProjectName}
+        onChange={e => handleDuplicateProjectNameChange(e.target.value)}
+      />
+    </ProjectActionModal>
+  );
+};
+
+DuplicateProjectModal.propTypes = {
+  selectedProject: PropTypes.object.isRequired,
+  setSelectedProject: PropTypes.func.isRequired,
+  toggleDuplicateModal: PropTypes.func.isRequired,
+  handleError: PropTypes.func.isRequired,
+  duplicateModalOpen: PropTypes.bool.isRequired,
+  duplicateProjectName: PropTypes.string,
+  setDuplicateProjectName: PropTypes.func.isRequired
+};
+
+export default DuplicateProjectModal;

--- a/client/src/components/Projects/ProjectActionModal.js
+++ b/client/src/components/Projects/ProjectActionModal.js
@@ -1,0 +1,126 @@
+import React from "react";
+import Modal from "react-modal";
+import Button from "../Button/Button";
+import { createUseStyles } from "react-jss";
+import CloseIcon from "../../images/close.png";
+import { PropTypes } from "prop-types";
+import CopyIcon from "../../images/copy.png";
+import DeleteIcon from "../../images/trash.png";
+
+const useStyles = createUseStyles({
+  title: {
+    fontSize: "25px",
+    lineHeight: "31px",
+    fontWeight: "bold",
+    textAlign: "center",
+    marginBottom: "30px"
+  },
+  titleIcon: {
+    margin: "0 6px 0 0",
+    verticalAlign: "middle"
+  },
+  modalActions: {
+    display: "flex",
+    justifyContent: "flex-end",
+    marginTop: "42px"
+  },
+  closeBtn: {
+    position: "absolute",
+    top: "24px",
+    right: "24px",
+    backgroundColor: "transparent",
+    border: "none"
+  }
+});
+
+const modalStyles = {
+  overlay: {
+    backgroundColor: "rgba(255, 255, 255, 0.5)",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center"
+  },
+  content: {
+    position: "relative",
+    top: "auto",
+    right: "auto",
+    bottom: "auto",
+    left: "auto",
+    boxSizing: "border-box",
+    maxHeight: "480px",
+    width: "666px",
+    maxWidth: "100%",
+    padding: "60px",
+    backgroundColor: "#ffffff",
+    boxShadow: "0px 5px 10px rgba(0, 46, 109, 0.2)"
+  }
+};
+
+const ProjectActionModal = ({
+  isOpen,
+  onRequestClose,
+  contentLabel,
+  toggleCloseButton,
+  action,
+  title,
+  handleSubmit,
+  submitButtonLabel,
+  children
+}) => {
+  const classes = useStyles();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onRequestClose={onRequestClose}
+      contentLabel={contentLabel}
+      style={modalStyles}
+      shouldFocusAfterRender={false}
+    >
+      <button className={classes.closeBtn} onClick={toggleCloseButton}>
+        <img src={CloseIcon} alt="Close" />
+      </button>
+      <h2 className={classes.title}>
+        <img
+          src={action === "duplicate" ? CopyIcon : DeleteIcon}
+          alt={action}
+          className={classes.titleIcon}
+        />
+        <strong>{title}</strong>
+      </h2>
+
+      {children}
+
+      <div className={classes.modalActions}>
+        <Button onClick={toggleCloseButton} variant="text">
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          color={action === "duplicate" ? "colorPrimary" : "colorError"}
+        >
+          {submitButtonLabel}
+        </Button>
+      </div>
+    </Modal>
+  );
+};
+
+ProjectActionModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onRequestClose: PropTypes.func.isRequired,
+  contentLabel: PropTypes.string.isRequired,
+  toggleCloseButton: PropTypes.func.isRequired,
+  toggleCancelButton: PropTypes.func.isRequired,
+  action: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
+  submitButtonLabel: PropTypes.string.isRequired,
+  children: PropTypes.any.isRequired
+};
+
+// Required to bind modal to our appElement (http://reactcommunity.org/react-modal/accessibility/)
+Modal.setAppElement("#root");
+
+export default ProjectActionModal;

--- a/client/src/components/Projects/ProjectsPage.js
+++ b/client/src/components/Projects/ProjectsPage.js
@@ -1,21 +1,18 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import { Link, withRouter } from "react-router-dom";
 import { createUseStyles } from "react-jss";
-import Modal from "react-modal";
-import * as projectService from "../services/project.service";
+import * as projectService from "../../services/project.service";
 import moment from "moment";
-import { useToast } from "../contexts/Toast";
+import { useToast } from "../../contexts/Toast";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSortUp, faSortDown } from "@fortawesome/free-solid-svg-icons";
-import SearchIcon from "../images/search.png";
-import WarningIcon from "../images/warning-icon.png";
-import CopyIcon from "../images/copy.png";
-import DeleteIcon from "../images/trash.png";
-import CloseIcon from "../images/close.png";
-import Pagination from "./Pagination.js";
-import Button from "./Button/Button";
-
+import SearchIcon from "../../images/search.png";
+import CopyIcon from "../../images/copy.png";
+import DeleteIcon from "../../images/trash.png";
+import Pagination from "../Pagination.js";
+import DeleteProjectModal from "./DeleteProjectModal";
+import DuplicateProjectModal from "./DuplicateProjectModal";
 
 const useStyles = createUseStyles({
   main: {
@@ -102,84 +99,10 @@ const useStyles = createUseStyles({
   },
   link: {
     textDecoration: "underline"
-  },
-  warningIcon: {
-    float: "left"
-  },
-  modal: {
-    "& h2": {
-      fontSize: "25px",
-      lineHeight: "31px",
-      fontWeight: "bold",
-      textAlign: "center",
-      marginBottom: "30px",
-      "& img": {
-        margin: "0 6px 0 0",
-        verticalAlign: "middle"
-      }
-    },
-    "& p": {
-      fontSize: "20px",
-      lineHeight: "32px",
-      textAlign: "center",
-      "& img": {
-        margin: "4px 12px 12px 0"
-      }
-    },
-    "& input": {
-      boxSizing: "border-box",
-      fontSize: "20px",
-      lineHeight: "24px",
-      padding: "16px",
-      border: "1px solid #979797",
-      marginTop: "8px"
-    }
-  },
-  deleteCopy: {
-    color: "#B64E38",
-    "& span": {
-      fontStyle: "italic"
-    }
-  },
-  modalActions: {
-    display: "flex",
-    justifyContent: "flex-end",
-    marginTop: "42px"
-  },
-  closeBtn: {
-    position: "absolute",
-    top: "24px",
-    right: "24px",
-    backgroundColor: "transparent",
-    border: "none"
   }
 });
 
-const modalStyles = {
-  overlay: {
-    backgroundColor: "rgba(255, 255, 255, 0.5)",
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center"
-  },
-  content: {
-    position: "relative",
-    top: "auto",
-    right: "auto",
-    bottom: "auto",
-    left: "auto",
-    boxSizing: "border-box",
-    maxHeight: "480px",
-    width: "666px",
-    maxWidth: "100%",
-    padding: "60px",
-    backgroundColor: "#ffffff",
-    boxShadow: "0px 5px 10px rgba(0, 46, 109, 0.2)",
-    ":focus": { outline: "none" }
-  }
-};
-
-const Projects = ({ account, history }) => {
+const ProjectsPage = ({ account, history }) => {
   const [projects, setProjects] = useState([]);
   const [filterText, setFilterText] = useState("");
   const [order, setOrder] = useState("asc");
@@ -214,13 +137,20 @@ const Projects = ({ account, history }) => {
     }
   };
 
-  useEffect(() => {
-    if(!selectedProject){
-      getProjects();
-    }
-  }, [email, historyPush, toastAdd, selectedProject]);
+  const handleError = useCallback(
+    error => {
+      if (error.response && error.response.status === 401) {
+        toastAdd(
+          "For your security, your session has expired. Please log in again."
+        );
+        historyPush(`/login/${encodeURIComponent(email)}`);
+      }
+      console.error(error);
+    },
+    [email, toastAdd, historyPush]
+  );
 
-  const getProjects = async () => {
+  const getProjects = useCallback(async () => {
     try {
       const result = await projectService.get();
       if (result.data === "" || result.data === false) {
@@ -231,17 +161,13 @@ const Projects = ({ account, history }) => {
     } catch (err) {
       handleError(err);
     }
-  };
+  }, [handleError]);
 
-  const handleError = (err) => {
-    if (err.response && err.response.status === 401) {
-          toastAdd(
-        "For your security, your session has expired. Please log in again."
-      );
-      historyPush(`/login/${encodeURIComponent(email)}`);
+  useEffect(() => {
+    if (!selectedProject) {
+      getProjects();
     }
-    console.error(err);
-  }
+  }, [selectedProject, getProjects]);
 
   const toggleDuplicateModal = async project => {
     if (project) {
@@ -256,39 +182,6 @@ const Projects = ({ account, history }) => {
   const toggleDeleteModal = project => {
     project ? setSelectedProject(project) : setSelectedProject(null);
     setDeleteModalOpen(!deleteModalOpen);
-  };
-
-  const duplicateProject = async project => {
-    const jsonProject = JSON.parse(project.formInputs);
-    jsonProject.PROJECT_NAME = duplicateProjectName;
-
-    try {
-      await projectService.post({
-        ...project,
-        name: duplicateProjectName,
-        formInputs: JSON.stringify(project)
-      })
-    } catch(err){
-      handleError(err);
-    }
-
-    toggleDuplicateModal();
-    setSelectedProject(null);
-  };
-
-  const deleteProject = async project => {
-    try {
-      await projectService.del(project.id);
-    } catch (err) {
-      handleError(err);
-    }
-
-    toggleDeleteModal();
-    setSelectedProject(null);
-  };
-
-  const handleDuplicateProjectNameChange = newProjectName => {
-    setDuplicateProjectName(newProjectName);
   };
 
   const descCompareBy = (a, b, orderBy) => {
@@ -527,96 +420,28 @@ const Projects = ({ account, history }) => {
         paginate={paginate}
       />
 
-      <Modal
-        isOpen={duplicateModalOpen}
-        onRequestClose={toggleDuplicateModal}
-        contentLabel="Duplicate Modal"
-        style={modalStyles}
-        className={classes.modal}
-      >
-        <button className={classes.closeBtn} onClick={toggleDuplicateModal}>
-          <img src={CloseIcon} alt="Close" />
-        </button>
-        <h2>
-          <img src={CopyIcon} alt="Copy" /> <strong>Duplicate Project</strong>
-        </h2>
-        <p>
-          Type a new name to duplicate the project,&nbsp;
-          <br />
-          <strong>{selectedProject && selectedProject.name}</strong>.
-        </p>
-        <input
-          placeholder="Name of Duplicated Project"
-          type="text"
-          id="duplicateName"
-          name="duplicateName"
-          value={duplicateProjectName}
-          onChange={e => handleDuplicateProjectNameChange(e.target.value)}
-        />
-        <div className={classes.modalActions}>
-          <Button
-            onClick={toggleDuplicateModal}
-            variant="text"
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={() => duplicateProject(selectedProject)}
-            variant="contained"
-            color="colorPrimary"
-          >
-            Create a Copy
-          </Button>
-        </div>
-      </Modal>
-      <Modal
-        isOpen={deleteModalOpen}
-        onRequestClose={toggleDeleteModal}
-        contentLabel="Delete Modal"
-        style={modalStyles}
-        className={classes.modal}
-        shouldFocusAfterRender={false}
-      >
-        <button className={classes.closeBtn} onClick={toggleDeleteModal}>
-          <img src={CloseIcon} alt="Close" />
-        </button>
-        <h2>
-          <img src={DeleteIcon} alt="Delete" /> <strong>Delete Project</strong>
-        </h2>
-        <p className={classes.deleteCopy}>
-          <img
-            src={WarningIcon}
-            className={classes.warningIcon}
-            alt="Warning"
-          />
-          Are you sure you want to <span>permanently</span> delete this project,
-          &nbsp;
-          <strong>{selectedProject && selectedProject.name}</strong>?
-        </p>
-        <div className={classes.modalActions}>
-          <Button 
-            onClick={toggleDeleteModal} 
-            variant="text"
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={() => deleteProject(selectedProject)}
-            variant="contained"
-            color="colorError"
-          >
-            Delete
-          </Button>
-        </div>
-      </Modal>
+      <DuplicateProjectModal
+        selectedProject={selectedProject}
+        setSelectedProject={setSelectedProject}
+        handleError={handleError}
+        toggleDuplicateModal={toggleDuplicateModal}
+        duplicateModalOpen={duplicateModalOpen}
+        duplicateProjectName={duplicateProjectName}
+        setDuplicateProjectName={setDuplicateProjectName}
+      />
+
+      <DeleteProjectModal
+        selectedProject={selectedProject}
+        setSelectedProject={setSelectedProject}
+        toggleDeleteModal={toggleDeleteModal}
+        handleError={handleError}
+        deleteModalOpen={deleteModalOpen}
+      />
     </div>
   );
 };
 
-// Required to bind modal to our appElement (http://reactcommunity.org/react-modal/accessibility/)
-Modal.setAppElement("#root");
-
-Projects.propTypes = {
+ProjectsPage.propTypes = {
   account: PropTypes.shape({
     firstName: PropTypes.string,
     lastName: PropTypes.string,
@@ -634,4 +459,4 @@ Projects.propTypes = {
   })
 };
 
-export default withRouter(Projects);
+export default withRouter(ProjectsPage);


### PR DESCRIPTION
refactoring opportunity as part of issue #609 

- Refactored Delete and Duplicate Modals into their own component (Reduced ProjectsPage component by 200 lines of code!)
- Created reusable `ProjectActionModal` that contains shared styling and behavior for the Delete and Duplicate Modals
- Renamed `Project`s component to `ProjectsPage`
- Moved all Projects page related components into its own folder (under `/Projects`)

