### PR TITLE
1354 affordable housing edge case dialog

### DIFF
--- a/client/src/components/PdfPrint/PdfFooter.js
+++ b/client/src/components/PdfPrint/PdfFooter.js
@@ -98,7 +98,7 @@ const PdfFooter = ({ project }) => {
 };
 
 PdfFooter.propTypes = {
-  project: PropTypes.shape(PropTypes.any)
+  project: PropTypes.any
 };
 
 export default PdfFooter;

--- a/client/src/components/PdfPrint/PdfPrint.js
+++ b/client/src/components/PdfPrint/PdfPrint.js
@@ -384,7 +384,7 @@ export const PdfPrint = forwardRef((props, ref) => {
 
 PdfPrint.propTypes = {
   rules: PropTypes.array,
-  project: PropTypes.shape
+  project: PropTypes.any
 };
 
 export default PdfPrint;

--- a/client/src/components/ProjectWizard/AffordableEdgeCaseModal.js
+++ b/client/src/components/ProjectWizard/AffordableEdgeCaseModal.js
@@ -36,7 +36,7 @@ const useStyles = createUseStyles(theme => ({
 const AffordableEdgeCaseModal = ({ isOpen, onClose, onYes }) => {
   const classes = useStyles();
   return (
-    <ModalDialog mounted={isOpen} onClose={onClose}>
+    <ModalDialog mounted={isOpen} onClose={onClose} omitCloseBox={true}>
       <div className={classes.container}>
         <div className={classes.modalHeader} style={{ marginBottom: "1.5rem" }}>
           <MdError

--- a/client/src/components/ProjectWizard/AffordableEdgeCaseModal.js
+++ b/client/src/components/ProjectWizard/AffordableEdgeCaseModal.js
@@ -1,0 +1,73 @@
+import React from "react";
+import PropTypes from "prop-types";
+import ModalDialog from "../UI/AriaModal/ModalDialog";
+import Button from "../Button/Button";
+import { createUseStyles } from "react-jss";
+import { MdError } from "react-icons/md";
+
+const useStyles = createUseStyles(theme => ({
+  container: {
+    width: "80%",
+    maxWidth: "35rem",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-end",
+    margin: 0
+  },
+  buttonFlexBox: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "center",
+    margin: 0
+  },
+  modalHeader: theme.typography.heading1,
+  modalSubHeader: theme.typography.subHeading,
+  instruction: {
+    fontSize: "20px",
+    lineHeight: "32px",
+    textAlign: "center",
+    color: "#B64E38",
+    "& span": {
+      fontStyle: "italic"
+    }
+  }
+}));
+
+const AffordableEdgeCaseModal = ({ isOpen, onClose, onYes }) => {
+  const classes = useStyles();
+  return (
+    <ModalDialog mounted={isOpen} onClose={onClose}>
+      <div className={classes.container}>
+        <div className={classes.modalHeader} style={{ marginBottom: "1.5rem" }}>
+          <MdError
+            style={{
+              marginBottom: "-5px",
+              color: "#C35302",
+              height: "80px",
+              width: "5rem"
+            }}
+          />
+        </div>
+        <div className={classes.modalSubHeader}>
+          {`100% affordable housing of less than 50 units are exempt from the TDM Ordinance. Did you intend to change to 100% Affordable Housing?`}
+        </div>
+        <div className={classes.buttonFlexBox}>
+          <Button onClick={onClose} variant="text" id="cancelButton">
+            NO
+          </Button>
+          <Button onClick={onYes} variant="contained" color={"colorPrimary"}>
+            YES
+          </Button>
+        </div>
+      </div>
+    </ModalDialog>
+  );
+};
+
+AffordableEdgeCaseModal.propTypes = {
+  isOpen: PropTypes.bool,
+  onClose: PropTypes.func,
+  onYes: PropTypes.func
+};
+
+export default AffordableEdgeCaseModal;

--- a/client/src/components/ProjectWizard/PackagePanel/RulePackage.js
+++ b/client/src/components/ProjectWizard/PackagePanel/RulePackage.js
@@ -116,7 +116,7 @@ const RulePackage = ({ name, checked, onPkgSelect, packageTooltip }) => {
     <div className={classes.container}>
       <div className={classes.rowContainer}>
         <RuleStrategyLabel
-          id="778875"
+          id={Number("778875")}
           code="sss"
           description={packageTooltip}
           display={true}

--- a/client/src/components/ProjectWizard/RuleStrategy/RuleStrategy.js
+++ b/client/src/components/ProjectWizard/RuleStrategy/RuleStrategy.js
@@ -349,7 +349,7 @@ RuleStrategy.propTypes = {
     calcUnits: PropTypes.string,
     calcMinValue: PropTypes.number,
     calcMaxValue: PropTypes.number,
-    description: PropTypes.string,
+    description: PropTypes.any,
     display: PropTypes.bool,
     displayComment: PropTypes.bool,
     comment: PropTypes.string,

--- a/client/src/components/ProjectWizard/RuleStrategy/RuleStrategyLabel.js
+++ b/client/src/components/ProjectWizard/RuleStrategy/RuleStrategyLabel.js
@@ -37,7 +37,7 @@ RuleStrategyLabel.propTypes = {
   id: PropTypes.number.isRequired,
   code: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  description: PropTypes.string,
+  description: PropTypes.any,
   display: PropTypes.bool,
   required: PropTypes.bool,
   link: PropTypes.string,

--- a/client/src/components/ProjectWizard/TdmCalculationContainer.js
+++ b/client/src/components/ProjectWizard/TdmCalculationContainer.js
@@ -364,6 +364,13 @@ export function TdmCalculationContainer({ contentContainerRef }) {
         // The 100% Affordable Housing Input should be set to true
         if (value === "4") {
           formInputs["AFFORDABLE_HOUSING"] = true;
+          // If < 50 residential units and Affordable Housing is changed to 100%,
+          // then page 4 is no longer applicable, redirect to page 3.
+          if (projectLevel <= 1) {
+            const thirdPage =
+              "/calculation/3" + (projectId ? `/${projectId}` : "/0");
+            navigate(thirdPage);
+          }
         } else {
           formInputs["AFFORDABLE_HOUSING"] = false;
         }

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -79,6 +79,10 @@ const TdmCalculationWizard = props => {
   */
   const calculationPath = "/calculation/:page/:projectId?/*";
 
+  const onInputChangeMeasure = e => {
+    return onInputChange(e);
+  };
+
   const shouldBlock = React.useCallback(
     ({ currentLocation, nextLocation }) => {
       const isSameProject = (currentLocation, nextLocation) => {
@@ -280,7 +284,7 @@ const TdmCalculationWizard = props => {
             projectLevel={projectLevel}
             rules={strategyRules}
             landUseRules={landUseRules}
-            onInputChange={onInputChange}
+            onInputChange={onInputChangeMeasure}
             onCommentChange={onCommentChange}
             initializeStrategies={initializeStrategies}
             onPkgSelect={onPkgSelect}
@@ -392,7 +396,7 @@ TdmCalculationWizard.propTypes = {
   // dateSubmitted: PropTypes.string,
   inapplicableStrategiesModal: PropTypes.bool,
   closeStrategiesModal: PropTypes.func,
-  project: PropTypes.shape
+  project: PropTypes.any
 };
 
 export default TdmCalculationWizard;

--- a/client/src/components/ProjectWizard/WizardFooter.js
+++ b/client/src/components/ProjectWizard/WizardFooter.js
@@ -121,6 +121,7 @@ const WizardFooter = ({
               id="submitButton"
               color="colorPrimary"
               isDisplayed={false && setDisplaySubmitButton()}
+              onClick={() => null}
             />
           </>
         ) : null}
@@ -173,7 +174,7 @@ WizardFooter.propTypes = {
   setDisplaySubmitButton: PropTypes.any,
   onSave: PropTypes.any,
   onDownload: PropTypes.any,
-  project: PropTypes.shape
+  project: PropTypes.any
 };
 
 export default WizardFooter;

--- a/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.js
@@ -1,10 +1,11 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import PackagePanel from "../PackagePanel/PackagePanel";
 import RuleStrategyPanels from "../RuleStrategy/RuleStrategyPanels";
 import { createUseStyles, useTheme } from "react-jss";
 import ResetButtons from "./ResetButtons";
 import { MdCheckCircle } from "react-icons/md";
+import AffordableEdgeCaseModal from "../AffordableEdgeCaseModal";
 
 const useStyles = createUseStyles({
   pkgSelectContainer: {
@@ -64,6 +65,55 @@ function ProjectMeasure(props) {
   const theme = useTheme();
   const classes = useStyles({ theme });
 
+  const [affordableEdgeCaseModalOpen, setAffordableEdgeCaseModalOpen] =
+    useState(false);
+  const [inputEvent, setInputEvent] = useState({});
+
+  const closeAffordableEdgeCaseModal = () => {
+    setAffordableEdgeCaseModalOpen(false);
+  };
+
+  const handleAffordableEdgeCaseModalProceed = () => {
+    // Submit data and set admin to false
+    onInputChange(inputEvent);
+    // Close the save confirmation modal
+    setAffordableEdgeCaseModalOpen(false);
+  };
+
+  const projectLevel =
+    rules && rules.find(rule => rule.code === "PROJECT_LEVEL")
+      ? rules.find(rule => rule.code === "PROJECT_LEVEL").value
+      : 0;
+
+  const onInputChangeIfAllowed = e => {
+    const ruleCode = (e.target && e.target.name) || e.detail.name;
+    // console.error(ruleCode);
+    // console.error(e.target.value);
+    // console.error(projectLevel);
+    if (
+      ruleCode === "STRATEGY_AFFORDABLE" &&
+      e.target.value == 4 &&
+      projectLevel <= 1
+    ) {
+      /* Need to stash the event object to pass to parent if user chooses to proceed.
+      However, React only stores part of the event (specifically excludes e.target.value)
+      when stored in a state variable, so we need to phony up and event object that
+      can be passed to the parent while retaining the essential properties.
+      */
+      const target = {
+        type: e.target.type,
+        name: e.target.name,
+        value: e.target.value,
+        checked: e.checked
+      };
+      const phonyEvent = { target };
+      setInputEvent(phonyEvent);
+      setAffordableEdgeCaseModalOpen(true);
+    } else {
+      onInputChange(e);
+    }
+  };
+
   useEffect(() => {
     initializeStrategies();
   });
@@ -106,8 +156,13 @@ function ProjectMeasure(props) {
       )}
       <RuleStrategyPanels
         rules={rules.filter(r => r.calculationPanelId != 27)}
-        onInputChange={onInputChange}
+        onInputChange={onInputChangeIfAllowed}
         onCommentChange={onCommentChange}
+      />
+      <AffordableEdgeCaseModal
+        isOpen={affordableEdgeCaseModalOpen}
+        onClose={closeAffordableEdgeCaseModal}
+        onYes={handleAffordableEdgeCaseModalProceed}
       />
     </div>
   );

--- a/client/src/components/ToolTip/ToolTipLabel.js
+++ b/client/src/components/ToolTip/ToolTipLabel.js
@@ -193,13 +193,13 @@ const ToolTipLabel = ({
 
 ToolTipLabel.propTypes = {
   id: PropTypes.string.isRequired,
-  tooltipContent: PropTypes.string.isRequired,
+  tooltipContent: PropTypes.any.isRequired,
   children: PropTypes.node.isRequired,
   code: PropTypes.string,
   requiredInput: PropTypes.bool,
   disabledInput: PropTypes.bool,
   setShowDescription: PropTypes.func,
-  description: PropTypes.string,
+  description: PropTypes.any,
   showDescription: PropTypes.bool
 };
 

--- a/client/src/components/UI/AriaModal/ModalDialog.js
+++ b/client/src/components/UI/AriaModal/ModalDialog.js
@@ -41,6 +41,12 @@ const useStyles = createUseStyles({
     justifyContent: "flex-end",
     margin: 0
   },
+  contentFlexBox: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "center",
+    margin: 0
+  },
   closeButton: {
     border: "0 solid white",
     backgroundColor: "transparent",
@@ -93,7 +99,7 @@ export default function ModalDialog({
             </button>
           </div>
         )}
-        {children}
+        <div className={classes.contentFlexBox}>{children}</div>
       </div>
     </AriaModal>
   );


### PR DESCRIPTION
Fixes #1354

### What changes did you make?

- Implemented Warning Dialog when user chooses 100% affordable housing strategy for project with 25-49 residential units.
-
-

### Why did you make the changes (we will use this info to test)?

- See Issue #1354
-
-



### Screenshots of  Changes to the Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
