### PR TITLE
removed the green color from restore trash icon

### DIFF
--- a/client/src/components/Projects/DeleteProjectModal.js
+++ b/client/src/components/Projects/DeleteProjectModal.js
@@ -43,7 +43,7 @@ const DeleteProjectModal = ({ mounted, onClose, project }) => {
         <>
           <div
             className={classes.heading1}
-            style={{ marginBottom: "1.5rem", color: "#a7c539" }}
+            style={{ marginBottom: "1.5rem", color: "" }}
           >
             <FontAwesomeIcon icon={faTrashArrowUp} /> Restore Project from Trash
           </div>
@@ -82,7 +82,7 @@ const DeleteProjectModal = ({ mounted, onClose, project }) => {
           <Button
             onClick={() => onClose("ok")}
             variant="contained"
-            color={"colorPrimary"}
+            color={"colorError"}
           >
             Restore
           </Button>

--- a/client/src/components/Projects/MultiProjectToolbarMenu.js
+++ b/client/src/components/Projects/MultiProjectToolbarMenu.js
@@ -181,7 +181,7 @@ const MultiProjectToolbarMenu = ({
             ) : (
               <FontAwesomeIcon
                 icon={faTrashArrowUp}
-                color={isDelBtnDisabled ? "#1010104d" : "#a7c539"}
+                color={isDelBtnDisabled ? "#1010104d" : ""}
               />
             )}
             <Tooltip

--- a/client/src/components/Projects/ProjectContextMenu.js
+++ b/client/src/components/Projects/ProjectContextMenu.js
@@ -169,7 +169,7 @@ const ProjectContextMenu = ({
           style={{ borderTop: "1px solid black" }}
         >
           {project.dateTrashed ? (
-            <span style={{ color: "#a7c539" }}>
+            <span style={{ color: "" }}>
               <FontAwesomeIcon
                 icon={faTrashArrowUp}
                 className={classes.listItemIcon}


### PR DESCRIPTION
Fixes #1661 

### What changes did you make?

- Changed the green color of restore trash icon back to default color.
- Changed the green color from the restore button back to red.

### Why did you make the changes (we will use this info to test)?

- The green color was not accessibility compliant.

### Issue-Specific User Account

The account tdm@hackforla.org was used for testing.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2024-04-10 at 5 24 02 PM](https://github.com/hackforla/tdm-calculator/assets/133067265/d4f7be60-320a-4563-b666-3e23ae9fe141)

![Screenshot 2024-04-10 at 9 10 05 PM](https://github.com/hackforla/tdm-calculator/assets/133067265/5a53b7f1-b447-40be-a8d5-1c651ab5ab2b). ![Screenshot 2024-04-10 at 5 24 25 PM](https://github.com/hackforla/tdm-calculator/assets/133067265/05a44e51-f108-4482-89fe-d9c984fb1f44)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2024-04-11 at 2 42 32 PM](https://github.com/hackforla/tdm-calculator/assets/133067265/1c4b92b1-a1b2-4fba-939d-257f3116184a)

![Screenshot 2024-04-11 at 2 43 09 PM](https://github.com/hackforla/tdm-calculator/assets/133067265/337ab20c-24b8-4d19-8b35-c4184951ac4e)

</details>
