### PR TITLE
Add progress bar, shopping cart to sidebar

### DIFF
--- a/client/src/components/ProjectWizard/RuleStrategy/RuleStrategy.js
+++ b/client/src/components/ProjectWizard/RuleStrategy/RuleStrategy.js
@@ -149,9 +149,11 @@ const RuleStrategy = ({
             : null}
         </div>
         <div className={classes.points}>
-          {`${calcValue ? Math.round(calcValue * 100) / 100 : ""} ${
-            calculationUnits || ""
-          }`}
+          {`${
+            calcValue
+              ? Math.round(calcValue * 100) / 100 + " " + calculationUnits || ""
+              : ""
+          } `}
         </div>
       </React.Fragment>
     );

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -159,6 +159,7 @@ const TdmCalculationWizard = props => {
             rules={rules}
             onViewChange={onViewChange}
             resultRules={resultRules}
+            strategyRules={strategyRules}
           />
         )}
         contentContainerRef={contentContainerRef}

--- a/client/src/components/ProjectWizard/WizardSidebar/EarnedPointsProgress.js
+++ b/client/src/components/ProjectWizard/WizardSidebar/EarnedPointsProgress.js
@@ -1,0 +1,217 @@
+import React, { useRef } from "react";
+import PropTypes from "prop-types";
+import { createUseStyles, useTheme } from "react-jss";
+import ToolTipIcon from "../../ToolTip/ToolTipIcon";
+import clsx from "clsx";
+
+/* 
+See https://css-tricks.com/building-progress-ring-quickly/
+
+for explanation of operation
+*/
+
+const DIAL_RADIUS = 95;
+const STROKE_WIDTH = 15;
+
+const useStyles = createUseStyles({
+  rotate: {
+    transform: "rotate(75deg)"
+  },
+  progress: {
+    transition: "stroke-dashoffset 18s"
+  },
+  tooltip: {
+    color: "rgb(30, 36, 63) !important",
+    padding: "15px",
+    minWidth: "200px",
+    maxWidth: "400px",
+    fontFamily: "Arial",
+    fontSize: 12,
+    lineHeight: "16px",
+    fontWeight: "bold",
+    boxShadow: "0px 0px 8px rgba(0, 46, 109, 0.2)",
+    borderRadius: 2,
+    "&.show": {
+      visibility: "visible !important",
+      opacity: "1 !important"
+    }
+  },
+  lowOpacity: {
+    opacity: 0.4
+  },
+  noDisplay: {
+    display: "none !important"
+  }
+});
+
+const EarnedPointsProgress = props => {
+  const theme = useTheme();
+  const classes = useStyles({ theme });
+  const controlRef = useRef(null);
+
+  const { rulesConfig } = props;
+  const radius = DIAL_RADIUS;
+  const stroke = STROKE_WIDTH;
+
+  const target = rulesConfig.targetPointsRule.value || 0;
+  const earned = rulesConfig.earnedPointsRule.value || 0;
+
+  const normalizedRadius = radius - stroke * 2;
+  const circumference = normalizedRadius * 2 * Math.PI;
+  const strokeDashoffset = Math.max(
+    0,
+    circumference - (earned / target) * 0.85 * circumference
+  );
+
+  return (
+    <div
+      ref={controlRef}
+      className={
+        target > 0
+          ? "tdm-calculation-progress"
+          : clsx("tdm-calculation-progress", classes.lowOpacity)
+      }
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr",
+        gridTemplateRows: "1fr",
+        justifyContent: "center"
+      }}
+    >
+      <div
+        style={{
+          gridColumn: 1,
+          gridRow: 1,
+          zIndex: 4,
+          fontFamily: "Oswald",
+          fontSize: "48px",
+          fontWeight: "700",
+          color: "black",
+          justifySelf: "center",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          letter: "1%"
+        }}
+      >
+        <div>{earned}</div>
+        <div
+          style={{
+            fontSize: "16px",
+            fontWeight: "700",
+            lineHeight: "24px"
+          }}
+        >
+          EARNED
+        </div>
+      </div>
+      <div
+        style={{
+          gridColumn: 1,
+          gridRow: 1,
+          zIndex: 4,
+          fontFamily: "Oswald",
+          fontSize: "22px",
+          fontWeight: "700",
+          color: theme.colorDefault,
+          justifySelf: "center",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          marginLeft: "99px",
+          marginTop: "90px"
+        }}
+      >
+        <div>{target}</div>
+        <div
+          style={{
+            fontSize: "14px"
+          }}
+        >
+          TARGET
+        </div>
+      </div>
+      <div
+        data-tip={
+          "<p>" +
+          rulesConfig.earnedPointsRule.description +
+          "</p><p>" +
+          rulesConfig.targetPointsRule.description +
+          "</p>"
+        }
+        data-iscapture="true"
+        data-html="true"
+        data-class={
+          target > 0
+            ? classes.tooltip
+            : clsx(classes.tooltip, classes.noDisplay)
+        }
+        style={{
+          gridRow: 1,
+          gridColumn: 1,
+          zIndex: 10,
+          marginLeft: 170,
+          marginTop: 45
+        }}
+      >
+        <ToolTipIcon />
+      </div>
+      <svg
+        className={classes.rotate}
+        style={{
+          width: radius * 2,
+          height: radius * 2,
+          gridColumn: "1",
+          gridRow: "1",
+          overflow: "visible"
+        }}
+      >
+        <circle
+          stroke="#CFCFCF"
+          fill={theme.colorDefault}
+          strokeWidth={stroke}
+          r={normalizedRadius}
+          cx={radius}
+          cy={radius}
+        />
+        <circle
+          stroke={
+            earned / target >= 1
+              ? theme.colorPrimary
+              : earned / target >= 0.01
+              ? theme.colorEarnedPoints
+              : theme.colorDisabled
+          }
+          fill="transparent"
+          strokeWidth={stroke}
+          strokeDasharray={circumference + " " + circumference}
+          strokeLinecap="round"
+          style={{
+            strokeDashoffset
+          }}
+          r={normalizedRadius}
+          cx={radius}
+          cy={radius}
+        />
+        <circle
+          stroke={theme.colorPrimary}
+          fill={theme.colorPrimary}
+          r="28"
+          cx="154"
+          cy="61"
+          style={{
+            gridColumn: 1,
+            gridRow: 1,
+            zIndex: -1
+          }}
+        />
+      </svg>
+    </div>
+  );
+};
+
+EarnedPointsProgress.propTypes = {
+  rulesConfig: PropTypes.object
+};
+
+export default EarnedPointsProgress;

