### PR TITLE
Hide tooltip icon for package strategies

### DIFF
--- a/client/src/components/ToolTip/ToolTipLabel.js
+++ b/client/src/components/ToolTip/ToolTipLabel.js
@@ -76,7 +76,10 @@ const ToolTipLabel = ({
       data-html="true"
     >
       {children}
-      {tooltipContent && code && !code.startsWith("STRATEGY") ? (
+      {tooltipContent &&
+      code &&
+      !code.startsWith("STRATEGY") &&
+      !code.startsWith("PKG") ? (
         <ToolTipIcon />
       ) : null}
     </label>


### PR DESCRIPTION
The package strategies at the top aren't showing tooltip icons anymore
![2021-09-26 21 26 32 localhost 1d0c1bf8ed41 crop](https://user-images.githubusercontent.com/1160105/134845700-e0378c2c-25be-420e-bf49-4edb5eb06e6c.png)


Closes #940