### PR TITLE
671 refactor tooltips pt3

### DIFF
--- a/client/src/components/ProjectWizard/RuleCalculation/RuleCalculation.js
+++ b/client/src/components/ProjectWizard/RuleCalculation/RuleCalculation.js
@@ -4,6 +4,7 @@ import { createUseStyles } from "react-jss";
 import ToolTipIcon from "../../ToolTip/ToolTipIcon";
 import ToolTip from "../../ToolTip/ToolTip";
 import clsx from "clsx";
+import ToolTipLabel from "../../ToolTip/ToolTipLabel";
 
 const useStyles = createUseStyles({
   field: {
@@ -172,6 +173,7 @@ const useStyles = createUseStyles({
   }
 });
 
+// Page 3
 const RuleCalculation = ({
   rule: {
     id,
@@ -337,20 +339,17 @@ const RuleCalculation = ({
         </div>
       ) : (
         <div className={clsx(classes.field, classes.miscFieldWrapper)}>
-          <label
+          <ToolTipLabel
+            id={"tooltip-parking-baseline" + id}
+            tooltipContent={description}
             htmlFor={code}
-            className={classes.miscFieldLabel}
-            data-for={"tooltip-parking-baseline" + id}
-            data-tip={description}
-            data-iscapture="true"
-            data-html="true"
-            data-class={classes.tooltip}
           >
             {name}
             <div className={classes.baselineIconContainer}>
               {description ? <ToolTipIcon /> : <span />}
             </div>
-          </label>
+          </ToolTipLabel>
+          <ToolTip id={"tooltip-parking-baseline" + id} />
           <div className={classes.codeWrapper} name={code} id={code} />
           <div className={classes.unitsCaption}>{units}</div>
           <div className={classes.calcUnitsCaption}>
@@ -359,7 +358,6 @@ const RuleCalculation = ({
             </span>
             <span className={classes.calcUnits}> {calcUnits || ""}</span>
           </div>
-          <ToolTip id={"tooltip-parking-baseline" + id} />
         </div>
       )}
       {validationErrors && showValidationErrors ? (

--- a/client/src/components/ProjectWizard/RuleCalculation/RuleCalculation.js
+++ b/client/src/components/ProjectWizard/RuleCalculation/RuleCalculation.js
@@ -4,7 +4,6 @@ import { createUseStyles } from "react-jss";
 import ToolTipIcon from "../../ToolTip/ToolTipIcon";
 import ToolTip from "../../ToolTip/ToolTip";
 import clsx from "clsx";
-import ToolTipLabel from "../../ToolTip/ToolTipLabel";
 
 const useStyles = createUseStyles({
   field: {
@@ -150,22 +149,6 @@ const useStyles = createUseStyles({
     flexGrow: "1",
     flexShrink: "1"
   },
-  tooltip: {
-    color: "rgb(30, 36, 63) !important",
-    padding: "15px",
-    minWidth: "200px",
-    maxWidth: "400px",
-    fontFamily: "Arial",
-    fontSize: 12,
-    lineHeight: "16px",
-    fontWeight: "bold",
-    boxShadow: "0px 0px 8px rgba(0, 46, 109, 0.2)",
-    borderRadius: 2,
-    "&.show": {
-      visibility: "visible !important",
-      opacity: "1 !important"
-    }
-  },
   baselineIconContainer: {
     width: 16,
     height: 16,
@@ -236,11 +219,6 @@ const RuleCalculation = ({
             </div>
           </label>
           <div className={classes.numberFieldUnits}>{units}</div>
-          {/*} <div className={classes.calcUnitsCaption}>
-            {`${
-              calcValue ? Math.round(calcValue * 100) / 100 : ""
-            } ${calcUnits || ""}`}
-          </div>*/}
         </div>
       ) : dataType === "boolean" ? (
         <div className={clsx(classes.field, classes.checkboxFieldWrapper)}>
@@ -339,16 +317,19 @@ const RuleCalculation = ({
         </div>
       ) : (
         <div className={clsx(classes.field, classes.miscFieldWrapper)}>
-          <ToolTipLabel
-            id={"tooltip-parking-baseline" + id}
-            tooltipContent={description}
-            htmlFor={code}
-          >
+          <label htmlFor={code}>
             {name}
             <div className={classes.baselineIconContainer}>
-              {description ? <ToolTipIcon /> : <span />}
+              {description ? (
+                <ToolTipIcon
+                  id={"tooltip-parking-baseline" + id}
+                  tooltipContent={description}
+                />
+              ) : (
+                <span />
+              )}
             </div>
-          </ToolTipLabel>
+          </label>
           <ToolTip id={"tooltip-parking-baseline" + id} />
           <div className={classes.codeWrapper} name={code} id={code} />
           <div className={classes.unitsCaption}>{units}</div>

--- a/client/src/components/ProjectWizard/RuleInput/RuleInput.js
+++ b/client/src/components/ProjectWizard/RuleInput/RuleInput.js
@@ -1,24 +1,25 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { createUseStyles } from "react-jss";
+import { createUseStyles, useTheme } from "react-jss";
 import clsx from "clsx";
 import InputMask from "react-input-mask";
 import ToolTip from "../../ToolTip/ToolTip";
 import RuleInputLabel from "./RuleInputLabel";
 
 const useStyles = createUseStyles({
-  field: {
+  rowContainer: {
     minWidth: "60vw",
     margin: "0.2em",
     display: "flex",
     flexDirection: "row",
-    justifyContent: "space-between"
+    justifyContent: "space-between",
+    alignItems: "center"
   },
   numberFieldWrapper: {
     marginBottom: "0.4em",
     alignItems: "center",
     "&:hover": {
-      backgroundColor: "#f0e300"
+      backgroundColor: ({ theme }) => theme.colorHighlight
     }
   },
   numberFieldUnits: {
@@ -55,7 +56,7 @@ const useStyles = createUseStyles({
   checkboxFieldWrapper: {
     alignItems: "baseline",
     "&:hover": {
-      backgroundColor: "#f0e300"
+      backgroundColor: ({ theme }) => theme.colorHighlight
     }
   },
   checkbox: {
@@ -66,7 +67,7 @@ const useStyles = createUseStyles({
   selectFieldWrapper: {
     alignItems: "baseline",
     "&:hover": {
-      backgroundColor: "#f0e300"
+      backgroundColor: ({ theme }) => theme.colorHighlight
     }
   },
   select: {
@@ -80,7 +81,7 @@ const useStyles = createUseStyles({
   miscFieldWrapper: {
     alignItems: "baseline",
     "&:hover": {
-      backgroundColor: "#f0e300"
+      backgroundColor: ({ theme }) => theme.colorHighlight
     }
   },
   codeWrapper: {
@@ -149,7 +150,8 @@ const RuleInput = ({
   },
   onPropInputChange
 }) => {
-  const classes = useStyles();
+  const theme = useTheme();
+  const classes = useStyles({ theme });
 
   // The validationErrors property of the rule indicates whether the
   // violates any of the database-driven validation rules. For now, this
@@ -171,7 +173,7 @@ const RuleInput = ({
   return (
     <React.Fragment>
       {dataType === "number" ? (
-        <div className={clsx(classes.field, classes.numberFieldWrapper)}>
+        <div className={clsx(classes.rowContainer, classes.numberFieldWrapper)}>
           <RuleInputLabel
             id={id}
             description={description}
@@ -208,7 +210,9 @@ const RuleInput = ({
           </div>
         </div>
       ) : dataType === "boolean" ? (
-        <div className={clsx(classes.field, classes.checkboxFieldWrapper)}>
+        <div
+          className={clsx(classes.rowContainer, classes.checkboxFieldWrapper)}
+        >
           <RuleInputLabel
             id={id}
             description={description}
@@ -231,7 +235,7 @@ const RuleInput = ({
           <div className={classes.numberFieldUnits}>{units}</div>
         </div>
       ) : dataType === "choice" ? (
-        <div className={clsx(classes.field, classes.selectFieldWrapper)}>
+        <div className={clsx(classes.rowContainer, classes.selectFieldWrapper)}>
           <RuleInputLabel
             id={id}
             description={description}
@@ -260,7 +264,7 @@ const RuleInput = ({
         dataType === "textarea" ||
         dataType === "mask" ? (
         <div
-          className={clsx(classes.field, classes.textFieldWrapper)}
+          className={clsx(classes.rowContainer, classes.textFieldWrapper)}
           onBlur={onBlur}
         >
           <RuleInputLabel
@@ -319,7 +323,7 @@ const RuleInput = ({
           )}
         </div>
       ) : (
-        <div className={clsx(classes.field, classes.miscFieldWrapper)}>
+        <div className={clsx(classes.rowContainer, classes.miscFieldWrapper)}>
           <RuleInputLabel
             id={id}
             description={description}
@@ -334,7 +338,7 @@ const RuleInput = ({
         </div>
       )}
       {validationErrors && showValidationErrors ? (
-        <div className={classes.field}>
+        <div className={classes.rowContainer}>
           <div className={classes.textInputLabel}></div>
           <div className={clsx(classes.textInputLabel, classes.errorLabel)}>
             {validationErrors[0]}

--- a/client/src/components/ProjectWizard/RuleInput/RuleInput.js
+++ b/client/src/components/ProjectWizard/RuleInput/RuleInput.js
@@ -58,11 +58,6 @@ const useStyles = createUseStyles({
       backgroundColor: "#f0e300"
     }
   },
-  checkboxFieldLabel: {
-    flexBasis: "70%",
-    flexGrow: "1",
-    flexShrink: "1"
-  },
   checkbox: {
     flexGrow: "0",
     flexShrink: "1",
@@ -74,12 +69,6 @@ const useStyles = createUseStyles({
       backgroundColor: "#f0e300"
     }
   },
-  selectFieldLabel: {
-    flexBasis: "45%",
-    flexGrow: "1",
-    flexShrink: "1"
-  },
-
   select: {
     flexBasis: "45%",
     flexGrow: "1",
@@ -93,11 +82,6 @@ const useStyles = createUseStyles({
     "&:hover": {
       backgroundColor: "#f0e300"
     }
-  },
-  miscFieldLabel: {
-    flexBasis: "70%",
-    flexGrow: "1",
-    flexShrink: "1"
   },
   codeWrapper: {
     flexBasis: "10%",
@@ -135,18 +119,6 @@ const useStyles = createUseStyles({
     flexShrink: "1",
     minHeight: "5em",
     border: "1px dashed red"
-  },
-  textareaLabel: {
-    flexBasis: "50%",
-    flexGrow: "1",
-    flexShrink: "1",
-    minHeight: "5em"
-  },
-  requiredInputLabel: {
-    "&:after": {
-      content: '" *"',
-      color: "red"
-    }
   },
   errorLabel: {
     color: "red",
@@ -234,11 +206,6 @@ const RuleInput = ({
           >
             {units}
           </div>
-          {/* <div className={classes.calcUnitsCaption}>
-            {`${
-              calcValue ? Math.round(calcValue * 100) / 100 : ""
-            } ${calcUnits || ""}`}
-          </div> */}
         </div>
       ) : dataType === "boolean" ? (
         <div className={clsx(classes.field, classes.checkboxFieldWrapper)}>
@@ -262,16 +229,6 @@ const RuleInput = ({
             data-testid={code}
           />
           <div className={classes.numberFieldUnits}>{units}</div>
-          {/* {calcValue ? (
-            <>
-              <div className={classes.unitsCaption}>{units}</div>
-              <div className={classes.calcUnitsCaption}>
-                {`${calcValue ? Math.round(calcValue * 100) / 100 : ""} ${
-                  calcUnits || ""
-                }`}
-              </div>
-            </>
-          ) : null} */}
         </div>
       ) : dataType === "choice" ? (
         <div className={clsx(classes.field, classes.selectFieldWrapper)}>
@@ -298,11 +255,6 @@ const RuleInput = ({
               </option>
             ))}
           </select>
-          {/* <div className={classes.calcUnitsCaption}>
-            {`${
-              calcValue ? Math.round(calcValue * 100) / 100 : ""
-            } ${calcUnits || ""}`}
-          </div> */}
         </div>
       ) : dataType === "string" ||
         dataType === "textarea" ||
@@ -379,11 +331,6 @@ const RuleInput = ({
           />
           <div className={classes.codeWrapper} name={code} id={code} />
           <div className={classes.unitsCaption}>{units}</div>
-          {/* <div className={classes.calcUnitsCaption}>
-            {`${
-              calcValue ? Math.round(calcValue * 100) / 100 : ""
-            } ${calcUnits || ""}`}
-          </div> */}
         </div>
       )}
       {validationErrors && showValidationErrors ? (

--- a/client/src/components/ProjectWizard/RuleInput/RuleInput.js
+++ b/client/src/components/ProjectWizard/RuleInput/RuleInput.js
@@ -4,6 +4,7 @@ import { createUseStyles } from "react-jss";
 import clsx from "clsx";
 import InputMask from "react-input-mask";
 import ToolTip from "../../ToolTip/ToolTip";
+import RuleInputLabel from "./RuleInputLabel";
 
 const useStyles = createUseStyles({
   field: {
@@ -122,9 +123,6 @@ const useStyles = createUseStyles({
   textDisabledInputLabel: {
     opacity: "0.5"
   },
-  textInputLabelAnchor: {
-    textDecoration: "underline"
-  },
   textarea: {
     flexBasis: "50%",
     flexGrow: "1",
@@ -155,22 +153,6 @@ const useStyles = createUseStyles({
     flexBasis: "50%",
     flexGrow: "1",
     flexShrink: "1"
-  },
-  tooltip: {
-    color: "rgb(30, 36, 63) !important",
-    padding: "15px",
-    minWidth: "200px",
-    maxWidth: "400px",
-    fontFamily: "Arial",
-    fontSize: 12,
-    lineHeight: "16px",
-    fontWeight: "bold",
-    boxShadow: "0px 0px 8px rgba(0, 46, 109, 0.2)",
-    borderRadius: 2,
-    "&.show": {
-      visibility: "visible !important",
-      opacity: "1 !important"
-    }
   }
 });
 
@@ -218,34 +200,15 @@ const RuleInput = ({
     <React.Fragment>
       {dataType === "number" ? (
         <div className={clsx(classes.field, classes.numberFieldWrapper)}>
-          <label
-            htmlFor={code}
-            className={
-              !display
-                ? clsx(classes.textInputLabel, classes.textDisabledInputLabel)
-                : required
-                ? clsx(classes.textInputLabel, classes.requiredInputLabel)
-                : classes.textInputLabel
-            }
-            data-for={"tooltip-project-spec" + id}
-            data-tip={description}
-            data-iscapture="true"
-            data-html="true"
-            data-class={classes.tooltip}
-          >
-            {link ? (
-              <a
-                href={link}
-                className={classes.textInputLabelAnchor}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {name}
-              </a>
-            ) : (
-              name
-            )}
-          </label>
+          <RuleInputLabel
+            id={id}
+            description={description}
+            code={code}
+            display={display}
+            required={required}
+            link={link}
+            name={name}
+          />
           <div>
             <input
               className={
@@ -279,32 +242,15 @@ const RuleInput = ({
         </div>
       ) : dataType === "boolean" ? (
         <div className={clsx(classes.field, classes.checkboxFieldWrapper)}>
-          <label
-            htmlFor={code}
-            className={
-              required
-                ? clsx(classes.textInputLabel, classes.requiredInputLabel)
-                : classes.textInputLabel
-            }
-            data-for={"tooltip-project-spec" + id}
-            data-tip={description}
-            data-iscapture="true"
-            data-html="true"
-            data-class={classes.tooltip}
-          >
-            {link ? (
-              <a
-                href={link}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={classes.textInputLabelAnchor}
-              >
-                {name}
-              </a>
-            ) : (
-              name
-            )}
-          </label>
+          <RuleInputLabel
+            id={id}
+            description={description}
+            code={code}
+            display={display}
+            required={required}
+            link={link}
+            name={name}
+          />
           <input
             type="checkbox"
             className={classes.checkbox}
@@ -329,32 +275,15 @@ const RuleInput = ({
         </div>
       ) : dataType === "choice" ? (
         <div className={clsx(classes.field, classes.selectFieldWrapper)}>
-          <label
-            htmlFor={code}
-            className={
-              required
-                ? clsx(classes.textInputLabel, classes.requiredInputLabel)
-                : classes.textInputLabel
-            }
-            data-for={"tooltip-project-spec" + id}
-            data-tip={description}
-            data-iscapture="true"
-            data-html="true"
-            data-class={classes.tooltip}
-          >
-            {link ? (
-              <a
-                href={link}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={classes.textInputLabelAnchor}
-              >
-                {name}
-              </a>
-            ) : (
-              name
-            )}
-          </label>
+          <RuleInputLabel
+            id={id}
+            description={description}
+            code={code}
+            display={display}
+            required={required}
+            link={link}
+            name={name}
+          />
           <select
             className={classes.select}
             value={value || ""}
@@ -382,32 +311,15 @@ const RuleInput = ({
           className={clsx(classes.field, classes.textFieldWrapper)}
           onBlur={onBlur}
         >
-          <label
-            htmlFor={code}
-            className={
-              required
-                ? clsx(classes.textInputLabel, classes.requiredInputLabel)
-                : classes.textInputLabel
-            }
-            data-for={"tooltip-project-spec" + id}
-            data-tip={description}
-            data-iscapture="true"
-            data-html="true"
-            data-class={classes.tooltip}
-          >
-            {link ? (
-              <a
-                href={link}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={classes.textInputLabelAnchor}
-              >
-                {name}
-              </a>
-            ) : (
-              name
-            )}
-          </label>
+          <RuleInputLabel
+            id={id}
+            description={description}
+            code={code}
+            display={display}
+            required={required}
+            link={link}
+            name={name}
+          />
           {dataType === "string" ? (
             <input
               type="text"
@@ -456,32 +368,15 @@ const RuleInput = ({
         </div>
       ) : (
         <div className={clsx(classes.field, classes.miscFieldWrapper)}>
-          <label
-            htmlFor={code}
-            className={
-              required
-                ? clsx(classes.textInputLabel, classes.requiredInputLabel)
-                : classes.textInputLabel
-            }
-            data-for={"tooltip-project-spec" + id}
-            data-tip={description}
-            data-iscapture="true"
-            data-html="true"
-            data-class={classes.tooltip}
-          >
-            {link ? (
-              <a
-                href={link}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={classes.textInputLabelAnchor}
-              >
-                {name}
-              </a>
-            ) : (
-              name
-            )}
-          </label>
+          <RuleInputLabel
+            id={id}
+            description={description}
+            code={code}
+            display={display}
+            required={required}
+            link={link}
+            name={name}
+          />
           <div className={classes.codeWrapper} name={code} id={code} />
           <div className={classes.unitsCaption}>{units}</div>
           {/* <div className={classes.calcUnitsCaption}>

--- a/client/src/components/ProjectWizard/RuleInput/RuleInputLabel.js
+++ b/client/src/components/ProjectWizard/RuleInput/RuleInputLabel.js
@@ -1,0 +1,56 @@
+import React from "react";
+import ToolTipLabel from "../../ToolTip/ToolTipLabel";
+import PropTypes from "prop-types";
+import { createUseStyles } from "react-jss";
+
+const useStyles = createUseStyles({
+  textInputLabelAnchor: {
+    textDecoration: "underline"
+  }
+});
+
+const RuleInputLabel = ({
+  id,
+  description,
+  code,
+  display,
+  required,
+  link,
+  name
+}) => {
+  const classes = useStyles();
+
+  return (
+    <ToolTipLabel
+      id={"tooltip-project-spec" + id}
+      tooltipContent={description}
+      htmlFor={code}
+      disabledInput={!display}
+      requiredInput={required}
+    >
+      {link ? (
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={classes.textInputLabelAnchor}
+        >
+          {name}
+        </a>
+      ) : (
+        name
+      )}
+    </ToolTipLabel>
+  );
+};
+
+RuleInputLabel.propTypes = {
+  id: PropTypes.number.isRequired,
+  code: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  display: PropTypes.bool,
+  required: PropTypes.bool,
+  link: PropTypes.string
+};
+export default RuleInputLabel;

--- a/client/src/components/ProjectWizard/RuleStrategy/RuleStrategy.js
+++ b/client/src/components/ProjectWizard/RuleStrategy/RuleStrategy.js
@@ -1,12 +1,13 @@
 /* eslint-disable linebreak-style */
 import React from "react";
 import PropTypes from "prop-types";
-import { createUseStyles } from "react-jss";
+import { createUseStyles, useTheme } from "react-jss";
 import clsx from "clsx";
 import ToolTip from "../../ToolTip/ToolTip";
+import RuleStrategyLabel from "./RuleStrategyLabel";
 
 const useStyles = createUseStyles({
-  strategyContainer: {
+  rowContainer: {
     minWidth: "60vw",
     margin: "0.2em",
     display: "flex",
@@ -14,11 +15,8 @@ const useStyles = createUseStyles({
     justifyContent: "space-between",
     alignItems: "center",
     "&:hover": {
-      backgroundColor: "#f0e300"
+      backgroundColor: ({ theme }) => theme.colorHighlight
     }
-  },
-  textInputLabelAnchor: {
-    textDecoration: "underline"
   },
   commentContainer: {
     minWidth: "60vw",
@@ -33,23 +31,15 @@ const useStyles = createUseStyles({
     opacity: 0.5
   },
   points: {
-    flexBasis: "10%",
-    marginLeft: "1em",
+    marginLeft: "0.5em",
     marginRight: "0.5em",
     textAlign: "right",
-    flexGrow: "0",
-    flexShrink: "1"
-  },
-  numberInputContainer: {
-    flexBasis: "40%",
-    flexGrow: "1",
-    flexShrink: "1",
-    textAlign: "right"
+    minWidth: "65px"
   },
   numberInput: {
     padding: "0.1em",
-    width: "auto",
-    textAlign: "right"
+    textAlign: "right",
+    width: "195px"
   },
   numberInputInvalid: {
     padding: "0.1em",
@@ -58,10 +48,10 @@ const useStyles = createUseStyles({
     border: "1px dashed red"
   },
   choiceSelectContainer: {
-    flexBasis: "40%",
-    flexGrow: "1",
-    flexShrink: "1",
     textAlign: "right"
+  },
+  select: {
+    width: "200px"
   },
   stringInput: {
     flexBasis: "50%",
@@ -105,11 +95,6 @@ const useStyles = createUseStyles({
     flexDirection: "row",
     justifyContent: "space-between"
   },
-  textInputLabel: {
-    flexBasis: "50%",
-    flexGrow: "1",
-    flexShrink: "1"
-  },
   errorLabel: {
     color: "red",
     flexBasis: "50%",
@@ -140,7 +125,10 @@ const RuleStrategy = ({
   onPropInputChange,
   onCommentChange
 }) => {
-  const classes = useStyles();
+  const theme = useTheme();
+  const classes = useStyles({ theme });
+
+  const disabledStyle = !display && classes.disabled;
 
   const onInputChange = e => {
     onPropInputChange(e);
@@ -171,37 +159,16 @@ const RuleStrategy = ({
   return (
     <React.Fragment>
       {dataType === "number" ? (
-        <div
-          className={
-            display
-              ? classes.strategyContainer
-              : clsx(classes.strategyContainer, classes.disabled)
-          }
-        >
-          <label
-            htmlFor={code}
-            className={classes.strategyName}
-            data-for={"tooltip-strategy" + id}
-            data-tip={description}
-            data-iscapture="true"
-            data-html="true"
-            data-class={classes.tooltip}
-          >
-            {" "}
-            {link ? (
-              <a
-                href={link}
-                className={classes.textInputLabelAnchor}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {name}
-              </a>
-            ) : (
-              name
-            )}{" "}
-          </label>
-          <div className={classes.numberInputContainer}>
+        <div className={clsx(classes.rowContainer, disabledStyle)}>
+          <RuleStrategyLabel
+            id={id}
+            description={description}
+            code={code}
+            display={display}
+            link={link}
+            name={name}
+          />
+          <div>
             <input
               className={
                 validationErrors
@@ -220,36 +187,15 @@ const RuleStrategy = ({
           {possibleAndEarnedPointsContainers()}
         </div>
       ) : dataType === "boolean" ? (
-        <div
-          className={
-            display
-              ? classes.strategyContainer
-              : clsx(classes.strategyContainer, classes.disabled)
-          }
-        >
-          <label
-            htmlFor={code}
-            className={classes.strategyName}
-            data-for={"tooltip-strategy" + id}
-            data-tip={description}
-            data-iscapture="true"
-            data-html="true"
-            data-class={classes.tooltip}
-          >
-            {" "}
-            {link ? (
-              <a
-                href={link}
-                className={classes.textInputLabelAnchor}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {name}
-              </a>
-            ) : (
-              name
-            )}{" "}
-          </label>
+        <div className={clsx(classes.rowContainer, disabledStyle)}>
+          <RuleStrategyLabel
+            id={id}
+            description={description}
+            code={code}
+            display={display}
+            link={link}
+            name={name}
+          />
           <div className={classes.booleanInputContainer}>
             <input
               type="checkbox"
@@ -264,39 +210,18 @@ const RuleStrategy = ({
           {possibleAndEarnedPointsContainers()}
         </div>
       ) : dataType === "choice" ? (
-        <div
-          className={
-            display
-              ? classes.strategyContainer
-              : clsx(classes.strategyContainer, classes.disabled)
-          }
-        >
-          <label
-            htmlFor={code}
-            className={classes.strategyName}
-            data-for={"tooltip-strategy" + id}
-            data-tip={description}
-            data-iscapture="true"
-            data-html="true"
-            data-class={classes.tooltip}
-          >
-            {" "}
-            {link ? (
-              <a
-                href={link}
-                className={classes.textInputLabelAnchor}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {name}
-              </a>
-            ) : (
-              name
-            )}{" "}
-          </label>
+        <div className={clsx(classes.rowContainer, disabledStyle)}>
+          <RuleStrategyLabel
+            id={id}
+            description={description}
+            code={code}
+            display={display}
+            link={link}
+            name={name}
+          />
           <div className={classes.choiceSelectContainer}>
             <select
-              width="100%"
+              className={classes.select}
               value={value || ""}
               onChange={onInputChange}
               name={code}
@@ -313,36 +238,15 @@ const RuleStrategy = ({
           {possibleAndEarnedPointsContainers()}
         </div>
       ) : dataType === "string" ? (
-        <div
-          className={
-            display
-              ? classes.strategyContainer
-              : clsx(classes.strategyContainer, classes.disabled)
-          }
-        >
-          <label
-            htmlFor={code}
-            className={classes.strategyName}
-            data-for={"tooltip-strategy" + id}
-            data-tip={description}
-            data-iscapture="true"
-            data-html="true"
-            data-class={classes.tooltip}
-          >
-            {" "}
-            {link ? (
-              <a
-                href={link}
-                className={classes.textInputLabelAnchor}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {name}
-              </a>
-            ) : (
-              name
-            )}{" "}
-          </label>
+        <div className={clsx(classes.rowContainer, disabledStyle)}>
+          <RuleStrategyLabel
+            id={id}
+            description={description}
+            code={code}
+            display={display}
+            link={link}
+            name={name}
+          />
           <input
             type="text"
             className={
@@ -359,45 +263,21 @@ const RuleStrategy = ({
           />
         </div>
       ) : (
-        <div
-          className={
-            display
-              ? classes.strategyContainer
-              : clsx(classes.strategyContainer, classes.disabled)
-          }
-          data-for={"tooltip-strategy" + id}
-          data-tip={description}
-          data-iscapture="true"
-          data-html="true"
-          data-class={classes.tooltip}
-        >
-          <label htmlFor={code} className={classes.strategyName}>
-            {" "}
-            {link ? (
-              <a
-                href={link}
-                className={classes.textInputLabelAnchor}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {name}
-              </a>
-            ) : (
-              name
-            )}{" "}
-          </label>
+        <div className={clsx(classes.rowContainer, disabledStyle)}>
+          <RuleStrategyLabel
+            id={id}
+            description={description}
+            code={code}
+            display={display}
+            link={link}
+            name={name}
+          />
           <div className={classes.allElse} name={code} />
           {possibleAndEarnedPointsContainers()}
         </div>
       )}
       {displayComment ? (
-        <div
-          className={
-            display
-              ? classes.commentContainer
-              : clsx(classes.commentContainer, classes.disabled)
-          }
-        >
+        <div className={clsx(classes.commentContainer, disabledStyle)}>
           <div>{`If applicable, please input the details about ${name}.`}</div>
           <div>
             <textarea

--- a/client/src/components/ProjectWizard/RuleStrategy/RuleStrategyLabel.js
+++ b/client/src/components/ProjectWizard/RuleStrategy/RuleStrategyLabel.js
@@ -1,0 +1,56 @@
+import React from "react";
+import ToolTipLabel from "../../ToolTip/ToolTipLabel";
+import PropTypes from "prop-types";
+import { createUseStyles } from "react-jss";
+
+const useStyles = createUseStyles({
+  textInputLabelAnchor: {
+    textDecoration: "underline"
+  }
+});
+
+const RuleStrategyLabel = ({
+  id,
+  description,
+  code,
+  display,
+  required,
+  link,
+  name
+}) => {
+  const classes = useStyles();
+
+  return (
+    <ToolTipLabel
+      id={"tooltip-strategy" + id}
+      tooltipContent={description}
+      htmlFor={code}
+      disabledInput={!display}
+      requiredInput={required}
+    >
+      {link ? (
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={classes.textInputLabelAnchor}
+        >
+          {name}
+        </a>
+      ) : (
+        name
+      )}
+    </ToolTipLabel>
+  );
+};
+
+RuleStrategyLabel.propTypes = {
+  id: PropTypes.number.isRequired,
+  code: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  display: PropTypes.bool,
+  required: PropTypes.bool,
+  link: PropTypes.string
+};
+export default RuleStrategyLabel;

--- a/client/src/components/ProjectWizard/WizardPages/ProjectPackages.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectPackages.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { createUseStyles, useTheme } from "react-jss";
 import ToolTipIcon from "../../ToolTip/ToolTipIcon";
 import ToolTip from "../../ToolTip/ToolTip";
+import ToolTipLabel from "../../ToolTip/ToolTipLabel";
 
 const useStyles = createUseStyles({
   box: {
@@ -292,18 +293,12 @@ function ProjectPackages(props) {
       <h3 className="tdm-wizard-page-subtitle">
         Learn more about packages
         <span style={{ textAlign: "left" }}>
-          <label
-            className={classes.tooltipLabel}
-            data-for={"tooltip-package-description"}
-            data-tip={
-              "There are many TDM strategies choices and most involve making long-term commitments in meeting program compliance.         Small development projects (defined as Program Level 1 that provide no more than the parking baseline), are provided TDM packages that allow fulfillment of the minimum 15 point target from a pre-selected menu.             A point incentive is provided for the packages made up of strategies that work together to reinforce their effectiveness in reducing drive-alone trips.             Each strategy selected on its own does not result in the required minimum point target but several selected together will. Each package can be unselected and individual strategies that will work best to both achieve the TDM program goals and your specific development objectives should be chosen. "
-            }
-            data-iscapture="true"
-            data-html="true"
-            data-class={classes.tooltip}
+          <ToolTipLabel
+            id="tooltip-package-description"
+            tooltipContent="There are many TDM strategies choices and most involve making long-term commitments in meeting program compliance.         Small development projects (defined as Program Level 1 that provide no more than the parking baseline), are provided TDM packages that allow fulfillment of the minimum 15 point target from a pre-selected menu.             A point incentive is provided for the packages made up of strategies that work together to reinforce their effectiveness in reducing drive-alone trips.             Each strategy selected on its own does not result in the required minimum point target but several selected together will. Each package can be unselected and individual strategies that will work best to both achieve the TDM program goals and your specific development objectives should be chosen. "
           >
             <ToolTipIcon />
-          </label>
+          </ToolTipLabel>
 
           <ToolTip id={"tooltip-package-description"} />
         </span>

--- a/client/src/components/ToolTip/ToolTipIcon.js
+++ b/client/src/components/ToolTip/ToolTipIcon.js
@@ -15,13 +15,36 @@ const useStyles = createUseStyles({
   },
   circle: {
     filter: "drop-shadow(0px 4px 2px rgba(0, 46, 109, 0.3))"
+  },
+  tooltip: {
+    color: "rgb(30, 36, 63) !important",
+    padding: "15px",
+    minWidth: "200px",
+    maxWidth: "400px",
+    fontFamily: "Arial",
+    fontSize: 12,
+    lineHeight: "16px",
+    fontWeight: "bold",
+    boxShadow: "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    borderRadius: 2,
+    "&.show": {
+      visibility: "visible !important",
+      opacity: "1 !important"
+    }
   }
 });
 
-const ToolTipIcon = ({ size = "small" }) => {
+const ToolTipIcon = ({ size = "small", id, tooltipContent }) => {
   const classes = useStyles({ size });
   return (
-    <span className={clsx("fa-layers", "fa-fw", classes.tooltipIconContainer)}>
+    <span
+      className={clsx("fa-layers", "fa-fw", classes.tooltipIconContainer)}
+      data-class={classes.tooltip}
+      data-for={id}
+      data-tip={tooltipContent}
+      data-iscapture="true"
+      data-html="true"
+    >
       <FontAwesomeIcon
         icon={faCircle}
         color="#a7c539"
@@ -33,7 +56,9 @@ const ToolTipIcon = ({ size = "small" }) => {
 };
 
 ToolTipIcon.propTypes = {
-  size: PropTypes.string
+  size: PropTypes.string,
+  id: PropTypes.string,
+  tooltipContent: PropTypes.string
 };
 
 export default ToolTipIcon;

--- a/client/src/components/ToolTip/ToolTipLabel.js
+++ b/client/src/components/ToolTip/ToolTipLabel.js
@@ -1,0 +1,75 @@
+import React from "react";
+import { PropTypes } from "prop-types";
+import { createUseStyles } from "react-jss";
+import clsx from "clsx";
+
+const useStyles = createUseStyles({
+  tooltipLabel: {
+    flexGrow: "1",
+    flexShrink: "1",
+    flexBasis: "50%" //RuleInput
+  },
+  tooltip: {
+    color: "rgb(30, 36, 63) !important",
+    padding: "15px",
+    minWidth: "200px",
+    maxWidth: "400px",
+    fontFamily: "Arial",
+    fontSize: 12,
+    lineHeight: "16px",
+    fontWeight: "bold",
+    boxShadow: "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    borderRadius: 2,
+    "&.show": {
+      visibility: "visible !important",
+      opacity: "1 !important"
+    }
+  },
+  requiredInputLabel: {
+    "&:after": {
+      content: '" *"',
+      color: "red"
+    }
+  },
+  disabledInputLabel: {
+    opacity: "0.5"
+  }
+});
+
+const ToolTipLabel = ({
+  id,
+  tooltipContent,
+  children,
+  code,
+  requiredInput,
+  disabledInput
+}) => {
+  const classes = useStyles();
+  const requiredStyle = requiredInput && classes.requiredInputLabel;
+  const disabledStyle = disabledInput && classes.disabledInputLabel;
+
+  return (
+    <label
+      htmlFor={code ? code : null}
+      className={clsx(classes.tooltipLabel, requiredStyle, disabledStyle)}
+      data-class={classes.tooltip}
+      data-for={id}
+      data-tip={tooltipContent}
+      data-iscapture="true"
+      data-html="true"
+    >
+      {children}
+    </label>
+  );
+};
+
+ToolTipLabel.propTypes = {
+  id: PropTypes.string.isRequired,
+  tooltipContent: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  code: PropTypes.string,
+  requiredInput: PropTypes.bool,
+  disabledInput: PropTypes.bool
+};
+
+export default ToolTipLabel;

--- a/client/src/components/ToolTip/ToolTipLabel.js
+++ b/client/src/components/ToolTip/ToolTipLabel.js
@@ -7,7 +7,7 @@ const useStyles = createUseStyles({
   tooltipLabel: {
     flexGrow: "1",
     flexShrink: "1",
-    flexBasis: "50%" //RuleInput
+    flexBasis: "50%"
   },
   tooltip: {
     color: "rgb(30, 36, 63) !important",

--- a/client/src/styles/theme.js
+++ b/client/src/styles/theme.js
@@ -8,6 +8,7 @@ module.exports = {
     colorDisabled: "rgba(0, 0, 0, .05)", //lightest grey transparent
     colorCancel: "rgba(0, 0, 0, 0.5)", //light grey, e.g. cancel button
     colorWhite: "#fff", //white
-    colorError: "#E46247" //e.g. red
+    colorError: "#E46247", //e.g. red
+    colorHighlight: "#F0E300" //yellow
   }
 };


### PR DESCRIPTION
closes #671 

- Refactor and create ToolTipLabel and RuleInputLabel
- Delete unused code and styling from RuleInput

Third commit:
-  Remove unused code
- Fix tooltip for parking baseline to only show up on tooltip icon (not label)
- Rename variables and classname
- Use jss theme colors when hovering on rows
- Make RuleStrategy and RuleInput styles more consistent with each other
- Restyled RuleStrategy so that columns and dropdowns are consistent and aligned
- Refactor disabled styling & logic in RuleStrategy
- Create new RuleStrategyLabel component

Apologies ahead of time for overloading the last commit. It  includes some styling changes I made to the strategies page to clean it up a git. 