### PR TITLE
Replace and correct all icons in the project with Material UI icons 

### DIFF
--- a/client/src/components/Projects/CsvModal.js
+++ b/client/src/components/Projects/CsvModal.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { PropTypes } from "prop-types";
-import { FaFileCsv } from "react-icons/fa";
+import { FaFileCsv } from "react-icons/fa6";
 import Button from "../Button/Button";
 import { createUseStyles, useTheme } from "react-jss";
 import ModalDialog from "../UI/AriaModal/ModalDialog";

--- a/client/src/components/Projects/MultiProjectToolbarMenu.js
+++ b/client/src/components/Projects/MultiProjectToolbarMenu.js
@@ -2,7 +2,7 @@ import React, { useContext, useRef } from "react";
 import UserContext from "../../contexts/UserContext";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
-import { FaFileCsv } from "react-icons/fa";
+import { FaFileCsv } from "react-icons/fa6";
 import {
   MdDelete,
   MdRestoreFromTrash,

--- a/client/src/components/Projects/ProjectContextMenu.js
+++ b/client/src/components/Projects/ProjectContextMenu.js
@@ -3,12 +3,12 @@ import UserContext from "../../contexts/UserContext";
 import PropTypes from "prop-types";
 
 import { createUseStyles } from "react-jss";
-import { FaFileCsv } from "react-icons/fa";
+import { FaFileCsv } from "react-icons/fa6";
 import {
   MdPrint,
   MdVisibility,
   MdVisibilityOff,
-  MdCamera,
+  MdCameraAlt,
   MdDelete,
   MdRestoreFromTrash,
   MdFileCopy,
@@ -91,7 +91,7 @@ const ProjectContextMenu = ({
           className={classes.listItem}
           onClick={() => handleClick(handleSnapshotModalOpen)}
         >
-          <MdCamera
+          <MdCameraAlt
             className={classes.listItemIcon}
             alt={`Snapshot Project #${project.id} Icon`}
           />

--- a/client/src/components/Projects/SnapshotProjectModal.js
+++ b/client/src/components/Projects/SnapshotProjectModal.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { createUseStyles, useTheme } from "react-jss";
 
 import Button from "../Button/Button";
-import { MdFileCopy } from "react-icons/md";
+import { MdCameraAlt } from "react-icons/md";
 import ModalDialog from "../UI/AriaModal/ModalDialog";
 
 const useStyles = createUseStyles(theme => ({
@@ -16,6 +16,9 @@ const useStyles = createUseStyles(theme => ({
   heading1: theme.typography.heading1,
   buttonColor: {
     backgroundColor: "#eaeff2"
+  },
+  camera: {
+    marginBottom: "-5px"
   }
 }));
 
@@ -37,7 +40,7 @@ export default function SnapshotProjectModal({
       initialFocus="#duplicateName"
     >
       <div className={classes.heading1} style={{ marginBottom: "1.5rem" }}>
-        <MdFileCopy /> Convert &quot;
+        <MdCameraAlt className={classes.camera} /> Convert &quot;
         {`${selectedProjectName}`}&quot; Into a Snapshot?
       </div>
       <div style={theme.typography.subHeading}>


### PR DESCRIPTION
Fixes #1790

### What changes did you make?

- Swap out MDCamera (aperture shaped) icon for MDCameraAlt (camera shaped)
- Swap FA FileCsv for FA6 FileCsv
- aligned camera to text on the snapshot modal

### Why did you make the changes (we will use this info to test)?

- Icons were inconsistent with the style guide

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![old_projectsPage-camera+csv](https://github.com/user-attachments/assets/61554849-d862-4797-b124-03053e9f0bb7)

![old_ProjectsPage-CSV](https://github.com/user-attachments/assets/1be611c6-b128-449f-9b94-69bbe21388f7)

![old_snapshotProjectModal](https://github.com/user-attachments/assets/0e14fbec-a18c-4d72-8212-87438f71ef96)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![projectsPage-camera+csv](https://github.com/user-attachments/assets/4363d9be-aae8-4af9-b9c2-b2f488830006)

![ProjectsPage-CSV](https://github.com/user-attachments/assets/087181b2-c8f4-47e6-a14b-dc1525fee848)

![snapshotProjectModal](https://github.com/user-attachments/assets/6e6daf7e-5159-4069-92e8-6d98e82df955)


</details>
