### PR TITLE
Add additional check for react-quill tooltip when editing an answer

### DIFF
--- a/client/src/components/Faq/Answer.jsx
+++ b/client/src/components/Faq/Answer.jsx
@@ -37,6 +37,10 @@ export const Answer = ({
 
   const handleSetFAQ = event => {
     // Check if the relatedTarget is within the Answer component
+    const tooltip = document.getElementsByClassName("ql-tooltip");
+    if (!tooltip[0].className.includes("hidden")) {
+      return;
+    }
     if (
       event.relatedTarget &&
       event.currentTarget.contains(event.relatedTarget)
@@ -46,6 +50,7 @@ export const Answer = ({
 
     onSetFaq();
   };
+
   return (
     <div onBlur={handleSetFAQ} className={classes.answerContainer}>
       {isEditAnswer ? (

--- a/client/src/components/Faq/Answer.jsx
+++ b/client/src/components/Faq/Answer.jsx
@@ -38,7 +38,7 @@ export const Answer = ({
   const handleSetFAQ = event => {
     // Check if the relatedTarget is within the Answer component
     const tooltip = document.getElementsByClassName("ql-tooltip");
-    if (!tooltip[0].className.includes("hidden")) {
+    if (tooltip[0].className.includes("editing")) {
       return;
     }
     if (
@@ -54,7 +54,7 @@ export const Answer = ({
   return (
     <div onBlur={handleSetFAQ} className={classes.answerContainer}>
       {isEditAnswer ? (
-        <div style={{ display: "flex", width: "100%" }}>
+        <div tabIndex="0" style={{ display: "flex", width: "100%" }}>
           <Quill
             value={answer}
             placeholder="Answer..."

--- a/client/src/components/Faq/Answer.jsx
+++ b/client/src/components/Faq/Answer.jsx
@@ -54,7 +54,7 @@ export const Answer = ({
   return (
     <div onBlur={handleSetFAQ} className={classes.answerContainer}>
       {isEditAnswer ? (
-        <div tabIndex="0" style={{ display: "flex", width: "100%" }}>
+        <div style={{ display: "flex", width: "100%" }}>
           <Quill
             value={answer}
             placeholder="Answer..."

--- a/client/src/components/Quill.js
+++ b/client/src/components/Quill.js
@@ -5,15 +5,9 @@ import "react-quill/dist/quill.snow.css";
 const Quill = props => {
   const modules = {
     toolbar: [
-      ["bold", "underline", "strike", "blockquote"],
-      [
-        { list: "ordered" },
-        { list: "bullet" },
-        { indent: "-1" },
-        { indent: "+1" }
-      ],
-      ["link", "image"],
-      ["clean"]
+      ["bold", "underline", "strike"],
+      [{ list: "ordered" }, { list: "bullet" }],
+      ["link"]
     ]
   };
 
@@ -21,12 +15,10 @@ const Quill = props => {
     "bold",
     "underline",
     "strike",
-    "blockquote",
     "list",
     "bullet",
     "indent",
-    "link",
-    "image"
+    "link"
   ];
 
   return (


### PR DESCRIPTION
- Fix for issue of answer editor exiting when setting a hyperlink from the text editor mentioned during 9/27/23 meeting on #1305 

- Additionally, this removes tools from the text editor that do not work for this iteration of the feature.