### PR TITLE
Issue 1071 re-word pkg tooltip, Issue 1163 only apply pkg if provided…

### DIFF
--- a/client/src/components/ProjectWizard/PackagePanel/PackageTooltips.js
+++ b/client/src/components/ProjectWizard/PackagePanel/PackageTooltips.js
@@ -130,18 +130,13 @@ export const TooltipResidential = () => {
         </div>
       </div>
       <p>
-        There are many TDM strategies choices and most involve making long-term
-        commitments in meeting program compliance. Small development projects
-        (defined as Program Level 1 that provide no more than the parking
-        baseline), are provided one or more TDM packages that allow fulfillment
-        of the minimum 15 point target from a pre-selected menu. A point
-        incentive is provided for the packages made up of strategies that work
+        {`Small development projects (Program Level 1) that provide parking 
+        less than 110% of baseline are eligible for one or 
+        more TDM packages that allow the fulfillment of the minimum 15-point target. 
+        A bonus point is awarded for a package that is made up of strategies that work 
         together to reinforce their effectiveness in reducing drive-alone trips.
-        Each strategy selected on its own does not result in the required
-        minimum point target but several selected together will. Each package
-        can be unselected and individual strategies that will work best to both
-        achieve the TDM program goal and your specific development objectives
-        should be chosen.
+        Bonus Packages may not be ideal for all projects but are a way to provide easy 
+        compliance and implementation for small projects.`}
       </p>
     </>
   );
@@ -199,18 +194,13 @@ export const TooltipSchool = () => {
         </div>
       </div>
       <p>
-        There are many TDM strategies choices and most involve making long-term
-        commitments in meeting program compliance. Small development projects
-        (defined as Program Level 1 that provide no more than the parking
-        baseline), are provided one or more TDM packages that allow fulfillment
-        of the minimum 15 point target from a pre-selected menu. A point
-        incentive is provided for the packages made up of strategies that work
+        {`Small development projects (Program Level 1) that provide parking less than
+        110% of baseline are eligible for one or 
+        more TDM packages that allow the fulfillment of the minimum 15-point target. 
+        A bonus point is awarded for a package that is made up of strategies that work 
         together to reinforce their effectiveness in reducing drive-alone trips.
-        Each strategy selected on its own does not result in the required
-        minimum point target but several selected together will. Each package
-        can be unselected and individual strategies that will work best to both
-        achieve the TDM program goal and your specific development objectives
-        should be chosen.
+        Bonus Packages may not be ideal for all projects but are a way to provide easy 
+        compliance and implementation for small projects.`}
       </p>
     </>
   );

--- a/client/src/components/TdmCalculationContainer.js
+++ b/client/src/components/TdmCalculationContainer.js
@@ -276,12 +276,23 @@ export function TdmCalculationContainer({
       r =>
         r.code.startsWith("LAND_USE") && r.code !== "LAND_USE_SCHOOL" && r.value
     );
-    return !!(projectLevel === 1 && applicableLandUse);
+    const lowParkRatio = rules.find(
+      r => r.code === "CALC_PARK_RATIO" && r.value < 110
+    );
+    return !!(projectLevel === 1 && applicableLandUse && lowParkRatio);
   })();
 
   const allowSchoolPackage = (() => {
     const triggerRule = landUseRules.filter(r => r.code === "LAND_USE_SCHOOL");
-    return !!(projectLevel === 1 && triggerRule[0] && triggerRule[0].value);
+    const lowParkRatio = rules.find(
+      r => r.code === "CALC_PARK_RATIO" && r.value < 110
+    );
+    return !!(
+      projectLevel === 1 &&
+      triggerRule[0] &&
+      triggerRule[0].value &&
+      lowParkRatio
+    );
   })();
 
   const getRuleByCode = ruleCode => {


### PR DESCRIPTION
Modify Packages to only apply to Level 1 Projects where parking provided < 110% of citywide parking baseline.
Fixes #1071 Fixes #1163. I needed to modify the wording of the tooltip for Issue 1071 to be consistent with the change of Issue #1163.