### PR TITLE
PDF Print - right-align values, temp fix to footer on PDF

### DIFF
--- a/client/src/components/PdfPrint/PdfFooter.js
+++ b/client/src/components/PdfPrint/PdfFooter.js
@@ -10,8 +10,6 @@ const useStyles = createUseStyles({
   },
   pdfFooterContainer: {
     margin: "24px 0 0",
-    position: "absolute",
-    bottom: "0",
     width: "100%"
   }
 });

--- a/client/src/components/PdfPrint/PdfPrint.js
+++ b/client/src/components/PdfPrint/PdfPrint.js
@@ -58,7 +58,7 @@ const useStyles = createUseStyles({
   measuresContainer: {
     paddingTop: "10px",
     margin: "0 12px",
-    width: "80%"
+    width: "90%"
   },
   earnedPoints: {
     fontWeight: "600",

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/LandUses.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/LandUses.jsx
@@ -17,7 +17,8 @@ const useStyles = createUseStyles({
   value: {
     display: "flex",
     fontSize: "14px",
-    justifyContent: "flex-end"
+    justifyContent: "flex-end",
+    marginRight: "6.5rem"
   }
 });
 

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/MeasureSelected.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/MeasureSelected.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
-import clsx from "clsx";
 import { roundToTwo } from "../../helpers";
 
 const useStyles = createUseStyles({
@@ -14,16 +13,12 @@ const useStyles = createUseStyles({
     margin: "4px auto"
   },
   ruleName: {
-    minWidth: "270px"
+    flexBasis: "40%"
   },
   ruleText: {
-    textAlign: "center",
+    flexBasis: "40%",
+    textAlign: "right",
     margin: "0 16px"
-  },
-  detailsContainer: {
-    display: "flex",
-    minWidth: "180px",
-    maxWidth: "35%"
   },
   pointsContainer: {
     display: "flex",
@@ -46,20 +41,19 @@ const MeasureSelected = props => {
   return (
     <div className={classes.rule}>
       <div className={classes.ruleName}>{rule.name}</div>
-      <div className={clsx("justify-content-center", classes.detailsContainer)}>
-        <div className={classes.ruleText}>
-          {rule.dataType === "boolean" || rule.dataType === "number"
-            ? null
-            : rule.dataType === "choice"
+
+      <div className={classes.ruleText}>
+        {rule.dataType === "boolean" || rule.dataType === "number"
+          ? null
+          : rule.dataType === "choice"
+          ? rule.choices.find(
+              choice => Number(choice.id) === Number(rule.value)
+            )
             ? rule.choices.find(
                 choice => Number(choice.id) === Number(rule.value)
-              )
-              ? rule.choices.find(
-                  choice => Number(choice.id) === Number(rule.value)
-                ).name
-              : rule.value
-            : rule.value}
-        </div>
+              ).name
+            : rule.value
+          : rule.value}
       </div>
       <div className={classes.pointsContainer}>
         <div className={classes.value}>{roundToTwo(rule.calcValue)}</div>

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectDetail.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectDetail.jsx
@@ -14,11 +14,12 @@ const useStyles = createUseStyles({
     fontSize: "0.875rem"
   },
   ruleName: {
-    minWidth: "270px"
+    flexBasis: "80%"
   },
   pointsContainer: {
     display: "flex",
-    justifyContent: "flex-end"
+    justifyContent: "flex-end",
+    flaxBasis: "20%"
   },
   measureDetails: {
     textAlign: "right",


### PR DESCRIPTION
Fixes #1568 Fixes #1747

### What changes did you make?

- Right-align test indicating choice selected for measures
- Temporary fix for footer on PDF where footer overlaps content, but pushing footer information to appear after the content.
- PDF Printout had excessive right-margin around details and measures.
- Horizontally right-align value for Land Uses with numeric fields above and below.
-

### Why did you make the changes (we will use this info to test)?

- Requested by Bonnie

### Issue-Specific User Account

(none)
### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
