### PR TITLE
#671 Refactored Sidebar and Calculator Tooltips

### DIFF
--- a/client/src/components/ProjectWizard/RuleCalculation/RuleCalculation.js
+++ b/client/src/components/ProjectWizard/RuleCalculation/RuleCalculation.js
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
-import ToolTip from "./ToolTip";
+import ToolTipIcon from "./ToolTipIcon";
 import clsx from "clsx";
+import ReactTooltip from "react-tooltip";
 
 const useStyles = createUseStyles({
   field: {
@@ -147,6 +148,25 @@ const useStyles = createUseStyles({
     flexBasis: "50%",
     flexGrow: "1",
     flexShrink: "1"
+  },
+  tooltip: {
+    color: "rgb(30, 36, 63) !important",
+    minWidth: "200px",
+    maxWidth: "400px",
+    fontFamily: "Arial",
+    fontSize: 12,
+    lineHeight: "16px",
+    fontWeight: "bold",
+    "-webkit-box-shadow": "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    "-moz-box-shadow": "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    boxShadow: "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    "-webkit-border-radius": 2,
+    "-moz-border-radius": 2,
+    borderRadius: 2,
+    "&.show": {
+      visibility: "visible !important",
+      opacity: "1 !important"
+    }
   }
 });
 
@@ -325,7 +345,13 @@ const RuleCalculation = ({
             data-class={classes.tooltip}
           >
             {name}
-            <ToolTip tipText={description} />
+            <ToolTipIcon
+              containerStyle={{
+                fontSize: 16,
+                verticalAlign: "top",
+                "&:hover": { cursor: "pointer" }
+              }}
+            />
           </label>
           <div className={classes.codeWrapper} name={code} id={code} />
           <div className={classes.unitsCaption}>{units}</div>
@@ -335,6 +361,21 @@ const RuleCalculation = ({
             </span>
             <span className={classes.calcUnits}> {calcUnits || ""}</span>
           </div>
+          <ReactTooltip
+            id={"main" + id}
+            place="right"
+            type="info"
+            effect="float"
+            multiline={true}
+            style={{
+              width: "25vw"
+            }}
+            textColor="#32578A"
+            backgroundColor="#F7F9FA"
+            borderColor="rgb(30, 36, 63)"
+            border={true}
+            offset={{ right: 20 }}
+          />
         </div>
       )}
       {validationErrors && showValidationErrors ? (

--- a/client/src/components/ProjectWizard/RuleInput/RuleInput.js
+++ b/client/src/components/ProjectWizard/RuleInput/RuleInput.js
@@ -157,6 +157,7 @@ const useStyles = createUseStyles({
     flexShrink: "1"
   },
   tooltip: {
+    color: "rgb(30, 36, 63) !important",
     padding: "15px",
     minWidth: "200px",
     maxWidth: "400px",
@@ -513,8 +514,8 @@ const RuleInput = ({
         }}
         textColor="#32578A"
         backgroundColor="#F7F9FA"
+        borderColor="rgb(30, 36, 63)"
         border={true}
-        borderColor="#B2C0D3"
         offset={{ right: 20 }}
       />
     </React.Fragment>

--- a/client/src/components/ProjectWizard/RuleStrategy/RuleStrategy.js
+++ b/client/src/components/ProjectWizard/RuleStrategy/RuleStrategy.js
@@ -435,8 +435,8 @@ const RuleStrategy = ({
         }}
         textColor="#32578A"
         backgroundColor="#F7F9FA"
+        borderColor="rgb(30, 36, 63)"
         border={true}
-        borderColor="#B2C0D3"
         offset={{ right: 20 }}
       />
     </React.Fragment>

--- a/client/src/components/ProjectWizard/SidebarPoints/SidebarPoints.js
+++ b/client/src/components/ProjectWizard/SidebarPoints/SidebarPoints.js
@@ -1,8 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
-import ToolTip from "./ToolTip";
+import ToolTipIcon from "./ToolTipIcon";
 import clsx from "clsx";
+import ReactTooltip from "react-tooltip";
 
 const useStyles = createUseStyles({
   ruleValue: {
@@ -23,6 +24,25 @@ const useStyles = createUseStyles({
   },
   noDisplay: {
     display: "none !important"
+  },
+  tooltip: {
+    color: "rgb(30, 36, 63) !important",
+    minWidth: "200px",
+    maxWidth: "400px",
+    fontFamily: "Arial",
+    fontSize: 12,
+    lineHeight: "16px",
+    fontWeight: "bold",
+    "-webkit-box-shadow": "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    "-moz-box-shadow": "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    boxShadow: "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    "-webkit-border-radius": 2,
+    "-moz-border-radius": 2,
+    borderRadius: 2,
+    "&.show": {
+      visibility: "visible !important",
+      opacity: "1 !important"
+    }
   }
 });
 
@@ -38,11 +58,37 @@ const SidebarPoints = props => {
       <div className={classes.ruleValue}>{rule.value}</div>
       <h3 className={classes.ruleName}>
         {rule.name}
-        <span className={clsx(classes.projectLevelContainer, noToolTip)}>
-          <ToolTip tipText={rule.description} />
+        <span
+          className={clsx(classes.projectLevelContainer, noToolTip)}
+          data-tip={rule.description}
+          data-iscapture="true"
+          data-html="true"
+          data-class={classes.tooltip}
+        >
+          <ToolTipIcon
+            containerStyle={{
+              fontSize: 16,
+              verticalAlign: "top",
+              "&:hover": { cursor: "pointer" }
+            }}
+          />
         </span>
       </h3>
       {/* <div> {rule.units}</div> */}
+      <ReactTooltip
+        place="right"
+        type="info"
+        effect="float"
+        multiline={true}
+        style={{
+          width: "25vw"
+        }}
+        textColor="#32578A"
+        backgroundColor="#F7F9FA"
+        borderColor="rgb(30, 36, 63)"
+        border={true}
+        offset={{ right: 20 }}
+      />
     </div>
   );
 };

--- a/client/src/components/ProjectWizard/SidebarPoints/SidebarProjectLevel.js
+++ b/client/src/components/ProjectWizard/SidebarPoints/SidebarProjectLevel.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
-import Tooltip from "./ToolTip";
+import ToolTipIcon from "./ToolTipIcon";
 import clsx from "clsx";
 
 const useStyles = createUseStyles({
@@ -30,6 +30,25 @@ const useStyles = createUseStyles({
   },
   noDisplay: {
     display: "none !important"
+  },
+  tooltip: {
+    color: "rgb(30, 36, 63) !important",
+    minWidth: "200px",
+    maxWidth: "400px",
+    fontFamily: "Arial",
+    fontSize: 12,
+    lineHeight: "16px",
+    fontWeight: "bold",
+    "-webkit-box-shadow": "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    "-moz-box-shadow": "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    boxShadow: "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    "-webkit-border-radius": 2,
+    "-moz-border-radius": 2,
+    borderRadius: 2,
+    "&.show": {
+      visibility: "visible !important",
+      opacity: "1 !important"
+    }
   }
 });
 
@@ -44,8 +63,20 @@ const SidebarProjectLevel = ({ level, rules }) => {
       <p className={classes.projectLevelValue}>{level}</p>
       <h3 className={classes.projectLevelHeader}>
         PROJECT LEVEL
-        <span className={clsx(classes.projectLevelContainer, noToolTip)}>
-          <Tooltip tipText={tipText} />
+        <span
+          className={clsx(classes.projectLevelContainer, noToolTip)}
+          data-tip={tipText}
+          data-iscapture="true"
+          data-html="true"
+          data-class={classes.tooltip}
+        >
+          <ToolTipIcon
+            containerStyle={{
+              fontSize: 16,
+              verticalAlign: "top",
+              "&:hover": { cursor: "pointer" }
+            }}
+          />
         </span>
       </h3>
     </div>


### PR DESCRIPTION
Changed both tooltips to the react-tooltips library and standardized the CSS. However, have not removed the old Sidebar/tooltip file. 

#671 