### PR TITLE
1143 update project 0 prompt link to revised tdm ordinance

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-lerna run lint
+npx lerna run lint

--- a/client/src/components/ProjectWizard/WizardPages/Level0Page.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/Level0Page.jsx
@@ -65,7 +65,7 @@ const Level0Page = ({ isLevel0 }) => {
                 your project due to its smaller size. Please check LAMC Section
                 12.26 J.3(c) of the{" "}
                 <a
-                  href="https://planning.lacity.org/odocument/1dc924ce-b94a-403b-afe0-17ba33b3dbe1/Draft_TDM_Ordinance.pdf"
+                  href="https://planning.lacity.org/odocument/bb9114b3-29e3-423f-8b91-027afb242e63/Revised_DRAFT_TDMOrdinance_June2022.pdf"
                   target="external"
                 >
                   Draft Revised TDM Ordinance{" "}


### PR DESCRIPTION
Closes #1143

Updated link to the June 2002 url

Screenshot below showing updated link when hovering over link text.
![Screenshot from 2022-07-13 15-10-45](https://user-images.githubusercontent.com/1160105/178846149-4ad8d9a8-f722-4cb6-bd16-a4c6e60dc118.png)
