### PR TITLE
716 refactor sidebar and fix minor styling changes on projects page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Route, Redirect } from "react-router-dom";
+import { Route, Redirect, Switch } from "react-router-dom";
 import { createUseStyles } from "react-jss";
 import { withToastProvider } from "./contexts/Toast";
 import TdmCalculationContainer from "./components/TdmCalculationContainer";
@@ -21,12 +21,12 @@ import ResetPassword from "./components/Authorization/ResetPassword";
 import ResetPasswordRequest from "./components/Authorization/ResetPasswordRequest";
 import "./styles/App.scss";
 import PublicComment from "./components/PublicComment/PublicCommentPage";
+import Sidebar from "./components/Sidebar";
 
 const useStyles = createUseStyles({
   root: {
     flex: "1 0 auto",
-    display: "flex",
-    flexDirection: "column"
+    display: "flex"
   }
 });
 
@@ -47,77 +47,101 @@ const App = ({
         id="main-content-container"
         ref={mainContentContainerRef}
       >
-        <Route
-          exact
-          path="/"
-          render={() =>
-            account.email ? (
-              <Redirect to="/calculation/1" />
-            ) : (
-              <Login setLoggedInAccount={setLoggedInAccount} />
-            )
-          }
-        />
-        <Route exact path="/calculation">
-          <Redirect to="/calculation/1" />
-        </Route>
-        <Route
-          path="/calculation/:page/:projectId?"
-          render={() => (
-            <TdmCalculationContainer
-              account={account}
-              hasConfirmedNavTransition={hasConfirmedTransition}
-              setLoggedInAccount={setLoggedInAccount}
-              tdmWizardContentContainerRef={tdmWizardContentContainerRef}
-            />
-          )}
-        />
-        <Route
-          path="/projects"
-          render={() => <ProjectsPage account={account} />}
-        />
-        <Route path="/about" component={About} />
-        <Route path="/termsandconditions" component={TermsAndConditionsPage} />
-        <Route path="/privacypolicy" component={PrivacyPolicy} />
-        <Route path="/register/:email?" component={Register} />
-        <Route path="/confirm/:token" component={ConfirmEmail} />
-        <Route
-          path="/login/:email?"
-          render={() =>
-            account.email ? (
-              <Redirect to="/calculation/1" />
-            ) : (
-              <Login setLoggedInAccount={setLoggedInAccount} />
-            )
-          }
-        />
-        <Route
-          path="/logout/:email?"
-          render={routeProps => {
-            setLoggedInAccount({});
-            return (
-              <Redirect
-                to={
-                  routeProps.match.params["email"]
-                    ? `/login/${routeProps.match.params["email"]}`
-                    : "/login"
-                }
-              />
-            );
-          }}
-        />
+        <Switch>
+          {/* These routes either have no sidebar or use a custom sidebar */}
+          <Route
+            path="/projects"
+            render={() => <ProjectsPage account={account} />}
+          />
 
-        <Route path="/forgotpassword" component={ResetPasswordRequest} />
-        <Route path="/resetPassword/:token" component={ResetPassword} />
-        <Route path="/contactus" component={ContactUs} />
-        {account && account.isAdmin ? (
-          <Route path="/admin" render={() => <Admin account={account} />} />
-        ) : null}
-        {account && account.isSecurityAdmin ? (
-          <Route path="/roles" render={() => <Roles />} />
-        ) : null}
-        <Route path="/faqs" component={FaqView} />
-        <Route path="/publiccomment" component={PublicComment} />
+          <Route
+            path="/calculation/:page/:projectId?"
+            render={() => (
+              <TdmCalculationContainer
+                account={account}
+                hasConfirmedNavTransition={hasConfirmedTransition}
+                setLoggedInAccount={setLoggedInAccount}
+                tdmWizardContentContainerRef={tdmWizardContentContainerRef}
+              />
+            )}
+          />
+
+          <Route exact path="/calculation">
+            <Redirect to="/calculation/1" />
+          </Route>
+
+          <Route
+            exact
+            path="/"
+            render={() =>
+              account.email ? (
+                <Redirect to="/calculation/1" />
+              ) : (
+                <Redirect to="/login" />
+              )
+            }
+          />
+
+          {/* These routes use the same sidebar component */}
+          <Route>
+            <>
+              <Sidebar />
+              <Switch>
+                <Route path="/about" component={About} />
+                <Route
+                  path="/termsandconditions"
+                  component={TermsAndConditionsPage}
+                />
+                <Route path="/privacypolicy" component={PrivacyPolicy} />
+                <Route path="/register/:email?" component={Register} />
+                <Route path="/confirm/:token" component={ConfirmEmail} />
+                <Route
+                  path="/login/:email?"
+                  render={() =>
+                    account.email ? (
+                      <Redirect to="/calculation/1" />
+                    ) : (
+                      <Login setLoggedInAccount={setLoggedInAccount} />
+                    )
+                  }
+                />
+                <Route
+                  path="/logout/:email?"
+                  render={routeProps => {
+                    setLoggedInAccount({});
+                    return (
+                      <Redirect
+                        to={
+                          routeProps.match.params["email"]
+                            ? `/login/${routeProps.match.params["email"]}`
+                            : "/login"
+                        }
+                      />
+                    );
+                  }}
+                />
+
+                <Route
+                  path="/forgotpassword"
+                  component={ResetPasswordRequest}
+                />
+                <Route path="/resetPassword/:token" component={ResetPassword} />
+                <Route path="/contactus" component={ContactUs} />
+                {account && account.isAdmin ? (
+                  <Route
+                    path="/admin"
+                    render={() => <Admin account={account} />}
+                  />
+                ) : null}
+                {account && account.isSecurityAdmin ? (
+                  <Route path="/roles" render={() => <Roles />} />
+                ) : null}
+                <Route path="/faqs" component={FaqView} />
+                <Route path="/publiccomment" component={PublicComment} />
+              </Switch>
+            </>
+          </Route>
+        </Switch>
       </div>
       <Footer />
     </React.Fragment>

--- a/client/src/components/About.js
+++ b/client/src/components/About.js
@@ -1,5 +1,4 @@
 import React from "react";
-import SideBar from "./Sidebar";
 import clsx from "clsx";
 import { createUseStyles } from "react-jss";
 import {
@@ -50,7 +49,6 @@ const About = () => {
       onClick={trackComponent}
     >
       <div className={clsx("tdm-wizard", classes.tdmWizard)}>
-        <SideBar />
         <div
           className="tdm-wizard-content-container"
           onLoad={trackComponent}

--- a/client/src/components/Authorization/Login.js
+++ b/client/src/components/Authorization/Login.js
@@ -5,7 +5,6 @@ import { createUseStyles } from "react-jss";
 import { Formik, Form, Field, ErrorMessage } from "formik";
 import * as Yup from "yup";
 import * as accountService from "../../services/account.service";
-import SideBar from "../Sidebar";
 import clsx from "clsx";
 import {
   useAppInsightsContext,
@@ -133,7 +132,6 @@ const Login = props => {
     <div className={classes.root}>
       <div className={clsx("tdm-wizard", classes.tdmWizard)}>
         <div className="tdm-wizard-sidebar" />
-        <SideBar />
         <div className="tdm-wizard-content-container" onClick={trackComponent}>
           <h1>Welcome to Los Angeles&rsquo; TDM Calculator</h1>
           <h3>Please sign into your account to save progress.</h3>

--- a/client/src/components/Authorization/Register.js
+++ b/client/src/components/Authorization/Register.js
@@ -6,7 +6,6 @@ import clsx from "clsx";
 import { Formik, Form, Field, ErrorMessage } from "formik";
 import { Link, withRouter } from "react-router-dom";
 import * as Yup from "yup";
-import Sidebar from "../Sidebar";
 
 const useStyles = createUseStyles({
   root: {
@@ -63,13 +62,13 @@ const Register = props => {
       if (response.isSuccess) {
         setSubmitted(true);
       } else if (response.code === "REG_DUPLICATE_EMAIL") {
-        setErrorMsg(`The email ${email} is already registered. Please 
-          login or use the Forgot Password feature if you have 
+        setErrorMsg(`The email ${email} is already registered. Please
+          login or use the Forgot Password feature if you have
           forgotten your password.`);
         setSubmitting(false);
       } else {
-        setErrorMsg(`An error occurred in sending the confirmation 
-          message to ${email}. Try to log in, and follow the 
+        setErrorMsg(`An error occurred in sending the confirmation
+          message to ${email}. Try to log in, and follow the
           instructions for re-sending the confirmation email.`);
         setSubmitting(false);
       }
@@ -84,7 +83,6 @@ const Register = props => {
   return (
     <div className={classes.root}>
       <div className={clsx("tdm-wizard", classes.wizardContainer)}>
-        <Sidebar />
         <div
           className={clsx(
             "tdm-wizard-content-container",

--- a/client/src/components/Authorization/ResetPassword.js
+++ b/client/src/components/Authorization/ResetPassword.js
@@ -6,7 +6,6 @@ import { Formik, Form, Field, ErrorMessage } from "formik";
 import * as Yup from "yup";
 import clsx from "clsx";
 import { useStyles } from "./ResetPasswordRequest";
-import Sidebar from "../Sidebar";
 
 const validationSchema = Yup.object().shape({
   password: Yup.string()
@@ -36,7 +35,6 @@ export function ResetPassword(props) {
 
   return (
     <div className={classes.root}>
-      <Sidebar />
       <div className={classes.formContent}>
         {!success ? (
           <>

--- a/client/src/components/Authorization/ResetPasswordRequest.js
+++ b/client/src/components/Authorization/ResetPasswordRequest.js
@@ -5,7 +5,6 @@ import * as Yup from "yup";
 import * as accountService from "../../services/account.service";
 import { createUseStyles } from "react-jss";
 import clsx from "clsx";
-import Sidebar from "../Sidebar";
 
 export const useStyles = createUseStyles({
   root: {
@@ -15,11 +14,11 @@ export const useStyles = createUseStyles({
     alignItems: "center",
     position: "relative",
     width: "100%",
-    height: "calc(100vh - 103px)"
+    height: "calc(100vh - 103px - 48px)"
   },
   content: {
     position: "relative",
-    height: "calc(100vh - 103px)",
+    height: "calc(100vh - 103px - 48px)",
     width: "calc(100vw - 387px)"
   },
   backLink: {
@@ -112,7 +111,6 @@ export function ResetPasswordRequest() {
 
   return (
     <div className={classes.root}>
-      <Sidebar />
       <div className={classes.content}>
         <Link className={classes.backLink} to={"/login"}>
           {"< Return to Login"}

--- a/client/src/components/Pagination.js
+++ b/client/src/components/Pagination.js
@@ -10,6 +10,9 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 
 const useStyles = createUseStyles({
+  paginationContainer: {
+    marginBottom: "20px"
+  },
   pagination: {
     display: "flex"
   },
@@ -45,7 +48,7 @@ const Pagination = props => {
   }
 
   return (
-    <div>
+    <div className={classes.paginationContainer}>
       <ul className={classes.pagination}>
         <button
           className={clsx("hoverPointer", classes.button)}

--- a/client/src/components/PrivacyPolicy.js
+++ b/client/src/components/PrivacyPolicy.js
@@ -1,5 +1,4 @@
 import React from "react";
-import SideBar from "./Sidebar";
 import clsx from "clsx";
 import { createUseStyles } from "react-jss";
 
@@ -83,7 +82,6 @@ const PrivacyPolicy = () => {
   return (
     <div className={classes.root}>
       <div className={clsx("tdm-wizard", classes.tdmWizard)}>
-        <SideBar />
         <div className="tdm-wizard-content-container">
           <h1 className={classes.header}>Privacy Policy</h1>
           <br />

--- a/client/src/components/Projects/ProjectsPage.js
+++ b/client/src/components/Projects/ProjectsPage.js
@@ -71,6 +71,9 @@ const useStyles = createUseStyles({
   theadLabel: {
     cursor: "pointer"
   },
+  labelSpan: {
+    display: "inline-flex" // fix arrow
+  },
   sortArrow: {
     marginLeft: "8px",
     verticalAlign: "baseline"

--- a/client/src/components/PublicComment/PublicCommentPage.js
+++ b/client/src/components/PublicComment/PublicCommentPage.js
@@ -2,7 +2,6 @@ import React from "react";
 import { postPublicComment } from "./postPublicComment";
 import { createUseStyles } from "react-jss";
 import clsx from "clsx";
-import Sidebar from "../Sidebar";
 import { ErrorMessage, Field, Form, Formik } from "formik";
 import * as Yup from "yup";
 import Button from "../Button/Button";
@@ -85,7 +84,6 @@ const PublicCommentPage = () => {
       onClick={trackComponent}
     >
       <div className="tdm-wizard">
-        <Sidebar />
         <div className="tdm-wizard-content-container">
           <PublicCommentForm />
         </div>

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
 
 export const useStyles = createUseStyles({
-  "sidebar-container": {
+  sidebarContainer: {
     margin: "0",
     flexBasis: "387px",
     flexGrow: 0,
@@ -17,48 +17,46 @@ export const useStyles = createUseStyles({
   },
   overlay: {
     backgroundColor: "rgba(0,69,124,0.75)",
-    // opacity: "0.8",
     height: "100%"
   },
-  "sidebar-content": {
+  sidebarContent: {
     display: "flex",
     flexDirection: "column",
     justifyContent: "flex-start",
     height: "100%"
   },
   "@media (max-width: 1024px)": {
-    "sidebar-container": {
+    sidebarContainer: {
       flexBasis: "200px",
       flexShrink: 1
     }
   },
   "@media (max-width:768px)": {
-    "sidebar-container": {
+    sidebarContainer: {
       flexBasis: "auto",
       backgroundPosition: "15% 44%"
     },
-    "sidebar-content": {
+    sidebarContent: {
       height: "auto",
       minHeight: 0
     }
   }
 });
 
-export function Sidebar(props) {
-  const { sidebarRef } = props;
+export function Sidebar({ sidebarRef, children }) {
   const classes = useStyles();
 
   return (
-    <div className={classes["sidebar-container"]} ref={sidebarRef}>
+    <div className={classes.sidebarContainer} ref={sidebarRef}>
       <div className={classes.overlay}>
-        <div className={classes["sidebar-content"]}>{props.children}</div>
+        <div className={classes.sidebarContent}>{children}</div>
       </div>
     </div>
   );
 }
 
 Sidebar.propTypes = {
-  children: PropTypes.any,
+  children: PropTypes.node,
   sidebarRef: PropTypes.object
 };
 

--- a/client/src/components/TermsAndConditions.js
+++ b/client/src/components/TermsAndConditions.js
@@ -1,0 +1,210 @@
+import React from "react";
+import clsx from "clsx";
+import { createUseStyles } from "react-jss";
+
+const useStyles = createUseStyles({
+  root: {
+    flex: "1 0 auto",
+    display: "flex",
+    flexDirection: "column"
+  },
+  tdmWizard: {
+    flex: "1 0 auto",
+    display: "flex",
+    flexDirection: "row"
+  },
+  aboutText: {
+    maxWidth: "500px",
+    minWidth: 300,
+    padding: "0 2em"
+  },
+  scroll: {
+    "&::-webkit-scrollbar": {
+      webkitappearance: "none",
+      width: "7px"
+    },
+    "&::-webkit-scrollbar-thumb": {
+      borderRadius: "4px",
+      backgroundColor: "rgba(0, 0, 0, .5)",
+      webkitBoxShadow: "0 0 1px rgba(255, 255, 255, .5)"
+    },
+    overflowY: "scroll",
+    width: "600px",
+    height: "600px"
+  },
+  header: {
+    fontFamily: "Calibri Bold",
+    fontWeight: "normal",
+    fontSize: "25px",
+    lineHeight: "1.25em",
+    color: "#0F2940",
+    textAlign: "center"
+  },
+  bold: {
+    textShadow: "1px 0 0 currentColor"
+  },
+  "@media (max-width: 768px)": {
+    aboutText: {
+      padding: "0"
+    }
+  },
+  link: {
+    textDecoration: "underline",
+    color: "blue"
+  },
+  greyText: {
+    color: "grey"
+  }
+});
+
+const TermsAndConditions = () => {
+  const classes = useStyles();
+  return (
+    <div className={classes.root}>
+      <div className={clsx("tdm-wizard", classes.tdmWizard)}>
+        <div className="tdm-wizard-content-container">
+          <h1 className={classes.header}>
+            TDM Calculator User Terms and Conditions
+          </h1>
+          <br />
+          <div className={(classes.aboutText, classes.scroll)}>
+            <p className={classes.greyText}>
+              PLEASE READ THIS AGREEMENT CAREFULLY BEFORE USING THIS WEB SITE.
+              BY USING THIS WEB SITE, YOU ARE CONSENTING TO BE OBLIGATED AND
+              BECOME A PARTY TO THIS AGREEMENT. IF YOU DO NOT AGREE TO THE TERMS
+              AND CONDITIONS BELOW YOU SHOULD NOT ACCESS OR USE THIS WEB SITE
+            </p>
+            <p>
+              The Los Angeles Department of Transportation (LADOT), in
+              partnership with the Department of City Planning and Hack for LA
+              (a project of Code for America), has developed the City of Los
+              Angeles Transportation Demand Management (TDM) Calculator (TDM
+              Calculator) to provide the public with an understanding of the TDM
+              Ordinance. Currently available for review: Council File
+              15-0719-S19 / the Los Angeles Department of City Planning website:
+              <span> </span>
+              <a
+                className={classes.link}
+                href="https://planning.lacity.org/plans-policies/initiatives-policies/mobility"
+              >
+                {" "}
+                planning4la.org/mobility
+              </a>
+              . The TDM Ordinance proposes to revise regulations that require
+              eligible land use development projects to adopt TDM strategies
+              with the goal to reduce the reliance on drive-alone trips in the
+              City of Los Angeles. The term “City” as used below shall refer to
+              the City of Los Angeles. The terms “City” and “Hack for LA” as
+              used below shall include their respective affiliates,
+              sub-consultants, employees, volunteers, and representatives.
+            </p>
+            <p>
+              This digital review tool, the TDM Calculator, has been provided to
+              You, the User, as a public service to assess different scenarios
+              that land use development would need to comply with if the City
+              were to adopt the TDM Ordinance. LADOT is pleased to be able to
+              provide this information to the public. LADOT believes that the
+              public is most effectively served when they are provided access to
+              the technical tools that inform the public policy-making process
+              that governs private and public land-use investments. However, in
+              using the TDM Calculator, You agree to be bound by this TDM
+              Calculator User Agreement (this Agreement).{" "}
+            </p>
+            <p>
+              <span className={classes.bold}>Limited License to Use.</span> This
+              Agreement gives You a limited, non-transferable, non-assignable,
+              and non-exclusive license to use the TDM Calculator on a computer
+              system owned, leased, or otherwise controlled by You in Your own
+              facilities, as set out below and provided that You know and follow
+              the terms of this Agreement. Your failure to follow the terms of
+              this Agreement shall automatically terminate this license and Your
+              right to use the TDM Calculator.{" "}
+            </p>
+            <p>
+              <span className={classes.bold}>Warranty Disclaimer.</span> LADOT
+              worked with the Department of City Planning and Hack for LA to
+              develop the TDM Calculator’s parameters, including potential TDM
+              strategies, and program point targets that could apply to land use
+              development. However, since the TDM Ordinance is a draft
+              regulation and not current law, it could further change, or be
+              adopted in whole, or in part, denied, or abandoned, the
+              information herein should not be interpreted to be binding on land
+              use development regulation outcomes that inform investment
+              decisions. Due to the dynamic nature of the information contained
+              within the TDM Calculator and the reliance upon information from
+              outside sources, the City does not guarantee the accuracy or
+              reliability of the information transmitted from this web site. The
+              TDM Calculator, OUTPUTS AND ASSOCIATED DATA ARE PROVIDED “as is”
+              WITHOUT WARRANTY OF ANY KIND, whether expressed, implied,
+              statutory or otherwise including but not limited to, warranties of
+              title or the implied warranties of merchantability and fitness for
+              a particular purpose. Neither the City nor Hack for LA are
+              responsible for any special, indirect, incidental, or
+              consequential damages that may arise from the use of, or the
+              inability to use, the data and/or the materials contained on the
+              data whether the materials contained on the data are provided by
+              the City or a third party.
+            </p>
+            <p>
+              LADOT is neither responsible nor liable for any viruses or other
+              contamination of your system nor for any delays, inaccuracies,
+              errors or omissions arising out of your use of the TDM Calculator
+              or with respect to the material contained within the TDM
+              Calculator.
+            </p>
+            <p>
+              <span className={classes.bold}>Limitation of Liability.</span> It
+              is understood that the TDM Calculator is provided without charge.
+              Neither the City nor Hack for LA can be responsible or liable for
+              any information derived from its use, nor liable for any viruses
+              or other contamination of your system nor for any delays,
+              inaccuracies, incompleteness, errors, or omissions arising out of
+              your use of the TDM Calculator or with respect to the material
+              contained in the TDM Calculator. You understand and agree that
+              Your sole remedy against the City or Hack for LA for loss or
+              damage caused by any defect or failure of the TDM Calculator,
+              regardless of the form of action, whether in contract, tort,
+              including negligence, strict liability, or otherwise, shall be the
+              repair or replacement of the TDM Calculator to the extent feasible
+              as determined solely by the City. In no event shall the City or
+              Hack for LA be responsible to You or anyone else for, or have
+              liability for any special, indirect, incidental, or consequential
+              damages (including, without limitation, damages for loss of
+              business profits or changes to businesses costs) or lost data or
+              downtime, however caused, and on any theory of liability from the
+              use of, or the inability to use, the TDM Calculator, whether the
+              data, and/or formulas contained in the TDM Calculator are provided
+              by the City or Hack for LA, or another third party, even if the
+              City has been advised of the possibility of such damages.{" "}
+            </p>
+            <p>
+              This Agreement and License shall be governed by the laws of the
+              State of California without regard to their conflicts of law
+              provisions and shall be effective as of the date that You are
+              making use of the TDM Calculator. Any action brought to enforce
+              the Agreement and/or in connection with this website shall be
+              brought in either the state or federal courts in the County of Los
+              Angeles County, State of California.
+            </p>
+            <p>
+              By using the TDM Calculator, You hereby waive and release all
+              claims, responsibilities, liabilities, actions, damages, costs,
+              and losses, known and unknown, against the City and Hack for LA
+              for Your use of the TDM Calculator.{" "}
+            </p>
+            <p>
+              Before making decisions using the information provided in this
+              application, contact City LADOT staff at{" "}
+              <a className={classes.link} href="https://www.lacity.org/">
+                ladot.tdm@lacity.org
+              </a>{" "}
+              to confirm the validity of the data provided.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TermsAndConditions;

--- a/client/src/components/TermsAndConditions/TermsAndConditionsPage.js
+++ b/client/src/components/TermsAndConditions/TermsAndConditionsPage.js
@@ -1,5 +1,4 @@
 import React from "react";
-import SideBar from "../Sidebar";
 import clsx from "clsx";
 import { createUseStyles } from "react-jss";
 import TermsAndConditionsContent from "./TermsAndConditionsContent";
@@ -25,7 +24,6 @@ const TermsAndConditionsPage = () => {
   return (
     <div className={classes.root}>
       <div className={clsx("tdm-wizard", classes.tdmWizard)}>
-        <SideBar />
         <div className="tdm-wizard-content-container">
           <div className={classes.contentContainer}>
             <TermsAndConditionsContent />


### PR DESCRIPTION
closes #716 

Refactor usage of sidebar -
  - Reorganize routes so that most routes are displaying the same Sidebar component; the Sidebar component does not need to be imported directly into the component
  - /projects and /calculation pages do not use the same shared Sidebar component; /projects page has no sidebar and /calculation (TdmCalculationWizard.js) still has Sidebar imported in because it needs the SidebarPanel with the points displayed and calculated. It's the only page/component that a sidebar that behaves differently from the rest of the app.
  - Clean up Sidebar component to make it more React-y

Note: the /confirm/ page now has a sidebar but the page itself needs to be styled. I added a new issue for that #738 


I also made two small style changes on the projects page, which are the first two commits:
- Fix sort arrow responsiveness on project table #432
- Add a margin bottom to the pagination on projects page