### PR TITLE
#407 Toasts now fixed to top of screen

### DIFF
--- a/client/src/contexts/Toast/Toast.js
+++ b/client/src/contexts/Toast/Toast.js
@@ -14,7 +14,7 @@ const useStyles = createUseStyles({
     display: "flex",
     justifyContent: "space-between",
     position: "fixed",
-    bottom: "4em",
+    top: "6em",
     cursor: "pointer"
   },
   container: {
@@ -38,7 +38,7 @@ const Toast = ({ children, remove }) => {
   removeRef.current = remove;
 
   useEffect(() => {
-    const duration = 5000;
+    const duration = 8000;
     const id = setTimeout(() => removeRef.current(), duration);
 
     return () => clearTimeout(id);

--- a/client/src/contexts/Toast/withToastProvider.js
+++ b/client/src/contexts/Toast/withToastProvider.js
@@ -6,9 +6,9 @@ import Toast from "./Toast";
 
 const useStyles = createUseStyles({
   root: {
-    position: "absolute",
-    bottom: "20px",
-    left: "50%"
+    alignItems: "center",
+    display: "flex",
+    justifyContent: "center"
   }
 });
 


### PR DESCRIPTION
Changed CSS so that toasts stays in top center of screen regardless of screen size and follows window, so user will notice even on the longer pages. Also changed the timer to 8 seconds.