### PR TITLE
Fix confirmation modal bug #662

### DIFF
--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -359,24 +359,22 @@ const TdmCalculationWizard = props => {
                       }}
                     />
                   </div>
-                  <div id="save-and-startover-buttons-container">
-                    <Button
-                      type="input"
-                      color="colorPrimary"
-                      variant="contained"
-                      isDisplayed={
-                        !!(
-                          account.id &&
-                          (!projectId || account.id === loginId) &&
-                          formIsDirty &&
-                          projectIsValid()
-                        )
-                      }
-                      onClick={onSave}
-                    >
-                      Save Project
-                    </Button>
-                  </div>
+                  <Button
+                    type="input"
+                    color="colorPrimary"
+                    variant="contained"
+                    isDisplayed={
+                      !!(
+                        account.id &&
+                        (!projectId || account.id === loginId) &&
+                        formIsDirty &&
+                        projectIsValid()
+                      )
+                    }
+                    onClick={onSave}
+                  >
+                    Save Project
+                  </Button>
                 </>
               ) : null}
             </div>

--- a/client/src/components/Projects/ProjectActionModal.js
+++ b/client/src/components/Projects/ProjectActionModal.js
@@ -112,7 +112,6 @@ ProjectActionModal.propTypes = {
   onRequestClose: PropTypes.func.isRequired,
   contentLabel: PropTypes.string.isRequired,
   toggleCloseButton: PropTypes.func.isRequired,
-  toggleCancelButton: PropTypes.func.isRequired,
   action: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   handleSubmit: PropTypes.func.isRequired,

--- a/client/src/components/Projects/ProjectsPage.js
+++ b/client/src/components/Projects/ProjectsPage.js
@@ -420,23 +420,29 @@ const ProjectsPage = ({ account, history }) => {
         paginate={paginate}
       />
 
-      <DuplicateProjectModal
-        selectedProject={selectedProject}
-        setSelectedProject={setSelectedProject}
-        handleError={handleError}
-        toggleDuplicateModal={toggleDuplicateModal}
-        duplicateModalOpen={duplicateModalOpen}
-        duplicateProjectName={duplicateProjectName}
-        setDuplicateProjectName={setDuplicateProjectName}
-      />
+      {
+        selectedProject && 
+        <>
+          <DuplicateProjectModal
+            selectedProject={selectedProject}
+            setSelectedProject={setSelectedProject}
+            handleError={handleError}
+            toggleDuplicateModal={toggleDuplicateModal}
+            duplicateModalOpen={duplicateModalOpen}
+            duplicateProjectName={duplicateProjectName}
+            setDuplicateProjectName={setDuplicateProjectName}
+          />
 
-      <DeleteProjectModal
-        selectedProject={selectedProject}
-        setSelectedProject={setSelectedProject}
-        toggleDeleteModal={toggleDeleteModal}
-        handleError={handleError}
-        deleteModalOpen={deleteModalOpen}
-      />
+          <DeleteProjectModal
+            selectedProject={selectedProject}
+            setSelectedProject={setSelectedProject}
+            toggleDeleteModal={toggleDeleteModal}
+            handleError={handleError}
+            deleteModalOpen={deleteModalOpen}
+          />
+        </>
+      }
+
     </div>
   );
 };

--- a/client/src/components/TdmCalculationContainer.js
+++ b/client/src/components/TdmCalculationContainer.js
@@ -130,6 +130,7 @@ export function TdmCalculationContainer({
     // update state with modified updatedFormInputs and rules
     setFormInputs(updatedFormInputs);
     setRules(rules);
+    setFormHasSaved(false);
   };
 
   const initializeStrategies = () => {
@@ -223,7 +224,6 @@ export function TdmCalculationContainer({
       ...modifiedInputs
     };
     recalculate(newFormInputs);
-    setFormHasSaved(false);
   };
 
   const projectLevel =
@@ -279,7 +279,6 @@ export function TdmCalculationContainer({
       [e.target.name]: value
     };
     recalculate(newFormInputs);
-    setFormHasSaved(false);
   };
 
   const onCommentChange = e => {
@@ -299,7 +298,6 @@ export function TdmCalculationContainer({
       [`${e.target.name}_comment`]: value
     };
     recalculate(newFormInputs);
-    setFormHasSaved(false);
   };
 
   const onUncheckAll = filterRules => {
@@ -312,7 +310,6 @@ export function TdmCalculationContainer({
       }
     }
     recalculate(updateInputs);
-    setFormHasSaved(false);
   };
 
   const projectIsValid = () => {
@@ -373,11 +370,11 @@ export function TdmCalculationContainer({
       try {
         const postResponse = await projectService.post(requestBody);
         const newPath = history.location.pathname + "/" + postResponse.data.id;
-        setFormHasSaved(true);
-        toast.add("Saved New Project");
         // Update URL to /calculation/<currentPage>/<newProjectId>
         // to keep working on same project.
         history.push(newPath);
+        setFormHasSaved(true);
+        toast.add("Saved New Project");
       } catch (err) {
         console.error(err);
         if (err.response) {


### PR DESCRIPTION
closes #662 

console warnings:
- Fixed some console warnings by adding a condition to check if there's a selectedProject
- Deleted unused "toggleCancelButton" prop because it's the same as the "toggleCloseButton" prop

NavConfirmationModal
- for some reason, when the `toast.add("Saved New Project")` is invoked _before_ the `history.push(newPath),` it causes the NavConfirmationModal to appear even tho the user has already saved the project. Not exactly sure why it's only happening on the project strategies page, but when I changed the order of the invocations, that seemed to have resolved the problem. 

```
        // changed order to:
        history.push(newPath);
        setFormHasSaved(true);
        toast.add("Saved New Project");
```

Also, did some minor refactoring