### PR TITLE
1670 - Ajusted WizardSidebar div that overlapped footer

### DIFF
--- a/client/src/components/ProjectWizard/WizardSidebar/SidebarCart.js
+++ b/client/src/components/ProjectWizard/WizardSidebar/SidebarCart.js
@@ -34,7 +34,10 @@ const useStyles = createUseStyles({
   dataPointsCell: { textAlign: "right" },
   dataPoints: { fontSize: "18px", fontFamily: "Oswald" },
   dataUnits: { fontSize: "14px", fontFamily: "Calibri", marginBottom: "10px" },
-  row: { display: "flex", justifyContent: "space-between" },
+  row: {
+    display: "flex",
+    justifyContent: "space-between"
+  },
   noDisplay: {
     display: "none !important"
   },

--- a/client/src/components/ProjectWizard/WizardSidebar/WizardSidebar.js
+++ b/client/src/components/ProjectWizard/WizardSidebar/WizardSidebar.js
@@ -10,10 +10,10 @@ const useStyles = createUseStyles({
     display: "flex",
     position: "sticky",
     top: 0,
-    // height: "calc(100vh - 103px - 48px)",
     height: "calc(100vh)",
     flexDirection: "column",
-    "@media (max-width:768px)": {
+    "@media (max-height: 800px)": {
+      overflowY: "hidden",
       height: "auto"
     }
   }


### PR DESCRIPTION
Fixes #1670 

### What changes did you make?
- Adjusted the main div in the WizardSidebar component for height less than 800px

### Why did you make the changes (we will use this info to test)?
- Sidebar was overlapping the footer when the browser height is less than 800px

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![before-sidecart](https://github.com/hackforla/tdm-calculator/assets/42459347/fe446c24-ae08-4e32-a30d-0627c658cb00)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![after-sidecart](https://github.com/hackforla/tdm-calculator/assets/42459347/6f205fb9-1490-4a13-9fa9-2cf6428f449c)


</details>
