### PR TITLE
Added a vertical space above p.1 General Project information on Check…

### DIFF
--- a/client/src/components/Checklist/ChecklistContent.js
+++ b/client/src/components/Checklist/ChecklistContent.js
@@ -51,6 +51,7 @@ const ChecklistContent = () => {
         Listed below are the documents that you may need when using{" "}
         <a href="/calculation">Create Project.</a>
       </p>
+      <br />
       <div>
         <article className={classes.section}>
           p.1


### PR DESCRIPTION
Fixes #1545 

### What changes did you make?

- Added a vertical space between the `Create Project` and `p. 1 General project information` by using `<br />`

### Why did you make the changes (we will use this info to test)?

- Our checklist spacing needs to be adjusted in order to ensure uniformity

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/hackforla/tdm-calculator/assets/31785367/cad3fbca-515f-4ac5-a35c-8c5ba3ad0f22)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/hackforla/tdm-calculator/assets/31785367/fa159f31-f4d9-439d-9714-81d475021773)


</details>
