### PR TITLE
Converted SCSS to JSS in ProjectSpecifications.js

### DIFF
--- a/client/src/components/ProjectWizard/WizardPages/ProjectSpecifications.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSpecifications.js
@@ -17,6 +17,15 @@ const useStyles = createUseStyles(theme => ({
   alignRight: {
     gridColumn: "h-end",
     justifyContent: "flex-end"
+  },
+  subtitle: {
+    marginTop: "0.5em",
+    marginBottom: "1em",
+    textAlign: "center",
+    fontWeight: "normal",
+    fontStyle: "normal",
+    fontSize: "20px",
+    lineHeight: "140%"
   }
 }));
 
@@ -26,7 +35,7 @@ function ProjectSpecifications(props) {
   return (
     <div>
       <div className={classes.header}>Determine Project Level</div>
-      <h3 className="tdm-wizard-page-subtitle">
+      <h3 className={classes.subtitle}>
         Project Level (left panel) and Citywide Parking Baseline (next page) are
         determined by the use specifications entered below.
       </h3>


### PR DESCRIPTION
Fixes #1599

### What changes did you make?

- Converted one h3 element with the content "Project Level (left panel)" from SCSS to JSS format.

### Why did you make the changes (we will use this info to test)?

- To consolidate CSS to fewer places to minimize styling issues.

### Issue-Specific User Account

The [securityadmin@dispostable.com](mailto:securityadmin@dispostable.com) account was used.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2024-01-30 at 10 28 42 PM](https://github.com/hackforla/tdm-calculator/assets/133067265/6ca95a11-4ba2-43a3-9a50-4413d2fa29c8)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2024-01-30 at 10 29 13 PM](https://github.com/hackforla/tdm-calculator/assets/133067265/1a39d24e-0c1f-40cb-b82f-dec58410f566)

</details>
