### PR TITLE
Add config for trusting sql server certificate

### DIFF
--- a/server/app/services/tedious-pool.js
+++ b/server/app/services/tedious-pool.js
@@ -29,6 +29,10 @@ var config = process.env.SQL_SERVER_INSTANCE
       }
     };
 
+if (process.env.SQL_TRUST_SERVER_CERTIFICATE) {
+  config.options.trustServerCertificate = true;
+}
+
 const pool = new sql.ConnectionPool(config);
 const poolConnect = pool.connect();
 


### PR DESCRIPTION
This is necessary because node-mssql v7 defaults to not trusting
self-signed certificate

Closes #932 