### PR TITLE
1675 - Added project timestamps to PDF footer

### DIFF
--- a/client/src/components/PdfPrint/PdfFooter.js
+++ b/client/src/components/PdfPrint/PdfFooter.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
+import { DateTime } from "luxon";
 
 const useStyles = createUseStyles({
   pdfTimeText: {
@@ -15,19 +16,20 @@ const useStyles = createUseStyles({
   }
 });
 
-const PdfFooter = props => {
+const PdfFooter = ({ dateModified, dateSnapshotted }) => {
   const classes = useStyles();
-  const { dateModified } = props;
-  const [printedDate, setPrintedDate] = useState(new Date());
+
+  const [printedDate, setPrintedDate] = useState(DateTime.now());
 
   useEffect(() => {
     // You would update these dates based on your application logic
     // For instance, you might fetch them from an API when the component mounts
     const updateDates = () => {
-      setPrintedDate(new Date()); // replace with actual date
+      setPrintedDate(DateTime.now()); // replace with actual date
     };
 
     updateDates();
+
     const intervalId = setInterval(updateDates, 60 * 1000); // updates every minute
 
     return () => clearInterval(intervalId); // cleanup on unmount
@@ -35,9 +37,14 @@ const PdfFooter = props => {
 
   return (
     <section className={classes.pdfFooterContainer}>
-      <div className={classes.pdfTimeText}>
-        Date Last Saved: {dateModified} Pacific Time
-      </div>
+      {dateSnapshotted !== "Invalid DateTime" ? (
+        <div className={classes.pdfTimeText}>
+          Snapshot Submitted: {dateSnapshotted}
+        </div>
+      ) : (
+        ""
+      )}
+      <div className={classes.pdfTimeText}>Date Last Saved: {dateModified}</div>
       <div
         className={classes.pdfTimeText}
         style={{
@@ -47,10 +54,9 @@ const PdfFooter = props => {
         }}
       >
         Date Printed:{" "}
-        {printedDate.toLocaleString("en-US", {
-          timeZone: "America/Los_Angeles"
-        })}{" "}
-        Pacific Time
+        {printedDate
+          .setZone("America/Los_Angeles")
+          .toFormat("yyyy-MM-dd, HH:mm:ss 'Pacific Time'")}
       </div>
       <span className={classes.pdfTimeText}>
         Los Angeles Department of Transportation | tdm.ladot.lacity.org |
@@ -59,8 +65,10 @@ const PdfFooter = props => {
     </section>
   );
 };
+
 PdfFooter.propTypes = {
-  dateModified: PropTypes.string || null
+  dateModified: PropTypes.string || null,
+  dateSnapshotted: PropTypes.string || null
 };
 
 export default PdfFooter;

--- a/client/src/components/PdfPrint/PdfPrint.js
+++ b/client/src/components/PdfPrint/PdfPrint.js
@@ -132,7 +132,8 @@ const useStyles = createUseStyles({
 // eslint-disable-next-line react/display-name
 export const PdfPrint = forwardRef((props, ref) => {
   const classes = useStyles();
-  const { rules, dateModified } = props;
+
+  const { rules, dateModified, dateSnapshotted } = props;
 
   const level = getRule(rules, "PROJECT_LEVEL");
   const targetPoints = getRule(rules, "TARGET_POINTS_PARK");
@@ -324,16 +325,21 @@ export const PdfPrint = forwardRef((props, ref) => {
           />
         </div>
       </section>
-      <PdfFooter dateModified={dateModified} />
+      <PdfFooter
+        dateModified={dateModified}
+        dateSnapshotted={dateSnapshotted}
+      />
     </div>
   );
 });
+
 PdfPrint.propTypes = {
   rules: PropTypes.array,
   account: PropTypes.object,
   projectId: PropTypes.number,
   loginId: PropTypes.number,
-  dateModified: PropTypes.string || null
+  dateModified: PropTypes.string || null,
+  dateSnapshotted: PropTypes.string || null
 };
 
 export default PdfPrint;

--- a/client/src/components/Projects/MultiProjectToolbarMenu.js
+++ b/client/src/components/Projects/MultiProjectToolbarMenu.js
@@ -13,7 +13,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Tooltip } from "react-tooltip";
 import PdfPrint from "../PdfPrint/PdfPrint";
-import moment from "moment";
+import { DateTime } from "luxon";
 import { useReactToPrint } from "react-to-print";
 
 const useStyles = createUseStyles({
@@ -51,7 +51,15 @@ const MultiProjectToolbarMenu = ({
   checkedProjectsStatusData,
   pdfProjectData
 }) => {
-  const momentModified = moment(checkedProjectsStatusData.dateModified);
+  const modifiedDate = DateTime.fromISO(checkedProjectsStatusData.dateModified)
+    .setZone("America/Los_Angeles")
+    .toFormat("yyyy-MM-dd, HH:mm:ss 'Pacific Time'");
+  const dateSnapshotted = DateTime.fromISO(
+    checkedProjectsStatusData.dateSnapshotted ?? ""
+  )
+    .setZone("America/Los_Angeles")
+    .toFormat("yyyy-MM-dd hh:mm a 'Pacific Time'");
+
   const printRef = useRef(null);
   const classes = useStyles();
   const userContext = useContext(UserContext);
@@ -146,7 +154,8 @@ const MultiProjectToolbarMenu = ({
               <PdfPrint
                 ref={printRef}
                 rules={pdfProjectData.pdf}
-                dateModified={momentModified.format("MM/DD/YYYY")}
+                dateModified={modifiedDate}
+                dateSnapshotted={dateSnapshotted}
               />
             </div>
           )}

--- a/client/src/components/Projects/MultiProjectToolbarMenu.js
+++ b/client/src/components/Projects/MultiProjectToolbarMenu.js
@@ -58,7 +58,7 @@ const MultiProjectToolbarMenu = ({
     checkedProjectsStatusData.dateSnapshotted ?? ""
   )
     .setZone("America/Los_Angeles")
-    .toFormat("yyyy-MM-dd hh:mm a 'Pacific Time'");
+    .toFormat("yyyy-MM-dd, hh:mm a 'Pacific Time'");
 
   const printRef = useRef(null);
   const classes = useStyles();

--- a/client/src/components/Projects/ProjectTableRow.js
+++ b/client/src/components/Projects/ProjectTableRow.js
@@ -62,7 +62,7 @@ const ProjectTableRow = ({
     .toFormat("yyyy-MM-dd, HH:mm:ss 'Pacific Time'");
   const dateSnapshotted = DateTime.fromISO(project.dateSnapshotted ?? "")
     .setZone("America/Los_Angeles")
-    .toFormat("yyyy-MM-dd hh:mm a 'Pacific Time'");
+    .toFormat("yyyy-MM-dd, hh:mm a 'Pacific Time'");
   const formInputs = JSON.parse(project.formInputs);
   const printRef = useRef();
 

--- a/client/src/components/Projects/ProjectTableRow.js
+++ b/client/src/components/Projects/ProjectTableRow.js
@@ -12,6 +12,7 @@ import {
   faEllipsisV
 } from "@fortawesome/free-solid-svg-icons";
 import moment from "moment";
+import { DateTime } from "luxon";
 import { useReactToPrint } from "react-to-print";
 import ProjectContextMenu from "./ProjectContextMenu";
 import PdfPrint from "../PdfPrint/PdfPrint";
@@ -56,7 +57,12 @@ const ProjectTableRow = ({
   checkedProjectIds
 }) => {
   const classes = useStyles();
-  const momentModified = moment(project.dateModified);
+  const modifiedDate = DateTime.fromISO(project.dateModified)
+    .setZone("America/Los_Angeles")
+    .toFormat("yyyy-MM-dd, HH:mm:ss 'Pacific Time'");
+  const dateSnapshotted = DateTime.fromISO(project.dateSnapshotted ?? "")
+    .setZone("America/Los_Angeles")
+    .toFormat("yyyy-MM-dd hh:mm a 'Pacific Time'");
   const formInputs = JSON.parse(project.formInputs);
   const printRef = useRef();
 
@@ -177,7 +183,8 @@ const ProjectTableRow = ({
               <PdfPrint
                 ref={printRef}
                 rules={projectRules}
-                dateModified={momentModified.format("MM/DD/YYYY")}
+                dateModified={modifiedDate}
+                dateSnapshotted={dateSnapshotted}
               />
             </div>
           </div>


### PR DESCRIPTION
Fixes #1675 

### What changes did you make?
- Added timestamps to PDF footer
- Timestamps are for: Snapshot, last saved, date printed

### Why did you make the changes (we will use this info to test)?
- To allow user to see relevant project dates and time when printing a project
- To format timestamps as `YYYY-MM-DD, 11:03 AM Pacific Time` or `YYYY-MM-DD, HH:MM:SS Pacific Time`

### Screenshots of Proposed Changes Of The Website

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="636" alt="before-snapshot" src="https://github.com/hackforla/tdm-calculator/assets/42459347/441585ce-fcb6-4d32-b8e5-b09b3d3c7c0d">

</details>

<details>
<summary>Visuals after changes are applied</summary>

<img width="660" alt="after-with-snapshot" src="https://github.com/hackforla/tdm-calculator/assets/42459347/8cea75a0-ef50-4826-a8fd-9fc97d2c72dd">

**With snapshot date**

<img width="658" alt="after-with-no-snapshot" src="https://github.com/hackforla/tdm-calculator/assets/42459347/2fa41b9f-4910-40d3-b6f5-32a67aa9e2f4">

**Without snapshot date**
</details>
