### PR TITLE
850 add user strategy to summary

### DIFF
--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
@@ -193,7 +193,7 @@ const useStyles = createUseStyles({
     minWidth: "180px",
     maxWidth: "100%",
     marginRight: "110px",
-    marginLeft: "110px"
+    marginLeft: "80px"
   }
 });
 

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
@@ -537,9 +537,12 @@ const ProjectSummary = props => {
       )}
       <div className={classes.categoryContainer}>
         <div className={clsx("space-between")}>
-          <span className={classes.categoryHeader}>PROJECT SPECIFICATIONS</span>
+          <span className={classes.categoryHeader}>USER DEFINED STRATEGY</span>
         </div>
-        <div className={classes.measuresContainer}></div>
+        <div className={classes.measuresContainer}>
+          {userDefinedStrategy.calcValue}
+          {userDefinedStrategy.comment}
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
@@ -193,7 +193,7 @@ const useStyles = createUseStyles({
 const ProjectSummary = props => {
   const classes = useStyles();
   const { rules } = props;
-  console.log("PROPS", props);
+
   const landUses = rules
     .filter(rule => rule.used && rule.value && rule.calculationPanelId === 5)
     .map(r => r.name)
@@ -224,7 +224,6 @@ const ProjectSummary = props => {
   const earnedPoints = getRule("PTS_EARNED");
 
   const userDefinedStrategy = getRule("STRATEGY_APPLICANT");
-  console.log(userDefinedStrategy);
 
   // Note: a rule is not effective if the value is any falsey value or "0"
   const measureRules =
@@ -540,7 +539,6 @@ const ProjectSummary = props => {
           <span className={classes.categoryHeader}>USER DEFINED STRATEGY</span>
         </div>
         <div className={classes.measuresContainer}>
-          {userDefinedStrategy.calcValue}
           {userDefinedStrategy.comment}
         </div>
       </div>

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
@@ -193,7 +193,7 @@ const useStyles = createUseStyles({
 const ProjectSummary = props => {
   const classes = useStyles();
   const { rules } = props;
-
+  console.log("PROPS", props);
   const landUses = rules
     .filter(rule => rule.used && rule.value && rule.calculationPanelId === 5)
     .map(r => r.name)
@@ -222,6 +222,9 @@ const ProjectSummary = props => {
   const level = getRule("PROJECT_LEVEL");
   const targetPoints = getRule("TARGET_POINTS_PARK");
   const earnedPoints = getRule("PTS_EARNED");
+
+  const userDefinedStrategy = getRule("STRATEGY_APPLICANT");
+  console.log(userDefinedStrategy);
 
   // Note: a rule is not effective if the value is any falsey value or "0"
   const measureRules =
@@ -532,6 +535,12 @@ const ProjectSummary = props => {
           <Loader loaded={false} className="spinner" left="auto" />
         </div>
       )}
+      <div className={classes.categoryContainer}>
+        <div className={clsx("space-between")}>
+          <span className={classes.categoryHeader}>PROJECT SPECIFICATIONS</span>
+        </div>
+        <div className={classes.measuresContainer}></div>
+      </div>
     </div>
   );
 };

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
@@ -192,9 +192,8 @@ const useStyles = createUseStyles({
     display: "flex",
     minWidth: "180px",
     maxWidth: "100%",
-    marginRight: "100px",
-    marginLeft: "70px",
-    border: "1px 	#BEBEBE solid",
+    marginRight: "3em",
+    border: "1px 	#E7EBF0 solid",
     borderRadius: "5px",
     marginTop: "8px",
     padding: "12px"

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary.js
@@ -192,8 +192,12 @@ const useStyles = createUseStyles({
     display: "flex",
     minWidth: "180px",
     maxWidth: "100%",
-    marginRight: "110px",
-    marginLeft: "80px"
+    marginRight: "100px",
+    marginLeft: "70px",
+    border: "1px 	#BEBEBE solid",
+    borderRadius: "5px",
+    marginTop: "8px",
+    padding: "12px"
   }
 });
 
@@ -469,16 +473,19 @@ const ProjectSummary = props => {
                     </div>
                   ))
                 : null}
-              {userDefinedStrategy && userDefinedStrategy.comment.length > 0 ? (
+              {userDefinedStrategy.calcValue &&
+              userDefinedStrategy.comment.length > 0 ? (
                 <div>
-                  <div className={classes.ruleName}></div>
+                  <div className={classes.ruleName}>
+                    Details about User Defined Strategy
+                  </div>
                   <div
                     className={clsx(
                       "justify-content-center",
                       classes.summaryContainer
                     )}
                   >
-                    Explanation: {userDefinedStrategy.comment}
+                    {userDefinedStrategy.comment}
                   </div>
                 </div>
               ) : null}


### PR DESCRIPTION
#850 User strategy entered on 4th page now appears on 5th(Summary) page.
<img width="1440" alt="Screen Shot 2021-08-05 at 6 01 17 PM" src="https://user-images.githubusercontent.com/30099154/128440448-717bf5fe-7276-42b7-a5ba-0e428ac28aa9.png">
![Uploading Screen Shot 2021-08-05 at 6.01.20 PM.png…]()
