### PR TITLE
Add placeholder, fix answers, reset new FAQ when done editing

### DIFF
--- a/client/src/components/Faq/Answer.jsx
+++ b/client/src/components/Faq/Answer.jsx
@@ -15,6 +15,8 @@ const useStyles = createUseStyles(theme => ({
   },
   answerText: {
     ...theme.typography.subHeading,
+    textAlign: "inherit",
+    padding: 8,
     fontWeight: 22,
     cursor: admin => (admin ? "pointer" : "default"),
     "&:hover": {
@@ -50,6 +52,7 @@ export const Answer = ({
         <div style={{ display: "flex", width: "100%" }}>
           <Quill
             value={answer}
+            placeholder="Answer..."
             onChange={handleAnswerChange}
             className={classes.answerInput}
           />

--- a/client/src/components/Faq/CategoryInput.jsx
+++ b/client/src/components/Faq/CategoryInput.jsx
@@ -15,6 +15,7 @@ const useStyles = createUseStyles(theme => ({
   categoryName: {
     ...theme.typography.heading3,
     fontSize: 24,
+    textAlign: "inherit",
     color: theme.colors.primary.white,
     cursor: admin => (admin ? "pointer" : "default"),
     "&:hover": {

--- a/client/src/components/Faq/FaqCategory.js
+++ b/client/src/components/Faq/FaqCategory.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
 import { NewFaqButton } from "./NewFaqButton";
@@ -83,6 +83,12 @@ const FaqCategory = props => {
     },
     [admin]
   );
+
+  useEffect(() => {
+    if (!admin) {
+      handleCloseNewFAQ();
+    }
+  }, [admin]);
 
   return (
     <>

--- a/client/src/components/Faq/Question.jsx
+++ b/client/src/components/Faq/Question.jsx
@@ -17,6 +17,7 @@ const useStyles = createUseStyles(theme => ({
   },
   questionText: {
     ...theme.typography.heading3,
+    textAlign: "inherit",
     fontSize: 22,
     cursor: admin => (admin ? "pointer" : "default"),
     "&:hover": {


### PR DESCRIPTION
Fixes for issues called out in https://github.com/hackforla/tdm-calculator/issues/1311 9/6/23 meeting:
- Left-Align all Categories and FAQs
- Add 'Answer' placeholder
- Fix HTML divs and links
- Reset 'New FAQ' logic after user clicks 'Save Edits' - this will prevent a blank category or FAQ from persisting after user navigates back to edit mode

Items that need to be worked on:
- Warning dialog for Saving edits