### PR TITLE
1635 Clear trash projects quick fix

### DIFF
--- a/client/src/hooks/useGetProjects.js
+++ b/client/src/hooks/useGetProjects.js
@@ -10,6 +10,16 @@ const useProjects = handleError => {
       if (result.data === "" || result.data === false) {
         setProjects([]);
       } else {
+        console.log(result.data);
+        console.log(
+          "CURRENT",
+          (new Date() - new Date(result.data[0].dateCreated)) /
+            1000 /
+            60 /
+            60 /
+            24
+        );
+
         setProjects(result.data);
       }
     } catch (err) {


### PR DESCRIPTION
Fixes #1635 

### What changes did you make?

When users view their saved projects, the fetch function now includes an imbedded delete function that scans through the fetched projects and deletes any that are in the trash and 30 days old.

### Why did you make the changes (we will use this info to test)?

The idea is for TDM to automatically delete all projects in the database that have been in the trash for 30 days. For now, we don't have that built into the back end, so we have the users automatically check and clean their own trash bin whenever they look at their projects. This does present a problem is the user trashes a bunch of projects and never logs in again, leaving their trash uncleaned, but this should work for now.