--- a/client/src/components/ProjectWizard/WizardSidebar/SidebarCart.js
+++ b/client/src/components/ProjectWizard/WizardSidebar/SidebarCart.js
@@ -1,0 +1,98 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { createUseStyles } from "react-jss";
+
+const useStyles = createUseStyles({
+  noDisplay: {
+    display: "none !important"
+  }
+});
+
+const SidebarCart = props => {
+  const { strategyRules } = props;
+  const classes = useStyles();
+  return (
+    <div width="100%">
+      <div
+        style={{
+          flexBasis: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column"
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            borderBottom: "2px solid black"
+          }}
+        >
+          <div style={{ fontSize: "16pt", weight: "bold", textAlign: "left" }}>
+            TDM MEASURES SELECTED
+          </div>
+          <div
+            style={{
+              fontSize: "12pt",
+              weight: "500",
+              textAlign: "right",
+              marginBottom: "2px"
+            }}
+          >
+            EARNED POINTS
+          </div>
+        </div>
+        <hr />
+
+        {strategyRules
+          .filter(r => r.calcValue > 0)
+          .map(rule => (
+            <div
+              key={rule.code}
+              style={{
+                display: "flex",
+                justifyContent: "space-between"
+              }}
+            >
+              <div
+                style={{
+                  fontSize: "16px",
+                  fontFamily: "Calibri",
+                  lineHeight: "18px",
+                  marginTop: "5px"
+                }}
+                classes={strategyRules ? "" : classes.noDisplay}
+              >
+                {rule.name}
+              </div>
+              <div style={{ textAlign: "right" }}>
+                <span
+                  style={{
+                    fontSize: "18px",
+                    fontFamily: "Oswald"
+                  }}
+                >
+                  {Math.round(rule.calcValue * 100) / 100}
+                </span>
+                <span
+                  style={{
+                    fontSize: "14px",
+                    fontFamily: "Calibri",
+                    marginBottom: "10px"
+                  }}
+                >
+                  &nbsp;pts
+                </span>
+              </div>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+};
+
+SidebarCart.propTypes = {
+  strategyRules: PropTypes.array
+};
+
+export default SidebarCart;

--- a/client/src/components/ProjectWizard/WizardSidebar/SidebarPointsPanel.js
+++ b/client/src/components/ProjectWizard/WizardSidebar/SidebarPointsPanel.js
@@ -1,46 +1,32 @@
-import React, { useEffect, useState } from "react";
+import React /*, { useEffect, useState } */ from "react";
 import PropTypes from "prop-types";
-import SidebarPoints from "./SidebarPoints";
+// import SidebarPoints from "./SidebarPoints";
 import SidebarProjectLevel from "./SidebarProjectLevel";
-import EarnedPointsMetContainer from "./EarnedPointsMetContainer";
+// import EarnedPointsMetContainer from "./EarnedPointsMetContainer";
+import EarnedPointsProgress from "./EarnedPointsProgress";
+import SidebarCart from "./SidebarCart";
+// import ToolTip from "../../ToolTip/ToolTip";
 
 const SidebarPointsPanel = props => {
-  const { rules } = props;
+  const { rules, strategyRules } = props;
   let targetPointsRule = {};
   let earnedPointsRule = {};
   let projectLevelRule = {};
   if (rules) {
-    targetPointsRule = rules.filter(
-      rule => rule.code === "TARGET_POINTS_PARK"
-    )[0];
-    earnedPointsRule = rules.filter(rule => rule.code === "PTS_EARNED")[0];
-    projectLevelRule = rules.filter(rule => rule.code === "PROJECT_LEVEL")[0];
+    targetPointsRule = rules.find(rule => rule.code === "TARGET_POINTS_PARK");
+    earnedPointsRule = rules.find(rule => rule.code === "PTS_EARNED");
+    projectLevelRule = rules.find(rule => rule.code === "PROJECT_LEVEL");
   }
 
-  const rulesConfig = {
-    target: {
-      value: rules[2].value
-    },
-    earned: {
-      value: rules[3].value
-    }
-  };
+  // const targetPoints = targetPointsRule ? targetPointsRule.value : null;
+  // const earnedPoints = earnedPointsRule ? earnedPointsRule.value : null;
+  const rulesConfig = { targetPointsRule, earnedPointsRule };
 
-  const target = rulesConfig.target.value;
-  const earned = rulesConfig.earned.value;
+  // const [earnedPointsMet, setEarnedPointsMet] = useState(false);
 
-  const targetPointsTipText = rules[2].description;
-  const earnedPointsTipText = rules[3].description;
-
-  const [earnedPointsMet, setEarnedPointsMet] = useState(false);
-
-  useEffect(() => {
-    if (earned >= target && target > 0) {
-      setEarnedPointsMet(true);
-    } else {
-      setEarnedPointsMet(false);
-    }
-  }, [earned, target]);
+  // useEffect(() => {
+  //   setEarnedPointsMet(earnedPoints >= targetPoints && targetPoints > 0);
+  // }, [earnedPoints, targetPoints]);
 
   return (
     <React.Fragment>
@@ -52,28 +38,48 @@ const SidebarPointsPanel = props => {
           rules={rules}
         />
       </div>
-      <hr className="tdm-divider" />
-      <div className="tdm-results-panel">
+      {/* <hr className="tdm-divider" /> */}
+      {/* <div className="tdm-results-panel">
         <SidebarPoints
           key={targetPointsRule.id}
           rule={targetPointsRule}
           rulesConfig={rulesConfig}
-          tipText={targetPointsTipText}
+          tipText={targetPointsRuleDescription}
         />
         <SidebarPoints
           key={earnedPointsRule.id}
           rule={earnedPointsRule}
           rulesConfig={rulesConfig}
-          tipText={earnedPointsTipText}
+          tipText={earnedPointsRule.desccription}
+        />
+      </div> */}
+      <div className="tdm-calculation-progress">
+        <EarnedPointsProgress
+          key={targetPointsRule.id}
+          rulesConfig={rulesConfig}
         />
       </div>
-      {earnedPointsMet && <EarnedPointsMetContainer />}
+
+      <div
+        style={
+          earnedPointsRule && earnedPointsRule.value
+            ? {}
+            : { visibility: "hidden" }
+        }
+        className="tdm-calculation-cart"
+      >
+        <SidebarCart strategyRules={strategyRules} />
+      </div>
+
+      {/* {earnedPointsMet && <EarnedPointsMetContainer />} */}
+      {/* <ToolTip /> */}
     </React.Fragment>
   );
 };
 
 SidebarPointsPanel.propTypes = {
-  rules: PropTypes.array
+  rules: PropTypes.array,
+  strategyRules: PropTypes.array
 };
 
 export default SidebarPointsPanel;

--- a/client/src/components/ProjectWizard/WizardSidebar/SidebarProjectLevel.js
+++ b/client/src/components/ProjectWizard/WizardSidebar/SidebarProjectLevel.js
@@ -7,7 +7,7 @@ import clsx from "clsx";
 const useStyles = createUseStyles({
   projectLevelHeader: {
     color: "white",
-    fontSize: 20,
+    fontSize: 18,
     fontFamily: "Oswald, Calibri",
     fontWeight: 500,
     textAlign: "center",
@@ -15,10 +15,10 @@ const useStyles = createUseStyles({
   },
   projectLevelValue: {
     color: "white",
-    fontSize: 100,
+    fontSize: 80,
     fontFamily: "Oswald, Calibri",
     fontWeight: "bold",
-    marginBottom: 0,
+    marginBottom: "-12px",
     textAlign: "center",
     lineHeight: "1.1em"
   },

--- a/client/src/components/ProjectWizard/WizardSidebar/WizardSidebar.js
+++ b/client/src/components/ProjectWizard/WizardSidebar/WizardSidebar.js
@@ -19,7 +19,7 @@ const useStyles = createUseStyles({
   }
 });
 
-const WizardSidebar = ({ rules, onViewChange, resultRules }) => {
+const WizardSidebar = ({ rules, onViewChange, resultRules, strategyRules }) => {
   const classes = useStyles();
 
   return (
@@ -29,7 +29,10 @@ const WizardSidebar = ({ rules, onViewChange, resultRules }) => {
           <SwitchViewButton onViewChange={onViewChange} isDisplayed={false}>
             Switch to Single Page View
           </SwitchViewButton>
-          <SidebarPointsPanel rules={resultRules} />
+          <SidebarPointsPanel
+            rules={resultRules}
+            strategyRules={strategyRules}
+          />
         </div>
       )}
     </Sidebar>
@@ -39,7 +42,8 @@ const WizardSidebar = ({ rules, onViewChange, resultRules }) => {
 WizardSidebar.propTypes = {
   rules: PropTypes.any,
   onViewChange: PropTypes.any,
-  resultRules: PropTypes.any
+  resultRules: PropTypes.any,
+  strategyRules: PropTypes.array
 };
 
 export default WizardSidebar;

--- a/client/src/styles/Calculation.scss
+++ b/client/src/styles/Calculation.scss
@@ -100,11 +100,40 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  flex-basis: 50%;
+  flex-basis: 25%;
+  flex-grow: 0;
   margin: 0;
   padding: 0.5em;
   background-color: transparent;
   color: $color-background;
+}
+
+.tdm-calculation-progress {
+  flex-basis: 25%;
+  flex-grow: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0.5em;
+  background-color: transparent;
+  color: $color-background;
+}
+
+.tdm-calculation-cart {
+  flex-basis: 50%;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  align-items: stretch;
+  justify-content: flex-start;
+  background-color: #f7f9fa;
+  font-family: Oswald;
+  padding: 10px;
+  line-height: 1.5em;
+  color: $color-primary;
+  overflow-y: scroll;
 }
 
 .tdm-wizard-review-page {
@@ -118,5 +147,10 @@
 @media (max-width: 768px) {
   .tdm-results-panel {
     top: 0;
+  }
+
+  // Hide the Shopping Cart on narrow devices
+  .tdm-calculation-cart {
+    display: none;
   }
 }


### PR DESCRIPTION
Fixes Issues #909, #908

Replace Target and Earned Points with a circular progress bar per design described in Issue #908.
Add Shopping Car to sidebar as descrivbed in Issue #874 
Modify Strategies page to hide "pts" under Earned Points column until/unless the strategy is selected.