### PR TITLE
Solved issue #1454

### DIFF
--- a/client/src/components/PrivacyPolicy.js
+++ b/client/src/components/PrivacyPolicy.js
@@ -434,7 +434,7 @@ const PrivacyPolicy = () => {
             If you have any questions, comments, concerns, or complaints related
             to our Review Tool websites, please contact us by email at{" "}
             <a href="mailto:privacy@HackforLa.org">
-              TDM-Calculator@hackforla.org
+              tdm@hackforla.org
             </a>
             , or by mail at:
           </p>


### PR DESCRIPTION
Changed the email on the Privacy Policy Page 

✅On the Privacy Policy Page, change the email at the bottom from "[TDM-Calculator@hackforla.org](mailto:TDM-Calculator@hackforla.org)" to "[tdm@hackforla.org](mailto:tdm@hackforla.org)"