### PR TITLE
Fix nav and login bug related to setting account and local storage #660

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -38,12 +38,17 @@ const App = () => {
   const [hasConfirmedTransition, setHasConfirmedTransition] = useState(true);
   const [isOpenNavConfirmModal, setIsOpenNavConfirmModal] = useState(false);
 
+  const setLoggedInAccount = loggedInUser => {
+    setAccount(loggedInUser);
+    localStorage.setItem("currentUser", JSON.stringify(loggedInUser));
+  };
+
   useEffect(() => {
     const currentUser = localStorage.getItem("currentUser");
     if (currentUser) {
       try {
-        const account = JSON.parse(currentUser);
-        setAccount(account);
+        const parsedAccount = JSON.parse(currentUser);
+        setAccount(parsedAccount);
       } catch (err) {
         // TODO: replace with production error logging.
         console.error(
@@ -51,13 +56,10 @@ const App = () => {
           currentUser
         );
       }
+    } else {
+      setLoggedInAccount({});
     }
-  }, [setAccount]);
-
-  const setLoggedInAccount = loggedInUser => {
-    setAccount(loggedInUser);
-    localStorage.setItem("currentUser", JSON.stringify(loggedInUser));
-  };
+  }, []);
 
   const getUserConfirmation = (_message, defaultConfirmCallback) => {
     setHasConfirmedTransition(false);
@@ -77,7 +79,7 @@ const App = () => {
             isOpenNavConfirmModal={isOpenNavConfirmModal}
             setIsOpenNavConfirmModal={setIsOpenNavConfirmModal}
           />
-          <Header account={account} setAccount={setAccount} />
+          <Header account={account} />
           <div className={classes.root}>
             <Route
               exact

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -66,7 +66,7 @@ const useStyles = createUseStyles({
   }
 });
 
-const Header = ({ account, setAccount }) => {
+const Header = ({ account }) => {
   const classes = useStyles();
   const [navbarOpen, setNavbarOpen] = useState(false);
 
@@ -93,15 +93,13 @@ const Header = ({ account, setAccount }) => {
         navbarOpen={navbarOpen}
         setNavbarOpen={setNavbarOpen}
         account={account}
-        setAccount={setAccount}
       />
     </div>
   );
 };
 
 Header.propTypes = {
-  account: PropTypes.object.isRequired,
-  setAccount: PropTypes.func.isRequired
+  account: PropTypes.object.isRequired
 };
 
 export default Header;

--- a/client/src/components/NavBar.js
+++ b/client/src/components/NavBar.js
@@ -93,7 +93,7 @@ const useStyles = createUseStyles({
   }
 });
 
-const NavBar = ({ account, setAccount, navbarOpen, setNavbarOpen }) => {
+const NavBar = ({ account, navbarOpen, setNavbarOpen }) => {
   const classes = useStyles();
 
   const handleHamburgerMenuClick = () => {
@@ -158,7 +158,6 @@ const NavBar = ({ account, setAccount, navbarOpen, setNavbarOpen }) => {
       </li>
       <NavBarLogin
         account={account}
-        setAccount={setAccount}
         classes={classes}
         navbarOpen={navbarOpen}
         handleHamburgerMenuClick={handleHamburgerMenuClick}
@@ -175,7 +174,6 @@ NavBar.propTypes = {
     isAdmin: PropTypes.bool,
     isSecurityAdmin: PropTypes.bool
   }),
-  setAccount: PropTypes.func.isRequired,
   navbarOpen: PropTypes.bool,
   setNavbarOpen: PropTypes.func.isRequired
 };

--- a/client/src/components/NavBarLogin.js
+++ b/client/src/components/NavBarLogin.js
@@ -5,12 +5,7 @@ import PropTypes from "prop-types";
 import clsx from "clsx";
 import NavBarToolTip from "./NavBarToolTip";
 
-const NavBarLogin = ({
-  account,
-  setAccount,
-  classes,
-  handleHamburgerMenuClick
-}) => {
+const NavBarLogin = ({ account, classes, handleHamburgerMenuClick }) => {
   const [isCalculation, setIsCalculation] = useState(false);
 
   const location = useLocation();
@@ -24,12 +19,7 @@ const NavBarLogin = ({
     } else {
       setIsCalculation(false);
     }
-
-    const currentUser = localStorage.getItem("currentUser");
-    if (!currentUser) {
-      setAccount({});
-    }
-  }, [location.pathname, setAccount]);
+  }, [location.pathname]);
 
   const loginLink = (
     <li className={clsx(classes.userLogin, classes.linkBlock)}>
@@ -83,7 +73,6 @@ const NavBarLogin = ({
 };
 
 NavBarLogin.propTypes = {
-  setAccount: PropTypes.func.isRequired,
   account: PropTypes.object,
   classes: PropTypes.object.isRequired,
   handleHamburgerMenuClick: PropTypes.func


### PR DESCRIPTION
Closes #660 

- Made sure to set local storage to `{}` if there is no currentUser in localStorage
- Refactored and removed unnecessary setAccount in NavBarLogin component