### PR TITLE
Decouples Server Testing Environment from Dev Environment

### DIFF
--- a/.github/workflows/tdm-server-tests.yml
+++ b/.github/workflows/tdm-server-tests.yml
@@ -1,6 +1,7 @@
 name: tdm-server-test
 run-name: ${{ github.actor }} is running tests for the server
 on:
+  push:
   pull_request:
     branches:
       - develop
@@ -22,31 +23,6 @@ jobs:
 
     - name: Install dependencies
       run: npm install
-      working-directory: server
-
-    - name: Set up environment variables
-      run: |
-        echo "TEST_ENV=true" >> .env
-        echo "PORT=5002" >> .env
-        echo "NODE_OPTIONS=--trace-deprecation" >> .env
-        echo "JWT_SECRET_KEY=testingSecretKey" >> .env
-        echo "CLIENT_URL=http://localhost:3001" >> .env
-        echo "SERVER_URL=http://localhost:5002" >> .env
-        echo "SENDGRID_API_KEY=SG.testAPIkey" >> .env
-        echo "EMAIL_SENDER=tdm+sendgrid@test.org" >> .env
-        echo "EMAIL_PUBLIC_COMMENT_LA_CITY=tdm+devpubliccommentplanning@test.org" >> .env
-        echo "EMAIL_PUBLIC_COMMENT_WEB_TEAM=tdm+devpubliccomment@test.org" >> .env
-        echo "APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/;LiveEndpoint=https://westus.livediagnostics.monitor.azure.com/" >> .env
-        echo "SECURITY_ADMIN_EMAIL=securityadmin@dispostable.com" >> .env
-        echo "SECURITY_ADMIN_PASSWORD=Dogfood1!" >> .env
-        echo "ADMIN_EMAIL=ladot@dispostable.com" >> .env
-        echo "ADMIN_PASSWORD=Dogfood1!" >> .env
-        echo "SQL_SERVER_NAME=localhost" >> .env
-        echo "SQL_SERVER_PORT=1434" >> .env
-        echo "SQL_DATABASE_NAME=tdmtestdb" >> .env
-        echo "SQL_USER_NAME=sa" >> .env
-        echo "SQL_PASSWORD=TestPassw0rd" >> .env
-        echo "SQL_ENCRYPT=false" >> .env
       working-directory: server
 
     - name: Run tests

--- a/push.sh
+++ b/push.sh
@@ -26,13 +26,17 @@ else
 fi
 
 # Run backend tests if the server directory has changes on the current branch and is different from origin/develop
+if ! docker info > /dev/null 2>&1; then
+  echo "The server tests use docker, and it isn't running - please start docker and try again."
+  exit 1
+fi
 SERVER_FILE_COUNT=$(git diff --name-only origin/develop HEAD | grep -c ^server)
 if [ "$SERVER_FILE_COUNT" -gt 0 ]
 then
   echo '*************  BACKEND SERVER TESTS *************'
   cd $PROJECT_ROOT_DIRECTORY/server
   npm run lint:fix
-  npm run test || exit 1
+  npm test || exit 1
 else
   echo 'Skipping backend server tests because no relevant changes were found'
 fi

--- a/server/.env.example
+++ b/server/.env.example
@@ -63,37 +63,3 @@ APPLICATIONINSIGHTS_CONNECTION_STRING=
 # SQL_TRUST_SERVER_CERTIFICATE=
 # EMAIL_SENDER=
 # APPLICATIONINSIGHTS_CONNECTION_STRING=
-
-###############################################################
-##      Testing (Comment out ALL the above variables)        ##
-###############################################################
-# TEST_ENV=true
-
-# PORT=5002
-# NODE_OPTIONS=--trace-deprecation
-
-# JWT_SECRET_KEY=testingSecretKey
-
-# CLIENT_URL=http://localhost:3001
-# SERVER_URL=http://localhost:5002
-
-# SENDGRID_API_KEY=SG.testAPIkey
-# EMAIL_SENDER=tdm+sendgrid@test.org
-# EMAIL_PUBLIC_COMMENT_LA_CITY=tdm+devpubliccommentplanning@test.org
-# EMAIL_PUBLIC_COMMENT_WEB_TEAM=tdm+devpubliccomment@test.org
-
-# APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/;LiveEndpoint=https://westus.livediagnostics.monitor.azure.com/
-
-# # Server Test Accounts
-# SECURITY_ADMIN_EMAIL=securityadmin@dispostable.com
-# SECURITY_ADMIN_PASSWORD=Dogfood1!
-# ADMIN_EMAIL=ladot@dispostable.com
-# ADMIN_PASSWORD=Dogfood1!
-
-# # testingcontainer Environment Variables
-# SQL_SERVER_NAME=localhost
-# SQL_SERVER_PORT=1434
-# SQL_DATABASE_NAME=tdmtestdb
-# SQL_USER_NAME=sa
-# SQL_PASSWORD=TestPassw0rd
-# SQL_ENCRYPT = false

--- a/server/_jest-setup_/global-setup/global-setup.js
+++ b/server/_jest-setup_/global-setup/global-setup.js
@@ -1,3 +1,4 @@
+require("../utils/env-setup");
 const { start } = require("../utils/mssql-container-setup");
 
 module.exports = async () => {

--- a/server/_jest-setup_/utils/env-setup.js
+++ b/server/_jest-setup_/utils/env-setup.js
@@ -1,0 +1,31 @@
+// env variables for testing
+process.env.TEST_ENV = "true";
+
+process.env.PORT = "5002";
+process.env.NODE_OPTIONS = "--trace-deprecation";
+
+process.env.JWT_SECRET_KEY = "testingSecretKey";
+
+process.env.CLIENT_URL = "http://localhost:3001";
+process.env.SERVER_URL = "http://localhost:5002";
+
+process.env.SENDGRID_API_KEY = "SG.testAPIkey";
+process.env.EMAIL_SENDER = "tdm+sendgrid@test.org";
+process.env.EMAIL_PUBLIC_COMMENT_LA_CITY =
+  "tdm+devpubliccommentplanning@test.org";
+process.env.EMAIL_PUBLIC_COMMENT_WEB_TEAM = "tdm+devpubliccomment@test.org";
+
+process.env.APPLICATIONINSIGHTS_CONNECTION_STRING =
+  "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/;LiveEndpoint=https://westus.livediagnostics.monitor.azure.com/";
+
+process.env.SECURITY_ADMIN_EMAIL = "securityadmin@dispostable.com";
+process.env.SECURITY_ADMIN_PASSWORD = "Dogfood1!";
+process.env.ADMIN_EMAIL = "ladot@dispostable.com";
+process.env.ADMIN_PASSWORD = "Dogfood1!";
+
+process.env.SQL_SERVER_NAME = "localhost";
+process.env.SQL_SERVER_PORT = "1434";
+process.env.SQL_DATABASE_NAME = "tdmtestdb";
+process.env.SQL_USER_NAME = "sa";
+process.env.SQL_PASSWORD = "TestPassw0rd";
+process.env.SQL_ENCRYPT = "false";


### PR DESCRIPTION
### What changes did you make?

- decoupled the test env from the dev env

### Why did you make the changes (we will use this info to test)?

- this will make it simpler to run tests concurrently with server and client running
1. Dev must open Docker (desktop)
2. cd into the `server` directory and run:  
```
npm test
```

## Notes

Upon Approval, I can edit the [Test Wiki](https://github.com/hackforla/tdm-calculator/wiki/Testing)