### PR TITLE
1282 fix modal dialog backdrop

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -56,7 +56,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -80,7 +79,6 @@
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
       "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -89,7 +87,6 @@
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.10.tgz",
       "integrity": "sha512-liKoppandF3ZcBnIYFjfSDHZLKdLHGJRkoWtG8zQyGJBQfIYobpnVGI5+pLBNtS6psFLDzyq8+h5HiVljW9PNA==",
-      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -137,7 +134,6 @@
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.10.tgz",
       "integrity": "sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.17.10",
         "@jridgewell/gen-mapping": "^0.1.0",
@@ -176,7 +172,6 @@
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.10.tgz",
       "integrity": "sha512-gh3RxjWbauw/dFiU/7whjd0qN9K6nPJMqe6+Er7rOavFh0CQUSwhAE3IcTho2rywPJFxej6TUUHDkWcYI6gGqQ==",
-      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.17.10",
         "@babel/helper-validator-option": "^7.16.7",
@@ -250,7 +245,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
       "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.16.7"
       },
@@ -274,7 +268,6 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
       "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.16.7",
         "@babel/types": "^7.17.0"
@@ -287,7 +280,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
       "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.16.7"
       },
@@ -322,7 +314,6 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
       "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-module-imports": "^7.16.7",
@@ -391,7 +382,6 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
       "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.17.0"
       },
@@ -415,7 +405,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
       "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.16.7"
       },
@@ -435,7 +424,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
       "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -459,7 +447,6 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
       "integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.16.7",
         "@babel/traverse": "^7.17.9",
@@ -486,7 +473,6 @@
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
       "integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==",
-      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1862,7 +1848,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
       "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
         "@babel/parser": "^7.16.7",
@@ -1876,7 +1861,6 @@
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.10.tgz",
       "integrity": "sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
         "@babel/generator": "^7.17.10",
@@ -2977,7 +2961,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -2990,7 +2973,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
       "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2999,7 +2981,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
       "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -3007,14 +2988,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-      "dev": true
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
       "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -5818,7 +5797,6 @@
       "version": "4.20.3",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
       "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5946,7 +5924,6 @@
       "version": "1.0.30001340",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001340.tgz",
       "integrity": "sha512-jUNz+a9blQTQVu4uFcn17uAD8IDizPzQkIKh3LCJfg9BkyIqExYYdyc/ZSlWUSKb8iYiXxKsxbv4zYSvkqjrxw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7035,7 +7012,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -7462,8 +7438,7 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.137",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
-      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
-      "dev": true
+      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA=="
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -7613,7 +7588,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9243,7 +9217,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -9393,7 +9366,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -12332,7 +12304,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -12373,7 +12344,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -13230,8 +13200,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multicast-dns": {
       "version": "7.2.4",
@@ -13370,8 +13339,7 @@
     "node_modules/node-releases": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
-      "dev": true
+      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -13871,8 +13839,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -16815,7 +16782,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -19378,7 +19344,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
-      "dev": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -19395,14 +19360,12 @@
     "@babel/compat-data": {
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
-      "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==",
-      "dev": true
+      "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw=="
     },
     "@babel/core": {
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.10.tgz",
       "integrity": "sha512-liKoppandF3ZcBnIYFjfSDHZLKdLHGJRkoWtG8zQyGJBQfIYobpnVGI5+pLBNtS6psFLDzyq8+h5HiVljW9PNA==",
-      "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -19436,7 +19399,6 @@
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.10.tgz",
       "integrity": "sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.17.10",
         "@jridgewell/gen-mapping": "^0.1.0",
@@ -19466,7 +19428,6 @@
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.10.tgz",
       "integrity": "sha512-gh3RxjWbauw/dFiU/7whjd0qN9K6nPJMqe6+Er7rOavFh0CQUSwhAE3IcTho2rywPJFxej6TUUHDkWcYI6gGqQ==",
-      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.17.10",
         "@babel/helper-validator-option": "^7.16.7",
@@ -19519,7 +19480,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
       "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.16.7"
       }
@@ -19537,7 +19497,6 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
       "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.16.7",
         "@babel/types": "^7.17.0"
@@ -19547,7 +19506,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
       "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.16.7"
       }
@@ -19573,7 +19531,6 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
       "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
