### PR TITLE
border, margins, and alignment fixed

### DIFF
--- a/client/src/components/Authorization/Login.js
+++ b/client/src/components/Authorization/Login.js
@@ -33,8 +33,10 @@ const Login = props => {
   const { setLoggedInAccount, match } = props;
   const history = useHistory();
   const [errorMsg, setErrorMsg] = useState("");
-  const [withoutSavingWarningIsVisible, setWithoutSavingWarningIsVisible] =
-    useState(false);
+  const [
+    withoutSavingWarningIsVisible,
+    setWithoutSavingWarningIsVisible
+  ] = useState(false);
   const classes = useStyles({ withoutSavingWarningIsVisible });
 
   const initialValues = {

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectSummary.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectSummary.js
@@ -90,9 +90,7 @@ const useStyles = createUseStyles({
     minWidth: "180px",
     maxWidth: "100%",
     marginRight: "3em",
-    border: "1px 	#E7EBF0 solid",
-    borderRadius: "5px",
-    marginTop: "8px",
+    marginTop: "4px",
     padding: "12px"
   }
 });
@@ -211,14 +209,11 @@ const ProjectSummary = props => {
                 <div>
                   <div className={classes.rule}>
                     <div className={classes.ruleName}>
-                      Details about User Defined Strategy
+                      User-Defined Strategy Details
                     </div>
                   </div>
                   <div
-                    className={clsx(
-                      "justify-content-center",
-                      classes.summaryContainer
-                    )}
+                    className={clsx("border-gray", classes.summaryContainer)}
                   >
                     {userDefinedStrategy.comment}
                   </div>


### PR DESCRIPTION
#850 
1. Alignment moved to the left.

2. Spelling for User-Defined Strategy Details

3.Margin for summary text fixed.

4. Using class for the "Earned" box border at the top. borders should be identical now.

5. No coding changes, but can't seem to replicate this issue. Contacting Fang to see if he fixed it without notifying me. I'll keep an eye on it.