### PR TITLE
removed N/A columns from CSV export

### DIFF
--- a/client/src/components/Projects/pdfCsvData.js
+++ b/client/src/components/Projects/pdfCsvData.js
@@ -372,7 +372,9 @@ const mapCsvRules = (project, rules) => {
 
   const ruleNames = columnData.flatMap(rule => {
     if (rule.dataType === "choice") {
-      return rule.choices.map(choice => rule.name + " - " + choice.name);
+      return rule.choices
+        .slice(1)
+        .map(choice => rule.name + " - " + choice.name);
     } else {
       return `${rule.name}${rule.units ? " (" + rule.units + ")" : ""}`;
     }
@@ -380,9 +382,11 @@ const mapCsvRules = (project, rules) => {
 
   const ruleValues = columnData.flatMap(rule => {
     if (rule.dataType === "choice") {
-      return rule.choices.map(choice =>
-        choice.id == rule.value || (choice.id == 0 && !rule.value) ? "Y" : "N"
-      );
+      return rule.choices
+        .slice(1)
+        .map(choice =>
+          choice.id == rule.value || (choice.id == 0 && !rule.value) ? "Y" : "N"
+        );
     } else {
       return rule.value ? rule.value.toString() : "";
     }


### PR DESCRIPTION
Fixes #1574

### What changes did you make?

- In the CSV download, columns representing multiple choice strategies where the N/A option is selected has been removed.
- [TDM EXAMPLE CSV](https://docs.google.com/spreadsheets/d/1fPj-RdfQjyTF7hSXwZpKB8KwhqQC2B4ZpjbjvznYbBw/edit#gid=414913169) please see spreadsheet linked to view example.

### Why did you make the changes (we will use this info to test)?

- The N/A choice does not need to be represented since it means that the strategy is not used, saving space and making the CSV file more efficient.

### Issue-Specific User Account

Account ladot@dispostable.com was used for testing.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

There are no Screenshots, since there are no visible changes to the website.
