### PR TITLE
1705 fix sidebar width faq page

### DIFF
--- a/client/src/components/Layout/ContentContainer.js
+++ b/client/src/components/Layout/ContentContainer.js
@@ -4,7 +4,7 @@ import { createUseStyles } from "react-jss";
 
 const useStyles = createUseStyles({
   contentContainer: {
-    flex: "1 1 auto",
+    flex: "1",
     display: "flex",
     flexDirection: "row",
     minHeight: "calc(100vh - 103px - 48px)"

--- a/client/src/components/Layout/Sidebar.js
+++ b/client/src/components/Layout/Sidebar.js
@@ -5,7 +5,7 @@ import { createUseStyles } from "react-jss";
 export const useStyles = createUseStyles({
   sidebarContainer: {
     margin: "0",
-    flexBasis: "387px",
+    flexBasis: "15%",
     flexGrow: 0,
     flexShrink: 1,
     backgroundImage: "url(/assets/sidebarBackground.jpg)",
@@ -27,7 +27,7 @@ export const useStyles = createUseStyles({
   },
   "@media (max-width: 1024px)": {
     sidebarContainer: {
-      flexBasis: "200px",
+      flexBasis: "10%",
       flexShrink: 1
     }
   },

--- a/client/src/components/Layout/Sidebar.js
+++ b/client/src/components/Layout/Sidebar.js
@@ -5,7 +5,7 @@ import { createUseStyles } from "react-jss";
 export const useStyles = createUseStyles({
   sidebarContainer: {
     margin: "0",
-    flexBasis: "15%",
+    flexBasis: "387px",
     flexGrow: 0,
     flexShrink: 1,
     backgroundImage: "url(/assets/sidebarBackground.jpg)",
@@ -27,7 +27,7 @@ export const useStyles = createUseStyles({
   },
   "@media (max-width: 1024px)": {
     sidebarContainer: {
-      flexBasis: "10%",
+      flexBasis: "200px",
       flexShrink: 1
     }
   },


### PR DESCRIPTION
…contentContained and sidebarContainer

Fixes #1705

### What changes did you make?

- change flex: "1 1 auto" in ContentContainer.js to flex:1 

### Why did you make the changes (we will use this info to test)?

- reducing flex basis to 0 makes it so the content doesn't expand when answer takes up space, it adjusts the content within the container 

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)



<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1432" alt="fix-sidebar-width-faq-page-before" src="https://github.com/user-attachments/assets/fdba46a5-42cb-4b14-b2e1-1be1d652a0de">




</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1419" alt="fix-sidebar-width-faq-page-after" src="https://github.com/user-attachments/assets/44b7aac7-94e5-470b-b2ae-77be21423980">

</details>
