### PR TITLE
Converted first h3 element from SCSS to JSS CSS

### DIFF
--- a/client/src/components/PrivacyPolicy.js
+++ b/client/src/components/PrivacyPolicy.js
@@ -43,6 +43,13 @@ const useStyles = createUseStyles({
   },
   addressParagraph: {
     marginBottom: "0px"
+  },
+  tdmWizardPageSubtitle: {
+    marginTop: "o.5em",
+    marginBottom: "1em",
+    textAlign: "center",
+    fontWeight: "bold",
+    fontStyle: "normal"
   }
 });
 
@@ -54,10 +61,7 @@ const PrivacyPolicy = () => {
         <h1 className={classes.title}>Privacy Policy</h1>
 
         <div className={classes.privacyPolicyContent}>
-          <h3
-            className="tdm-wizard-page-subtitle"
-            style={{ fontWeight: "bold" }}
-          >
+          <h3 className={classes.tdmWizardPageSubtitle}>
             We respect your privacy and recognize that we must maintain and use
             your information responsibly.
           </h3>


### PR DESCRIPTION
Fixes #1588

### What changes did you make?

- Converted the first h3 element SCSS className to JSS CSS className.

### Why did you make the changes (we will use this info to test)?

- Cleaning up CSS code to maintain in one place so that there are less issues.

### Issue-Specific User Account

The securityadmin@dispostable.com account was used.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2024-01-24 at 12 44 01 PM](https://github.com/hackforla/tdm-calculator/assets/133067265/1e7c8db7-d131-4e8f-89b6-536fd1a383d7)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2024-01-24 at 12 43 47 PM](https://github.com/hackforla/tdm-calculator/assets/133067265/b5a9778f-790f-4cbd-823e-9aa1393a4ccb)

</details>
