### PR TITLE
Moved filter drawer to the right side of the screen

### DIFF
--- a/client/src/components/Projects/FilterDrawer.js
+++ b/client/src/components/Projects/FilterDrawer.js
@@ -77,7 +77,7 @@ const FilterPopup = ({ criteria, setCriteria, setCollapsed }) => {
       <button
         style={{
           border: "none",
-          textAlign: "right",
+          textAlign: "left",
           backgroundColor: "white",
           margin: 0,
           padding: 0

--- a/client/src/components/Projects/ProjectsPage.js
+++ b/client/src/components/Projects/ProjectsPage.js
@@ -25,7 +25,7 @@ import FilterDrawer from "./FilterDrawer.js";
 const useStyles = createUseStyles({
   outerDiv: {
     display: "flex",
-    flexDirection: "row",
+    flexDirection: "row-reverse",
     justifyItems: "flex-start"
   },
   contentDiv: {


### PR DESCRIPTION
Fixes #1576 

### What changes did you make?

- The Filter drawer has been moved to the right side of the screen. And the  << has been aligned properly.
- The animation will slide in/out from the right.

### Why did you make the changes (we will use this info to test)?

- The changes was made following the post stake holder meeting decision to put the filter drawer to the right.

### Issue-Specific User Account

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1440" alt="Screenshot 2024-01-11 at 21 23 04" src="https://github.com/hackforla/tdm-calculator/assets/25173636/4a00ad61-9332-477f-b08b-26dfe30218b1">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1440" alt="Screenshot 2024-01-11 at 21 22 23" src="https://github.com/hackforla/tdm-calculator/assets/25173636/cdb531f2-eede-476b-8021-6db5e70b38aa">


</details>
