### PR TITLE
1710 saving new project bug

### DIFF
--- a/client/src/components/ProjectWizard/TdmCalculationContainer.js
+++ b/client/src/components/ProjectWizard/TdmCalculationContainer.js
@@ -53,6 +53,8 @@ export function TdmCalculationContainer({ contentContainerRef }) {
   const [rules, setRules] = useState([]);
   const [dateModified, setDateModified] = useState();
   const [dateSnapshotted, setDateSnapshotted] = useState();
+  const [savingNewProject, setSavingNewProject] = useState(false);
+
   const toast = useToast();
 
   const fetchRules = useCallback(async () => {
@@ -476,11 +478,13 @@ export function TdmCalculationContainer({ contentContainerRef }) {
         }
       }
     } else {
+      setSavingNewProject(true);
       try {
         const postResponse = await projectService.post(requestBody);
         // Update URL to /calculation/<currentPage>/<newProjectId>
         // to keep working on same project.
-        const newPath = `/calculation/${location.pathname.split("/")[1]}/${
+
+        const newPath = `/calculation/${location.pathname.split("/")[2]}/${
           postResponse.data.id
         }`;
         navigate(newPath, { replace: true });
@@ -533,6 +537,7 @@ export function TdmCalculationContainer({ contentContainerRef }) {
       contentContainerRef={contentContainerRef}
       inapplicableStrategiesModal={inapplicableStrategiesModal}
       closeStrategiesModal={closeStrategiesModal}
+      savingNewProject={savingNewProject}
     />
   );
 }

--- a/client/src/components/ProjectWizard/TdmCalculationContainer.js
+++ b/client/src/components/ProjectWizard/TdmCalculationContainer.js
@@ -53,8 +53,6 @@ export function TdmCalculationContainer({ contentContainerRef }) {
   const [rules, setRules] = useState([]);
   const [dateModified, setDateModified] = useState();
   const [dateSnapshotted, setDateSnapshotted] = useState();
-  const [savingNewProject, setSavingNewProject] = useState(false);
-
   const toast = useToast();
 
   const fetchRules = useCallback(async () => {
@@ -478,7 +476,6 @@ export function TdmCalculationContainer({ contentContainerRef }) {
         }
       }
     } else {
-      setSavingNewProject(true);
       try {
         const postResponse = await projectService.post(requestBody);
         // Update URL to /calculation/<currentPage>/<newProjectId>
@@ -537,7 +534,6 @@ export function TdmCalculationContainer({ contentContainerRef }) {
       contentContainerRef={contentContainerRef}
       inapplicableStrategiesModal={inapplicableStrategiesModal}
       closeStrategiesModal={closeStrategiesModal}
-      savingNewProject={savingNewProject}
     />
   );
 }

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -57,7 +57,8 @@ const TdmCalculationWizard = props => {
     dateSnapshotted,
     contentContainerRef,
     inapplicableStrategiesModal,
-    closeStrategiesModal
+    closeStrategiesModal,
+    savingNewProject
   } = props;
   const classes = useStyles();
   const context = useContext(ToastContext);
@@ -90,15 +91,26 @@ const TdmCalculationWizard = props => {
       },
       nextLocation.pathname
     );
-    return (
-      currentMatch &&
-      nextMatch &&
-      currentMatch.params.projectId === nextMatch.params.projectId
-    );
+    console.log("CURRENTMATCH", currentMatch);
+    console.log("NEXTMATCH", nextMatch);
+    console.log("savingNewProject", savingNewProject);
+    if (!savingNewProject) {
+      return (
+        currentMatch &&
+        nextMatch &&
+        currentMatch.params.projectId === nextMatch.params.projectId
+      );
+    } else {
+      return currentMatch && nextMatch;
+    }
   };
 
   const shouldBlock = React.useCallback(
     ({ currentLocation, nextLocation }) => {
+      console.log("CONDITON 1", currentLocation.pathname.split("/")[3]);
+      console.log("CONDITON 2", nextLocation.pathname.split("/")[3]);
+      console.log("CONDITON 3", !isSameProject(currentLocation, nextLocation));
+
       return formIsDirty && !isSameProject(currentLocation, nextLocation);
     },
     [formIsDirty]
@@ -294,7 +306,6 @@ const TdmCalculationWizard = props => {
         return null;
     }
   };
-
   return (
     <div className={classes.wizard}>
       <InapplicableStrategiesModal
@@ -373,7 +384,8 @@ TdmCalculationWizard.propTypes = {
   dateModified: PropTypes.string,
   dateSnapshotted: PropTypes.string,
   inapplicableStrategiesModal: PropTypes.bool,
-  closeStrategiesModal: PropTypes.func
+  closeStrategiesModal: PropTypes.func,
+  savingNewProject: PropTypes.bool
 };
 
 export default TdmCalculationWizard;

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -57,8 +57,7 @@ const TdmCalculationWizard = props => {
     dateSnapshotted,
     contentContainerRef,
     inapplicableStrategiesModal,
-    closeStrategiesModal,
-    savingNewProject
+    closeStrategiesModal
   } = props;
   const classes = useStyles();
   const context = useContext(ToastContext);
@@ -91,26 +90,17 @@ const TdmCalculationWizard = props => {
       },
       nextLocation.pathname
     );
-    console.log("CURRENTMATCH", currentMatch);
-    console.log("NEXTMATCH", nextMatch);
-    console.log("savingNewProject", savingNewProject);
-    if (!savingNewProject) {
-      return (
-        currentMatch &&
-        nextMatch &&
-        currentMatch.params.projectId === nextMatch.params.projectId
-      );
-    } else {
-      return currentMatch && nextMatch;
-    }
+
+    return (
+      currentMatch &&
+      nextMatch &&
+      (currentMatch.params.projectId === nextMatch.params.projectId ||
+        !projectId)
+    );
   };
 
   const shouldBlock = React.useCallback(
     ({ currentLocation, nextLocation }) => {
-      console.log("CONDITON 1", currentLocation.pathname.split("/")[3]);
-      console.log("CONDITON 2", nextLocation.pathname.split("/")[3]);
-      console.log("CONDITON 3", !isSameProject(currentLocation, nextLocation));
-
       return formIsDirty && !isSameProject(currentLocation, nextLocation);
     },
     [formIsDirty]
@@ -384,8 +374,7 @@ TdmCalculationWizard.propTypes = {
   dateModified: PropTypes.string,
   dateSnapshotted: PropTypes.string,
   inapplicableStrategiesModal: PropTypes.bool,
-  closeStrategiesModal: PropTypes.func,
-  savingNewProject: PropTypes.bool
+  closeStrategiesModal: PropTypes.func
 };
 
 export default TdmCalculationWizard;


### PR DESCRIPTION
Fixes #1710 

### What changes did you make?

modified the "navigate away" line on save for new projects to point toward a different variable.

Changed the check for the popup modal to NOT trigger if the page the user is navigating away from is has a project id of 0.

### Why did you make the changes (we will use this info to test)?

When navigating to a new path on save, the navigation function now grabs the correct page number, so it should navigate users back to the same page they saved on, rather than a "N/A" page number.

The popup modal was triggered by url change from a project with no id number (such as from a new project) to a project with an id number. I set the modal to not trigger if the first url had no project id number. 

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)


<details>
<summary>Visuals before changes are applied</summary>
![image](https://github.com/hackforla/tdm-calculator/assets/30099154/d8084304-fca1-431b-9bac-fd11574ba422)

![image](https://github.com/hackforla/tdm-calculator/assets/30099154/f7c8fe49-4671-4a1c-a55e-93a21fff13bd)
</details>

