### PR TITLE
Modify the PDF Print format so the footer appears on each page

### DIFF
--- a/client/src/components/PdfPrint/PdfFooter.js
+++ b/client/src/components/PdfPrint/PdfFooter.js
@@ -12,7 +12,13 @@ const useStyles = createUseStyles({
   },
   pdfFooterContainer: {
     margin: "24px 0 0",
-    width: "100%"
+    width: "100%",
+    position: "fixed",
+    bottom: "0",
+    height: "100px",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-end"
   }
 });
 

--- a/client/src/components/PdfPrint/PdfPrint.js
+++ b/client/src/components/PdfPrint/PdfPrint.js
@@ -119,6 +119,9 @@ const useStyles = createUseStyles({
     marginLeft: "12px",
     border: "1px solid #E7EBF0"
   },
+  footerSpace: {
+    height: "100px"
+  },
   "@media (max-width: 768px)": {
     logoContainer: {
       justifySelf: "start"
@@ -177,151 +180,202 @@ export const PdfPrint = forwardRef((props, ref) => {
 
   return (
     <div ref={ref} className={classes.Pdf}>
-      <h1>
-        <img
-          className={classes.logo}
-          src={logo}
-          alt="LA Department of Transportation Logo"
-        />
-        {""} | TDM Calculation Project Summary
-      </h1>
-      <section className={classes.categoryContainer}>
-        <div
-          className={[
-            classes.categoryHeaderContainer,
-            classes.projectTitleName
-          ]}
-        >
-          <span
-            className={classes.categoryHeader}
-            style={{
-              paddingLeft: "12px"
-            }}
-          >
-            PROJECT NAME:
-          </span>
-          {projectName && projectName.value ? (
-            <span className={classes.textProjectInfoHeaderAddress}>
-              {projectName.value}
-            </span>
-          ) : null}
-        </div>
-        <div className={classes.projectInfoDetailsContainer}>
-          {projectAddress && projectAddress.value && (
-            <ProjectInfo name={projectAddress.name} rule={projectAddress} />
-          )}
-          {parcelNumbers && parcelNumbers.value ? (
-            <ProjectInfoList name={"PARCEL # (AIN)"} rule={parcelNumbers} />
-          ) : null}
-          {buildingPermit && (
-            <ProjectInfo name={buildingPermit.name} rule={buildingPermit} />
-          )}
-          {versionNumber && (
-            <ProjectInfo name={versionNumber.name} rule={versionNumber} />
-          )}
-          {caseNumberPlanning && (
-            <ProjectInfo
-              name={caseNumberPlanning.name}
-              rule={caseNumberPlanning}
-            />
-          )}
-          {caseNumberLADOT && (
-            <ProjectInfo name={caseNumberLADOT.name} rule={caseNumberLADOT} />
-          )}
-        </div>
-      </section>
-      <section className={classes.categoryContainer}>
-        <div className={clsx("space-between", classes.categoryHeaderContainer)}>
-          <span className={classes.categoryHeader}>RESULTS</span>
-        </div>
-        <div className={classes.pdfResultsContainer}>
-          <PdfResult
-            rule={targetPoints}
-            valueTestId={"summary-pdf-target-points-value"}
-          />
-          <PdfResult
-            rule={earnedPoints}
-            valueTestId={"summary-pdf-earned-points-value"}
-          />
-        </div>
-      </section>
-      <section className={classes.categoryContainer}>
-        <div className={clsx("space-between", classes.categoryHeaderContainer)}>
-          <span className={classes.categoryHeader}>PROJECT DETAILS</span>
-        </div>
-        <div className={classes.measuresContainer}>
-          <ProjectDetail
-            rule={level}
-            value={level.value.toString()}
-            valueTestId={"summary-project-level-value"}
-          />
-          <LandUses rules={rules} />
-          {rulesNotEmpty
-            ? specificationRules.map(rule => {
-                return (
-                  <ProjectDetail rule={rule} valueTestId={""} key={rule.id} />
-                );
-              })
-            : null}
-          <ProjectDetail
-            rule={parkingProvided}
-            value={numberWithCommas(roundToTwo(parkingProvided.value))}
-            valueTestId={""}
-          />
-          <ProjectDetail
-            rule={parkingRequired}
-            value={numberWithCommas(roundToTwo(parkingRequired.value))}
-            valueTestId={""}
-          />
-          <ProjectDetail
-            rule={parkingRatio}
-            value={Math.floor(parkingRatio.value).toString()}
-            valueTestId={"summary-parking-ratio-value"}
-          />
-          {projectDescription &&
-          projectDescription.value &&
-          projectDescription.value.length > 0 ? (
-            <div>
-              <div className={classes.rule}>
-                <div className={classes.projectDescription}>
-                  {projectDescription.name}:
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <h1>
+                <img
+                  className={classes.logo}
+                  src={logo}
+                  alt="LA Department of Transportation Logo"
+                />
+                {""} | TDM Calculation Project Summary
+              </h1>
+              <section className={classes.categoryContainer}>
+                <div
+                  className={[
+                    classes.categoryHeaderContainer,
+                    classes.projectTitleName
+                  ]}
+                >
+                  <span
+                    className={classes.categoryHeader}
+                    style={{
+                      paddingLeft: "12px"
+                    }}
+                  >
+                    PROJECT NAME:
+                  </span>
+                  {projectName && projectName.value ? (
+                    <span className={classes.textProjectInfoHeaderAddress}>
+                      {projectName.value}
+                    </span>
+                  ) : null}
                 </div>
-              </div>
-              <div className={classes.projectDescriptionValue}>
-                {projectDescription.value}
-              </div>
-            </div>
-          ) : null}
-        </div>
-      </section>
-      <section className={classes.categoryContainer}>
-        <div className={clsx("space-between", classes.categoryHeaderContainer)}>
-          <span className={classes.categoryHeader}>
-            TDM STRATEGIES SELECTED
-          </span>
-          <span className={classes.earnedPoints}>EARNED POINTS</span>
-        </div>
-        <div className={classes.measuresContainer}>
-          {rulesNotEmpty
-            ? measureRules.map(rule => (
-                <MeasureSelected rule={rule} key={rule.id} />
-              ))
-            : null}
-          {userDefinedStrategy.calcValue &&
-          userDefinedStrategy.comment.length > 0 ? (
-            <div>
-              <div className={classes.rule}>
-                <div className={classes.ruleName}>
-                  User-Defined Strategy Details:
+                <div className={classes.projectInfoDetailsContainer}>
+                  {projectAddress && projectAddress.value && (
+                    <ProjectInfo
+                      name={projectAddress.name}
+                      rule={projectAddress}
+                    />
+                  )}
+                  {parcelNumbers && parcelNumbers.value ? (
+                    <ProjectInfoList
+                      name={"PARCEL # (AIN)"}
+                      rule={parcelNumbers}
+                    />
+                  ) : null}
+                  {buildingPermit && (
+                    <ProjectInfo
+                      name={buildingPermit.name}
+                      rule={buildingPermit}
+                    />
+                  )}
+                  {versionNumber && (
+                    <ProjectInfo
+                      name={versionNumber.name}
+                      rule={versionNumber}
+                    />
+                  )}
+                  {caseNumberPlanning && (
+                    <ProjectInfo
+                      name={caseNumberPlanning.name}
+                      rule={caseNumberPlanning}
+                    />
+                  )}
+                  {caseNumberLADOT && (
+                    <ProjectInfo
+                      name={caseNumberLADOT.name}
+                      rule={caseNumberLADOT}
+                    />
+                  )}
                 </div>
-              </div>
-              <div className={classes.summaryContainer}>
-                {userDefinedStrategy.comment}
-              </div>
-            </div>
-          ) : null}
-        </div>
-      </section>
+              </section>
+              <section className={classes.categoryContainer}>
+                <div
+                  className={clsx(
+                    "space-between",
+                    classes.categoryHeaderContainer
+                  )}
+                >
+                  <span className={classes.categoryHeader}>RESULTS</span>
+                </div>
+                <div className={classes.pdfResultsContainer}>
+                  <PdfResult
+                    rule={targetPoints}
+                    valueTestId={"summary-pdf-target-points-value"}
+                  />
+                  <PdfResult
+                    rule={earnedPoints}
+                    valueTestId={"summary-pdf-earned-points-value"}
+                  />
+                </div>
+              </section>
+              <section className={classes.categoryContainer}>
+                <div
+                  className={clsx(
+                    "space-between",
+                    classes.categoryHeaderContainer
+                  )}
+                >
+                  <span className={classes.categoryHeader}>
+                    PROJECT DETAILS
+                  </span>
+                </div>
+                <div className={classes.measuresContainer}>
+                  <ProjectDetail
+                    rule={level}
+                    value={level.value.toString()}
+                    valueTestId={"summary-project-level-value"}
+                  />
+                  <LandUses rules={rules} />
+                  {rulesNotEmpty
+                    ? specificationRules.map(rule => {
+                        return (
+                          <ProjectDetail
+                            rule={rule}
+                            valueTestId={""}
+                            key={rule.id}
+                          />
+                        );
+                      })
+                    : null}
+                  <ProjectDetail
+                    rule={parkingProvided}
+                    value={numberWithCommas(roundToTwo(parkingProvided.value))}
+                    valueTestId={""}
+                  />
+                  <ProjectDetail
+                    rule={parkingRequired}
+                    value={numberWithCommas(roundToTwo(parkingRequired.value))}
+                    valueTestId={""}
+                  />
+                  <ProjectDetail
+                    rule={parkingRatio}
+                    value={Math.floor(parkingRatio.value).toString()}
+                    valueTestId={"summary-parking-ratio-value"}
+                  />
+                  {projectDescription &&
+                  projectDescription.value &&
+                  projectDescription.value.length > 0 ? (
+                    <div>
+                      <div className={classes.rule}>
+                        <div className={classes.projectDescription}>
+                          {projectDescription.name}:
+                        </div>
+                      </div>
+                      <div className={classes.projectDescriptionValue}>
+                        {projectDescription.value}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              </section>
+              <section className={classes.categoryContainer}>
+                <div
+                  className={clsx(
+                    "space-between",
+                    classes.categoryHeaderContainer
+                  )}
+                >
+                  <span className={classes.categoryHeader}>
+                    TDM STRATEGIES SELECTED
+                  </span>
+                  <span className={classes.earnedPoints}>EARNED POINTS</span>
+                </div>
+                <div className={classes.measuresContainer}>
+                  {rulesNotEmpty
+                    ? measureRules.map(rule => (
+                        <MeasureSelected rule={rule} key={rule.id} />
+                      ))
+                    : null}
+                  {userDefinedStrategy.calcValue &&
+                  userDefinedStrategy.comment.length > 0 ? (
+                    <div>
+                      <div className={classes.rule}>
+                        <div className={classes.ruleName}>
+                          User-Defined Strategy Details:
+                        </div>
+                      </div>
+                      <div className={classes.summaryContainer}>
+                        {userDefinedStrategy.comment}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              </section>
+            </td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td>
+              <div className={classes.footerSpace} />
+            </td>
+          </tr>
+        </tfoot>
+      </table>
 
       <PdfFooter project={project} />
     </div>


### PR DESCRIPTION
Fixes #1757 

### What changes did you make?

- Made it so the PDF print footer appears at the bottom of every page without overlapping
- Justify content to bottom for when the footer is smaller (i.e. no snapshots)

### Why did you make the changes (we will use this info to test)?

- Footer appears right under the body instead of at the bottom of every page

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![old_pdf_1](https://github.com/user-attachments/assets/942bcc46-a41c-402d-b539-a3fd4911cf4c)

![old_pdf_2](https://github.com/user-attachments/assets/3e758ddc-821d-4cdd-abfc-90cf5dc40b52)

![old_pdf_3_small_footer](https://github.com/user-attachments/assets/6c8fb54e-2799-4dd2-bf86-7381ee91d92f)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![new_pdf_1](https://github.com/user-attachments/assets/6ec98557-81db-49cf-bd2d-d214ce143a61)

![new_pdf_2](https://github.com/user-attachments/assets/65880366-520f-4c47-82eb-e52b07f92b08)

![new_pdf_3_small_footer](https://github.com/user-attachments/assets/9078e834-5880-46d2-af9d-64d28839d5bc)


</details>