-      "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-module-imports": "^7.16.7",
@@ -19627,7 +19584,6 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
       "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.17.0"
       }
@@ -19645,7 +19601,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
       "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.16.7"
       }
@@ -19658,8 +19613,7 @@
     "@babel/helper-validator-option": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
-      "dev": true
+      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ=="
     },
     "@babel/helper-wrap-function": {
       "version": "7.16.8",
@@ -19677,7 +19631,6 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
       "integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.16.7",
         "@babel/traverse": "^7.17.9",
@@ -19697,8 +19650,7 @@
     "@babel/parser": {
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
-      "integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==",
-      "dev": true
+      "integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ=="
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.16.7",
@@ -20612,7 +20564,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
       "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
         "@babel/parser": "^7.16.7",
@@ -20623,7 +20574,6 @@
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.10.tgz",
       "integrity": "sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
         "@babel/generator": "^7.17.10",
@@ -20747,13 +20697,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-1.0.1.tgz",
       "integrity": "sha512-f1G1WGDXEU/RN1TWAxBPQgQudtLnLQPyiWdtypkPC+mVYNKFKH/HYXSxH4MVNqwF8M0eDsoiU7HumJHCg/L/jg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@csstools/selector-specificity": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-1.0.0.tgz",
       "integrity": "sha512-RkYG5KiGNX0fJ5YoI0f4Wfq2Yo74D25Hru4fxTOioYdQvHBxcrrtTTyT5Ozzh2ejcNrhFy7IEts2WyEY7yi5yw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@emotion/babel-plugin": {
       "version": "11.7.2",
@@ -21412,7 +21364,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-      "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -21421,26 +21372,22 @@
     "@jridgewell/resolve-uri": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-      "dev": true
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA=="
     },
     "@jridgewell/set-array": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
-      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
-      "dev": true
+      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ=="
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-      "dev": true
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
       "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
-      "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -22145,7 +22092,8 @@
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.2.0.tgz",
       "integrity": "sha512-+hIlG4nJS6ivZrKnOP7OGsDu9Fxmryj9vCl8x0ZINtTJcCHs2zLsYif5GzuRiBF2ck5GZG2aQr7Msg+EHlnYVQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -22909,13 +22857,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -23022,7 +22972,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -23368,7 +23319,8 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
       "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
@@ -23648,7 +23600,6 @@
       "version": "4.20.3",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
       "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001332",
         "electron-to-chromium": "^1.4.118",
@@ -23735,8 +23686,7 @@
     "caniuse-lite": {
       "version": "1.0.30001340",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001340.tgz",
-      "integrity": "sha512-jUNz+a9blQTQVu4uFcn17uAD8IDizPzQkIKh3LCJfg9BkyIqExYYdyc/ZSlWUSKb8iYiXxKsxbv4zYSvkqjrxw==",
-      "dev": true
+      "integrity": "sha512-jUNz+a9blQTQVu4uFcn17uAD8IDizPzQkIKh3LCJfg9BkyIqExYYdyc/ZSlWUSKb8iYiXxKsxbv4zYSvkqjrxw=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -24216,7 +24166,8 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
       "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "css-has-pseudo": {
       "version": "3.0.4",
@@ -24329,7 +24280,8 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
       "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "css-select": {
       "version": "4.3.0",
@@ -24453,7 +24405,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
       "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -24537,7 +24490,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -24868,8 +24820,7 @@
     "electron-to-chromium": {
       "version": "1.4.137",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
-      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
-      "dev": true
+      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -24988,8 +24939,7 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -25207,7 +25157,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-react-app": {
       "version": "7.0.1",
@@ -25487,7 +25438,8 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
       "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-testing-library": {
       "version": "5.5.0",
@@ -26179,8 +26131,7 @@
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -26289,8 +26240,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
       "version": "11.0.4",
@@ -26624,7 +26574,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "idb": {
       "version": "6.1.5",
@@ -27666,7 +27617,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -28450,8 +28402,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -28485,8 +28436,7 @@
     "json5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-      "dev": true
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -29160,8 +29110,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
       "version": "7.2.4",
@@ -29273,8 +29222,7 @@
     "node-releases": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
-      "dev": true
+      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -29639,8 +29587,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.0",
@@ -29786,7 +29733,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
       "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-calc": {
       "version": "8.2.4",
@@ -29859,7 +29807,8 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
       "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-custom-properties": {
       "version": "12.1.7",
@@ -29892,25 +29841,29 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.1.tgz",
       "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
       "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
       "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
       "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-double-position-gradients": {
       "version": "3.1.1",
@@ -29935,7 +29888,8 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
       "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-focus-visible": {
       "version": "6.0.4",
@@ -29959,13 +29913,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
       "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-gap-properties": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
       "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-image-set-function": {
       "version": "4.0.6",
@@ -29980,7 +29936,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
       "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-js": {
       "version": "4.0.0",
@@ -30058,13 +30015,15 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
       "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
       "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-merge-longhand": {
       "version": "5.1.4",
@@ -30132,7 +30091,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -30197,7 +30157,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
       "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -30293,13 +30254,15 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
       "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
       "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-place": {
       "version": "7.0.4",
@@ -30395,7 +30358,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
       "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-selector-not": {
       "version": "5.0.0",
@@ -31678,8 +31642,7 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "send": {
       "version": "0.18.0",
@@ -32213,7 +32176,8 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "stylehacks": {
       "version": "5.1.0",
@@ -32867,7 +32831,8 @@
     "use-memo-one": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
-      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ=="
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -33173,7 +33138,8 @@
           "version": "8.6.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
           "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -33640,7 +33606,8 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/client/src/components/Button/Button.js
+++ b/client/src/components/Button/Button.js
@@ -6,7 +6,8 @@ import clsx from "clsx";
 const useStyles = createUseStyles({
   button: {
     cursor: "pointer",
-    fontFamily: "Calibri Bold",
+    fontFamily: "Calibri",
+    fontWeight: 700,
     height: "min-content",
     margin: "0.5em",
     padding: "0.5em 1em",

--- a/client/src/components/Button/EditToggleButton.js
+++ b/client/src/components/Button/EditToggleButton.js
@@ -13,6 +13,7 @@ const EditToggleButton = ({ id, onClick, editMode }) => {
       onClick={onClick}
       id={id}
       data-testid={id}
+      style={{ margin: "0" }}
     >
       <>
         <FontAwesomeIcon icon={faFloppyDisk} />

--- a/client/src/components/Checklist/ChecklistContent.js
+++ b/client/src/components/Checklist/ChecklistContent.js
@@ -5,9 +5,6 @@ import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 
 const useStyles = createUseStyles({
   title: {
-    color: "#0F2940",
-    fontFamily: "Calibri Bold",
-    fontSize: "24px",
     margin: "2px"
   },
   text: {
@@ -51,7 +48,7 @@ const ChecklistContent = () => {
   const classes = useStyles();
   return (
     <>
-      <h3 className={classes.title}>Checklist</h3>
+      <h1 className={classes.title}>Checklist</h1>
       <br />
       <p className={classes.text}>
         Listed below are the documents that you may need when using Create

--- a/client/src/components/Faq/Answer.jsx
+++ b/client/src/components/Faq/Answer.jsx
@@ -51,7 +51,7 @@ export const Answer = ({
           style={{ display: "flex" }}
         >
           <p
-            style={{ marginTop: "0.5em", fontWeight: "bold" }}
+            style={{ margin: " 0.5rem 0" }}
             dangerouslySetInnerHTML={{ __html: answer }}
           />
         </div>

--- a/client/src/components/Faq/FaqView.jsx
+++ b/client/src/components/Faq/FaqView.jsx
@@ -302,7 +302,9 @@ const FaqView = ({ isAdmin }) => {
             onClick={handleAdminChange}
           />
         )}
-        <h1 className="tdm-wizard-page-title">Frequently Asked Questions</h1>
+        <h1 className="tdm-wizard-page-title" style={{ margin: "0" }}>
+          Frequently Asked Questions
+        </h1>
         <div className={classes.buttonContainer}>
           {admin ? (
             <AddNewCategoryButton

--- a/client/src/components/Pagination.js
+++ b/client/src/components/Pagination.js
@@ -32,7 +32,8 @@ const useStyles = createUseStyles({
     margin: "0 8px"
   },
   pageLink: {
-    fontFamily: "Calibri Bold",
+    fontFamily: "Calibri",
+    fontWeight: "700",
     margin: "auto 0",
     fontSize: "18px"
   }

--- a/client/src/components/PdfPrint/PdfPrint.js
+++ b/client/src/components/PdfPrint/PdfPrint.js
@@ -89,7 +89,8 @@ const useStyles = createUseStyles({
   textProjectInfoHeaderAddress: {
     color: "rgba(15, 41, 64, .5)",
     fontSize: "16px",
-    fontFamily: "Calibri Bold"
+    fontFamily: "Calibri",
+    fontWeight: 700
   },
   "@media (max-width: 768px)": {
     logoContainer: {

--- a/client/src/components/ProjectWizard/WizardPages/DiscoverTooltips.js
+++ b/client/src/components/ProjectWizard/WizardPages/DiscoverTooltips.js
@@ -15,7 +15,8 @@ const useStyles = createUseStyles({
     flexGrow: "1",
     flexBasis: "50%",
     flexShrink: "1",
-    fontFamily: "Calibri Bold"
+    fontFamily: "Calibri",
+    fontWeight: 700
   }
 });
 

--- a/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.js
@@ -71,11 +71,13 @@ function ProjectMeasure(props) {
 
   return (
     <div>
-      <h1 className="tdm-wizard-page-title">Select TDM Strategies</h1>
-      <h3 className="tdm-wizard-page-subtitle">
+      <h1 style={theme.typography.heading1} margin="0">
+        <span>Select TDM Strategies</span>
+      </h1>
+      <div style={theme.typography.subHeading}>
         Select TDM strategies to earn earn points to reach the Target (left
         panel).
-      </h3>
+      </div>
       {(allowResidentialPackage || allowSchoolPackage) && (
         <>
           <div className={classes.packageBanner}>

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfo.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfo.jsx
@@ -19,7 +19,8 @@ const useStyles = createUseStyles({
   },
   projectInfoDetails: {
     color: "#0F2940",
-    fontFamily: "Calibri Bold",
+    fontFamily: "Calibri",
+    fontWeight: 700,
     fontSize: "16px"
   }
 });

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoContainer.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoContainer.jsx
@@ -14,14 +14,16 @@ const useStyles = createUseStyles({
   textProjectInfoHeader: {
     color: "#0F2940",
     fontSize: "24px",
-    fontFamily: "Calibri Bold",
+    fontFamily: "Calibri",
+    fontWeight: 700,
     paddingLeft: "12px",
     paddingRight: ".8em"
   },
   textProjectInfoHeaderAddress: {
     color: "rgba(15, 41, 64, .5)",
     fontSize: "24px",
-    fontFamily: "Calibri Bold"
+    fontFamily: "Calibri",
+    fontWeight: "700"
   },
   projectInfoDetailsContainer: {
     paddingTop: "6px",

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoList.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoList.jsx
@@ -18,7 +18,8 @@ const useStyles = createUseStyles({
   },
   projectInfoDetails: {
     color: "#0F2940",
-    fontFamily: "Calibri Bold",
+    fontFamily: "Calibri",
+    fontWeight: 700,
     fontSize: "16px"
   },
   AINValuesContainer: {

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectSummary.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectSummary.js
@@ -12,6 +12,7 @@ import MeasureSelected from "./MeasureSelected";
 import PointsEarnedMessage from "./PointsEarnedMessage";
 import LandUses from "./LandUses";
 import Result from "./Result";
+import { useTheme } from "react-jss";
 
 const useStyles = createUseStyles({
   projectSummary: {
@@ -19,9 +20,9 @@ const useStyles = createUseStyles({
     flexDirection: "column",
     flex: "1 1 auto"
   },
-  success: {
-    color: "#A7C539"
-  },
+  // success: {
+  //   color: "#A7C539"
+  // },
   failure: {
     color: "#E46247"
   },
@@ -70,8 +71,8 @@ const useStyles = createUseStyles({
     fontFamily: "Calibri",
     fontWeight: "700",
     fontStyle: "normal",
-    lineHeight: "32px",
-    fontSmoothing: "antialiased"
+    lineHeight: "32px"
+    // fontSmoothing: "antialiased"
   },
   resultsContainer: {
     padding: "30px 0",
@@ -117,6 +118,7 @@ const useStyles = createUseStyles({
 
 const ProjectSummary = props => {
   const classes = useStyles();
+  const theme = useTheme();
   const { rules } = props;
 
   const parkingRequired = getRule(rules, "PARK_REQUIREMENT");
@@ -177,8 +179,10 @@ const ProjectSummary = props => {
 
   return (
     <div className={clsx("tdm-wizard-review-page", classes.projectSummary)}>
-      <h1 className="tdm-wizard-page-title">TDM Calculation Summary</h1>
-      <div className={classes.lastSavedContainer}>
+      <h1 style={{ ...theme.typography.heading1, margin: 0, padding: 0 }}>
+        TDM Calculation Summary
+      </h1>
+      <div style={{ ...theme.typography.paragraph1, margin: 0, padding: 0 }}>
         {props.dateModified && (
           <span className={classes.lastSaved}>
             <FontAwesomeIcon icon={faClock} /> &nbsp;Last saved:{" "}

--- a/client/src/components/ToolTip/ToolTipLabel.js
+++ b/client/src/components/ToolTip/ToolTipLabel.js
@@ -38,8 +38,8 @@ const useStyles = createUseStyles(theme => ({
     flexBasis: "50%",
     "&:hover": {
       cursor: "pointer"
-    },
-    fontSmoothing: "antialiased"
+    }
+    // fontSmoothing: "antialiased"
   },
   tooltip: {
     color: "rgb(30, 36, 63) !important",

--- a/client/src/components/UI/AriaModal/ModalDialog.js
+++ b/client/src/components/UI/AriaModal/ModalDialog.js
@@ -18,6 +18,7 @@ const useStyles = createUseStyles(() => ({
     justifyContent: "center",
     alignItems: "center",
     backgroundColor: "rgba(255, 255, 255, 0.8)",
+    // backgroundColor: "rgba(255, 0,0, 0.8)",
     fontSize: "1rem",
     fontWeight: "normal"
   },
@@ -60,7 +61,7 @@ export default function ModalDialog({
   const classes = useStyles({ theme });
 
   const getApplicationNode = () => {
-    return document.getElementById("root");
+    return document.getElementById("body");
   };
 
   return (
@@ -76,6 +77,7 @@ export default function ModalDialog({
       verticallyCenter={true}
       underlayClickExits={underlayClickExits}
       escapeExits={escapeExits || false}
+      // scrollDisabled={false}
     >
       <div>
         {omitCloseBox ? null : (

--- a/client/src/components/UI/AriaModal/ModalDialog.js
+++ b/client/src/components/UI/AriaModal/ModalDialog.js
@@ -17,7 +17,7 @@ const useStyles = createUseStyles(() => ({
     flexDirection: "column",
     justifyContent: "center",
     alignItems: "center",
-    backgroundColor: "rgba(255, 255, 255, 0.8)",
+    backgroundColor: "rgba(255, 255, 255, 0.7)",
     // backgroundColor: "rgba(255, 0,0, 0.8)",
     fontSize: "1rem",
     fontWeight: "normal"
@@ -33,7 +33,7 @@ const useStyles = createUseStyles(() => ({
     border: "1px solid #d8dce3",
     borderRadius: "0",
     boxSizing: "border-box",
-    boxShadow: "0px 5px 10px rgba(0, 46, 109, 0.8)",
+    boxShadow: "0px 5px 10px rgba(0, 46, 109, 0.5)",
     backgroundColor: "rgba(255, 255, 255, 1)"
   },
   buttonFlexBox: {

--- a/client/src/components/UI/AriaModal/ModalDialog.js
+++ b/client/src/components/UI/AriaModal/ModalDialog.js
@@ -18,7 +18,6 @@ const useStyles = createUseStyles(() => ({
     justifyContent: "center",
     alignItems: "center",
     backgroundColor: "rgba(255, 255, 255, 0.7)",
-    // backgroundColor: "rgba(255, 0,0, 0.8)",
     fontSize: "1rem",
     fontWeight: "normal"
   },

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -28,19 +28,31 @@ body {
   font-family: $font;
   -webkit-text-size-adjust: 100%;
   color: #474747;
+  overflow-y: scroll;
 }
 
 h1 {
-  font-family: "Calibri Bold";
-  font-size: 1.7em;
-  margin-top: 0;
-  margin-bottom: 0;
+  font-weight: bold;
+  font-size: 28px;
+  line-height: 140%;
+}
+
+h2 {
+  font-weight: bold;
+  font-size: 24px;
+  line-height: 140%;
+}
+
+h3 {
+  font-weight: bold;
+  font-size: 20px;
+  line-height: 140%;
 }
 
 p {
-  font-size: 1em;
-  line-height: 1.4em;
-  margin-bottom: 1em;
+  font-weight: normal;
+  font-size: 16px;
+  line-height: 120%;
 }
 
 cite {
@@ -48,8 +60,7 @@ cite {
 }
 
 blockquote {
-  font-family: "Calibri Bold";
-  font-weight: normal;
+  font-weight: 700;
   background-color: #92cc4e;
   color: #474747;
   padding: 1em 2em;
@@ -59,8 +70,7 @@ blockquote {
 }
 
 strong {
-  font-family: "Calibri Bold";
-  font-weight: normal;
+  font-weight: bold;
 }
 
 code {
@@ -103,12 +113,17 @@ abbr {
   color: #cc4e10;
 }
 
-button,
+button {
+  font-family: $font;
+  font-weight: bold;
+  font-size: 16px;
+}
+
 input,
 select,
 textarea {
-  font-family: inherit;
-  font-size: 100%;
+  font-family: $font;
+  font-size: 16px;
   margin: 0 1px 0;
 }
 
@@ -122,7 +137,6 @@ input[type="radio"] {
 // default styles for  links, buttons, etc here?
 // import individual scss files below
 #root {
-  font-family: $font;
   color: $color-primary;
   background-color: $color-background;
 }

--- a/client/src/styles/AuthForms.css
+++ b/client/src/styles/AuthForms.css
@@ -11,7 +11,8 @@
 }
 
 @font-face {
-  font-family: "Calibri Bold";
+  font-family: "Calibri";
+  font-weight: 700;
   src: url("fonts/calibriBold.eot");
   /* IE9 Compat Modes */
   src: url("fonts/calibriBold.eot?#iefix") format("embedded-opentype"),

--- a/client/src/styles/_variables.scss
+++ b/client/src/styles/_variables.scss
@@ -1,30 +1,33 @@
 @import "./_variables_ladot.scss";
 @font-face {
-    font-family: "Calibri";
-    src: url("fonts/calibri.eot"); /* IE9 Compat Modes */
-    src: url("fonts/calibri.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-        url("fonts/calibri.woff2") format("woff2"), /* Super Modern Browsers */
-        url("fonts/calibri.woff") format("woff"), /* Pretty Modern Browsers */
-        url("fonts/calibri.ttf")  format("truetype"), /* Safari, Android, iOS */
-        url("fonts/calibri.svg#svgFontName") format("svg"); /* Legacy iOS */
+  font-family: "Calibri";
+  src: url("fonts/calibri.eot"); /* IE9 Compat Modes */
+  src: url("fonts/calibri.eot?#iefix") format("embedded-opentype"),
+    /* IE6-IE8 */ url("fonts/calibri.woff2") format("woff2"),
+    /* Super Modern Browsers */ url("fonts/calibri.woff") format("woff"),
+    /* Pretty Modern Browsers */ url("fonts/calibri.ttf") format("truetype"),
+    /* Safari, Android, iOS */ url("fonts/calibri.svg#svgFontName")
+      format("svg"); /* Legacy iOS */
 }
 @font-face {
-    font-family: "Calibri Bold";
-    src: url("fonts/calibriBold.eot"); /* IE9 Compat Modes */
-    src: url("fonts/calibriBold.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-        url("fonts/calibriBold.woff2") format("woff2"), /* Super Modern Browsers */
-        url("fonts/calibriBold.woff") format("woff"), /* Pretty Modern Browsers */
-        url("fonts/calibriBold.ttf")  format("truetype"), /* Safari, Android, iOS */
-        url("fonts/calibriBold.svg#svgFontName") format("svg"); /* Legacy iOS */
+  font-family: "Calibri";
+  font-weight: 700;
+  src: url("fonts/calibriBold.eot"); /* IE9 Compat Modes */
+  src: url("fonts/calibriBold.eot?#iefix") format("embedded-opentype"),
+    /* IE6-IE8 */ url("fonts/calibriBold.woff2") format("woff2"),
+    /* Super Modern Browsers */ url("fonts/calibriBold.woff") format("woff"),
+    /* Pretty Modern Browsers */ url("fonts/calibriBold.ttf") format("truetype"),
+    /* Safari, Android, iOS */ url("fonts/calibriBold.svg#svgFontName")
+      format("svg"); /* Legacy iOS */
 }
-  
+
 // font family is dictated by the LADOT style guide
 $font: "Calibri", Arial, sans-serif;
 
-$color-primary: #0F2940; // LADOT Blue
+$color-primary: #0f2940; // LADOT Blue
 $color-secondary: black;
 $color-background: white;
-$color-lightgrey: #D8D8D8;
+$color-lightgrey: #d8d8d8;
 $color-darkgrey: #979797;
 $color-form-lightgrey: $color-lightgrey;
 
@@ -35,6 +38,5 @@ $color-form-lightgrey: $color-lightgrey;
 // using temp color variables until we get feedback/wireframes from ui/ux designers:
 // $color-link: $color-express-park-1 ;
 $color-button: $color-express-park-9;
-
 
 $color-highlight: #a7c539; // Color for Prev/Next  buttons

--- a/client/src/styles/theme.js
+++ b/client/src/styles/theme.js
@@ -32,7 +32,7 @@ module.exports = {
     },
     typography: {
       largeText: {
-        fontFamily: "calibri",
+        fontFamily: "Calibri",
         fontSize: "38px",
         fontWeight: 700,
         lineHeight: "40px",
@@ -41,7 +41,7 @@ module.exports = {
         color: "#000000"
       },
       heading1: {
-        fontFamily: "calibri",
+        fontFamily: "Calibri",
         fontSize: "28px",
         fontWeight: 700,
         lineHeight: "40px",
@@ -50,7 +50,7 @@ module.exports = {
         color: "#000000"
       },
       heading2: {
-        fontFamily: "calibri",
+        fontFamily: "Calibri",
         fontSize: "24px",
         fontWeight: 700,
         lineHeight: "32px",
@@ -59,7 +59,7 @@ module.exports = {
         color: "#000000"
       },
       heading3: {
-        fontFamily: "calibri",
+        fontFamily: "Calibri",
         fontSize: "20px",
         fontWeight: 700,
         lineHeight: "28px",
@@ -68,7 +68,7 @@ module.exports = {
         color: "#000000"
       },
       subHeading: {
-        fontFamily: "calibri",
+        fontFamily: "Calibri",
         fontSize: "20px",
         fontWeight: 400,
         lineHeight: "28px",
@@ -77,7 +77,7 @@ module.exports = {
         color: "#000000"
       },
       paragraph1: {
-        fontFamily: "calibri",
+        fontFamily: "Calibri",
         fontSize: "16px",
         fontWeight: 400,
         lineHeight: "20px",
@@ -86,7 +86,7 @@ module.exports = {
         color: "#000000"
       },
       button: {
-        fontFamily: "calibri",
+        fontFamily: "CSalibri",
         fontSize: "16px",
         fontWeight: 700,
         lineHeight: "20px",

--- a/client/src/styles/theme.js
+++ b/client/src/styles/theme.js
@@ -86,7 +86,7 @@ module.exports = {
         color: "#000000"
       },
       button: {
-        fontFamily: "CSalibri",
+        fontFamily: "Calibri",
         fontSize: "16px",
         fontWeight: 700,
         lineHeight: "20px",


### PR DESCRIPTION
Fixes #1282 Bug where modal backdrop did not cover the entire #body element, which caused the modal content to sometimes be above the viewable area if the screen was scrolled down.  Also adjusted backdrop opacity to be consistent with the Design for the "Laeve the Project Wizard Dialog".

Also modified the App.scss file to agree with the Design System Typography specs, so it is not normally necessary to explicitly apply styles to `<h1> - <h3>, <p> or <button>` elements to get typography consistent with the Design System.  This is a partial fix to Issue #1341.

In several places the text was made bold by applying the "Calibri Bold" font instead of the usual "Calibri" font. Then if the developer attempted to make the font more bold by applying a font-weight of 700, or the <strong> element, it had no effect. Decided to make font "Calibri" throughout the app, and style it as bold by setting the font-weight to "bold" or 700.  This is also helpful in resolving Issue #1341 
