### PR TITLE
Added description and fixed duplicate modal not using project name

### DIFF
--- a/client/src/components/Projects/CopyProjectModal.js
+++ b/client/src/components/Projects/CopyProjectModal.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { createUseStyles, useTheme } from "react-jss";
 
@@ -28,6 +28,10 @@ export default function CopyProjectModal({
   const [duplicateProjectName, setDuplicateProjectName] = useState(
     `${selectedProjectName} (COPY)`
   );
+
+  useEffect(() => {
+    setDuplicateProjectName(`${selectedProjectName} (COPY)`);
+  }, [selectedProjectName]);
 
   return (
     <ModalDialog

--- a/client/src/components/Projects/ProjectsPage.js
+++ b/client/src/components/Projects/ProjectsPage.js
@@ -262,13 +262,16 @@ const ProjectsPage = ({ contentContainerRef }) => {
     if (action === "ok") {
       const projectFormInputsAsJson = JSON.parse(selectedProject.formInputs);
       projectFormInputsAsJson.PROJECT_NAME = newProjectName;
-
+      let newProject = {
+        ...selectedProject,
+        name: newProjectName,
+        formInputs: JSON.stringify(projectFormInputsAsJson)
+      };
+      if (!newProject.description) {
+        newProject.description = "";
+      }
       try {
-        await projectService.post({
-          ...selectedProject,
-          name: newProjectName,
-          formInputs: JSON.stringify(projectFormInputsAsJson)
-        });
+        await projectService.post(newProject);
         await updateProjects();
       } catch (err) {
         handleError(err);


### PR DESCRIPTION
Fixes #1716 

### What changes did you make?

-Set the duplication project function to give a new project an empty string for a description if the original project did not have a description value.

-set the duplicate modal to utilize "useEffect" to update the selected projects name.

### Why did you make the changes (we will use this info to test)?

-The duplicate project function wasn't working because of a 400 Error in the Axios call: the description of the duplicate project has to be a string value. Previously, the duplicated project would use 'null'. This pull request adds a line to check if the description value is 'null', changes it into an empty string, then creates the duplicate.

-(oddly enough, have "undefined" for a description value works fine. This is the value currently used when creating brand new projects.)

- The duplicate modal was not displaying the selected projects name correctly.  It set the "duplicate project" value before the "selected project" value could be properly passed down. I added a the useEffect hook to update that value correctly.


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

Error Message
![Screenshot 2024-06-19 at 2 37 55 PM](https://github.com/hackforla/tdm-calculator/assets/30099154/1dd0cd55-4424-40ec-bee7-90b5668de04d)

Duplicated project values
![Screenshot 2024-06-19 at 2 33 57 PM](https://github.com/hackforla/tdm-calculator/assets/30099154/505bdacd-4711-42a6-a917-ea69e1e652ec)

Modal before useEffect fix
![Screenshot 2024-06-19 at 3 42 52 PM](https://github.com/hackforla/tdm-calculator/assets/30099154/ca3ddabb-8250-4553-8b5f-42d774dc6512)

