### PR TITLE
Changed font-size for earned and target points

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/client/src/components/ProjectWizard/SidebarPoints/SidebarPoints.js
+++ b/client/src/components/ProjectWizard/SidebarPoints/SidebarPoints.js
@@ -7,7 +7,7 @@ import ReactTooltip from "react-tooltip";
 
 const useStyles = createUseStyles({
   ruleValue: {
-    fontSize: "40px",
+    fontSize: "100px",
     fontFamily: "Oswald, Calibri",
     fontWeight: "bold",
     marginBottom: 6

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tdm-calculator",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Increased Size of Earned Points and Target Points on Sidebar to be equal to Project Level #712 

![Screen Shot 2021-01-24 at 8 50 49 AM](https://user-images.githubusercontent.com/40730303/105637257-68327100-5e21-11eb-84b8-a7a01c8db4f5.png)
