### PR TITLE
Fix Affordable Housing edge case

### DIFF
--- a/client/src/components/ProjectWizard/RuleStrategy/RuleStrategyList.js
+++ b/client/src/components/ProjectWizard/RuleStrategy/RuleStrategyList.js
@@ -12,6 +12,7 @@ const useStyles = createUseStyles({
 });
 
 const RuleStrategyList = ({
+  projectLevel,
   rules,
   onInputChange,
   onCommentChange,
@@ -25,6 +26,7 @@ const RuleStrategyList = ({
             return (
               <RuleStrategy
                 key={rule.id}
+                projectLevel={projectLevel}
                 rule={rule}
                 onPropInputChange={onInputChange}
                 onCommentChange={onCommentChange}
@@ -38,6 +40,7 @@ const RuleStrategyList = ({
 };
 
 RuleStrategyList.propTypes = {
+  projectLevel: PropTypes.number,
   rules: PropTypes.array.isRequired,
   onInputChange: PropTypes.func.isRequired,
   onCommentChange: PropTypes.func.isRequired,

--- a/client/src/components/ProjectWizard/RuleStrategy/RuleStrategyPanels.js
+++ b/client/src/components/ProjectWizard/RuleStrategy/RuleStrategyPanels.js
@@ -81,6 +81,7 @@ const RuleStrategyPanels = props => {
               ) : null}
               <RuleStrategyList
                 key={rules[0].calculationPanelId}
+                projectLevel={projectLevel}
                 rules={rules}
                 onInputChange={props.onInputChange}
                 onCommentChange={props.onCommentChange}

--- a/client/src/components/ProjectWizard/TdmCalculationContainer.js
+++ b/client/src/components/ProjectWizard/TdmCalculationContainer.js
@@ -540,14 +540,9 @@ export function TdmCalculationContainer({ contentContainerRef }) {
       schoolPackageSelected={schoolPackageSelected}
       formIsDirty={!formHasSaved}
       projectIsValid={projectIsValid}
-      // loginId={loginId}
-      // dateModified={dateModified}
-      // dateSnapshotted={dateSnapshotted}
-      // dateSubmitted={dateSubmitted}
       contentContainerRef={contentContainerRef}
       inapplicableStrategiesModal={inapplicableStrategiesModal}
       closeStrategiesModal={closeStrategiesModal}
-      // projectId={projectId}
       project={project}
     />
   );

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.js
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.js
@@ -45,7 +45,6 @@ const TdmCalculationWizard = props => {
     onPkgSelect,
     onParkingProvidedChange,
     resultRuleCodes,
-    // loginId,
     onSave,
     allowResidentialPackage,
     allowSchoolPackage,
@@ -53,9 +52,6 @@ const TdmCalculationWizard = props => {
     schoolPackageSelected,
     formIsDirty,
     projectIsValid,
-    // dateModified,
-    // dateSnapshotted,
-    // dateSubmitted,
     contentContainerRef,
     inapplicableStrategiesModal,
     closeStrategiesModal,
@@ -331,7 +327,6 @@ const TdmCalculationWizard = props => {
       >
         {pageContents(page)}
         <WizardFooter
-          // projectId={projectId}
           rules={rules}
           page={page}
           onPageChange={onPageChange}
@@ -343,10 +338,6 @@ const TdmCalculationWizard = props => {
           setDisplaySubmitButton={setDisplaySubmitButton}
           onSave={onSave}
           project={project}
-          // dateModified={dateModified}
-          // dateSnapshotted={dateSnapshotted}
-          // dateSubmitted={dateSubmitted}
-          // loginId={loginId}
         />
       </ContentContainer>
     </div>

--- a/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.js
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.js
@@ -1,11 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import PackagePanel from "../PackagePanel/PackagePanel";
 import RuleStrategyPanels from "../RuleStrategy/RuleStrategyPanels";
 import { createUseStyles, useTheme } from "react-jss";
 import ResetButtons from "./ResetButtons";
 import { MdCheckCircle } from "react-icons/md";
-import AffordableEdgeCaseModal from "../AffordableEdgeCaseModal";
 
 const useStyles = createUseStyles({
   pkgSelectContainer: {
@@ -49,6 +48,7 @@ const useStyles = createUseStyles({
 });
 function ProjectMeasure(props) {
   const {
+    projectLevel,
     rules,
     onInputChange,
     onCommentChange,
@@ -64,55 +64,6 @@ function ProjectMeasure(props) {
 
   const theme = useTheme();
   const classes = useStyles({ theme });
-
-  const [affordableEdgeCaseModalOpen, setAffordableEdgeCaseModalOpen] =
-    useState(false);
-  const [inputEvent, setInputEvent] = useState({});
-
-  const closeAffordableEdgeCaseModal = () => {
-    setAffordableEdgeCaseModalOpen(false);
-  };
-
-  const handleAffordableEdgeCaseModalProceed = () => {
-    // Submit data and set admin to false
-    onInputChange(inputEvent);
-    // Close the save confirmation modal
-    setAffordableEdgeCaseModalOpen(false);
-  };
-
-  const projectLevel =
-    rules && rules.find(rule => rule.code === "PROJECT_LEVEL")
-      ? rules.find(rule => rule.code === "PROJECT_LEVEL").value
-      : 0;
-
-  const onInputChangeIfAllowed = e => {
-    const ruleCode = (e.target && e.target.name) || e.detail.name;
-    // console.error(ruleCode);
-    // console.error(e.target.value);
-    // console.error(projectLevel);
-    if (
-      ruleCode === "STRATEGY_AFFORDABLE" &&
-      e.target.value == 4 &&
-      projectLevel <= 1
-    ) {
-      /* Need to stash the event object to pass to parent if user chooses to proceed.
-      However, React only stores part of the event (specifically excludes e.target.value)
-      when stored in a state variable, so we need to phony up and event object that
-      can be passed to the parent while retaining the essential properties.
-      */
-      const target = {
-        type: e.target.type,
-        name: e.target.name,
-        value: e.target.value,
-        checked: e.checked
-      };
-      const phonyEvent = { target };
-      setInputEvent(phonyEvent);
-      setAffordableEdgeCaseModalOpen(true);
-    } else {
-      onInputChange(e);
-    }
-  };
 
   useEffect(() => {
     initializeStrategies();
@@ -155,19 +106,16 @@ function ProjectMeasure(props) {
         />
       )}
       <RuleStrategyPanels
+        projectLevel={projectLevel}
         rules={rules.filter(r => r.calculationPanelId != 27)}
-        onInputChange={onInputChangeIfAllowed}
+        onInputChange={onInputChange}
         onCommentChange={onCommentChange}
-      />
-      <AffordableEdgeCaseModal
-        isOpen={affordableEdgeCaseModalOpen}
-        onClose={closeAffordableEdgeCaseModal}
-        onYes={handleAffordableEdgeCaseModalProceed}
       />
     </div>
   );
 }
 ProjectMeasure.propTypes = {
+  projectLevel: PropTypes.number,
   rules: PropTypes.arrayOf(
     PropTypes.shape({
       calculationPanelId: PropTypes.number.isRequired,

--- a/client/src/components/UI/UniversalSelect.jsx
+++ b/client/src/components/UI/UniversalSelect.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 
 UniversalSelect.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   options: PropTypes.arrayOf(
     PropTypes.shape({
@@ -20,6 +21,7 @@ UniversalSelect.propTypes = {
 };
 
 export default function UniversalSelect({
+  value,
   defaultValue,
   options,
   onChange,
@@ -37,12 +39,12 @@ export default function UniversalSelect({
       }
     });
   };
-  console.log(defaultValue);
   return (
     <Select
       className={classNames(className)}
       autoFocus={autoFocus}
       onChange={handleSelectChange}
+      value={value}
       defaultValue={defaultValue}
       name={name}
       inputId={id}


### PR DESCRIPTION
Fixes #1354

### What changes did you make?

- Moved the AffordableHousingEdgeCaseModal calls into RuleStrategy, so previous valueof the drop-down can be restored if the user choose No from the dialog.
-
-

### Why did you make the changes (we will use this info to test)?

- The UniversalSelect component was not working - it would not pre-select an existing value.  Switched ReactStrategy component back to using standard react select control.
- The previous attempt at the Affordable Housing dialog was unable to revert to the original value if the user selected "No" when prompted.
