### PR TITLE
Minor tweak to Issue 932

### DIFF
--- a/server/app/services/tedious-pool.js
+++ b/server/app/services/tedious-pool.js
@@ -29,7 +29,7 @@ var config = process.env.SQL_SERVER_INSTANCE
       }
     };
 
-if (process.env.SQL_TRUST_SERVER_CERTIFICATE) {
+if (process.env.SQL_TRUST_SERVER_CERTIFICATE === "true") {
   config.options.trustServerCertificate = true;
 }
 


### PR DESCRIPTION
Fixes #932 
Original fix was written such that any nont-null value of SQL_TRUST_SERVER_CERTIFICATE was interpreted as true.
Modified so that only the value of "true" is interpreted as true, so, for example

```
SQL_TRUST_SERVER_CERTIFICATE=false
```
is now evaluated to false, as it should be set for all environments except a db running in a local docker container.

Also updated the .env file on the G-Drive to reflect the appropriate setting for each environment.