### PR TITLE
#756 Fix error message and resends email when user tries to login with unconfirmed email

### DIFF
--- a/client/src/components/Authorization/Login.js
+++ b/client/src/components/Authorization/Login.js
@@ -108,11 +108,19 @@ const Login = props => {
             action: "login failed",
             value: "email not confirmed"
           });
-          await accountService.resendConfirmationEmail(email);
-          setErrorMsg(`Your email has not been confirmed.
-          Please look through your email for a Registration
-          Confirmation link and use it to confirm that you
-          own this email address.`);
+
+          const resendResponse = await accountService.resendConfirmationEmail(
+            email
+          );
+          if (resendResponse.code === "REG_SUCCESS") {
+            setErrorMsg(`A new confirmation email has been sent.
+            Please look through your email for a "Verify Your Account" subject line and
+            verify that you own this email address.`);
+          } else {
+            setErrorMsg(
+              `We found your email address but there was an error trying to resend your confirmation email.`
+            );
+          }
           setSubmitting(false);
         } catch (err) {
           window.dataLayer.push({

--- a/server/app/services/account.service.js
+++ b/server/app/services/account.service.js
@@ -99,7 +99,7 @@ const resendConfirmationEmail = async email => {
     result = {
       success: true,
       code: "REG_SUCCESS",
-      newId: selectByEmailResponse.recordset.rows[0].id,
+      newId: selectByEmailResponse.recordset[0].id,
       message: "Account found."
     };
     result = await requestRegistrationConfirmation(email, result);
@@ -110,7 +110,7 @@ const resendConfirmationEmail = async email => {
     return {
       success: false,
       code: "REG_ACCOUNT_NOT_FOUND",
-      message: `Email ${email} is not registered. `
+      message: `Resending confirmation email to ${email} failed due to: ${err.message}`
     };
   }
 };
@@ -132,7 +132,7 @@ const requestRegistrationConfirmation = async (email, result) => {
     return {
       success: false,
       code: "REG_EMAIL_FAILED",
-      message: `Sending registration confirmation email to ${email} failed.`
+      message: `Sending registration confirmation email to ${email} failed due to: ${err.message}`
     };
   }
 };

--- a/server/app/services/sendgrid-service.js
+++ b/server/app/services/sendgrid-service.js
@@ -27,7 +27,7 @@ const sendRegistrationConfirmation = async (email, token) => {
   const msg = {
     to: `${email}`,
     from: senderEmail,
-    subject: "Verify your account",
+    subject: "Verify Your Account",
     text: "Verify your account",
     html: `<p>Hello, please click the following link to verify your account.</p>
               <br>


### PR DESCRIPTION
Closes #756 

Side note - Reposting from [slack post](https://hackforla.slack.com/archives/CKY65G266/p1614568234007300). It has not yet been made into an issue: 
i just tried logging in with an unconfirmed email 3 times, saw 3 registration confirmation emails, tried clicking on the oldest email link and it verified me. Not sure if this is expected behavior or if only the most recent email link should be allowed to verify the user.