### PR TITLE
Aligned and switchout icons for expand and collapse

### DIFF
--- a/client/src/components/Faq/ExpandButtons.jsx
+++ b/client/src/components/Faq/ExpandButtons.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
-import { MdExpandLess, MdExpandMore } from "react-icons/md";
+import { MdOutlineUnfoldMore, MdOutlineUnfoldLess } from "react-icons/md";
 
 const useStyles = createUseStyles({
   expandCollapseFlexContainer: {
@@ -38,22 +38,36 @@ const ExpandButtons = ({ toggleExpandCollapse }) => {
   return (
     <div className={classes.expandCollapseFlexContainer}>
       <div className={classes.expandCollapseAll}>
-        <div className={classes.faqExpandIcons}>
-          <MdExpandMore className={classes.faqCarotIcon} />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center"
+          }}
+        >
+          <MdOutlineUnfoldMore className={classes.faqCarotIcon} />
+          <button
+            className={classes.toggleButton}
+            onClick={() => toggleExpandCollapse(true)}
+          >
+            Expand All
+          </button>
         </div>
-        <button
-          className={classes.toggleButton}
-          onClick={() => toggleExpandCollapse(true)}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center"
+          }}
         >
-          Expand All
-        </button>
-        <MdExpandLess className={classes.faqCarotIcon} />
-        <button
-          className={classes.toggleButton}
-          onClick={() => toggleExpandCollapse()}
-        >
-          Collapse All
-        </button>
+          <MdOutlineUnfoldLess className={classes.faqCarotIcon} />
+          <button
+            className={classes.toggleButton}
+            onClick={() => toggleExpandCollapse()}
+          >
+            Collapse All
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/Faq/FaqButtonContainer.jsx
+++ b/client/src/components/Faq/FaqButtonContainer.jsx
@@ -51,12 +51,12 @@ export const FaqButtonContainer = ({
       )}
       <div className={classes.faqIcon}>
         {faq.expand ? (
-          <MdExpandMore
+          <MdExpandLess
             style={{ cursor: "pointer" }}
             onClick={() => collapseFaq(faq)}
           />
         ) : (
-          <MdExpandLess
+          <MdExpandMore
             style={{ cursor: "pointer" }}
             onClick={() => expandFaq(faq)}
           />


### PR DESCRIPTION
Fixes #1798 

### What changes did you make?

- Aligned the expand and collapse icon to the text.
- Switched out the expand all, collapse all, expand, and collapse button to match the design guide.

### Why did you make the changes (we will use this info to test)?

- Incorrect icons were switched out to the correct icons.

### Issue-Specific User Account

tdm@hackforla.org account was used for testing.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2024-08-28 at 8 12 27 PM](https://github.com/user-attachments/assets/251b5559-e9f1-4af8-bec4-4e11e81c89cd)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2024-08-28 at 8 12 46 PM](https://github.com/user-attachments/assets/0c466e9b-02f8-4021-8e80-b2ef39886197)

</details>
