### PR TITLE
TextPopup - unique values from projets, not sortedProjects

### DIFF
--- a/client/src/components/Projects/ProjectsPage.js
+++ b/client/src/components/Projects/ProjectsPage.js
@@ -742,7 +742,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
                           <td key={header.id}>
                             <ProjectTableColumnHeader
                               uniqueValues={[
-                                ...new Set(sortedProjects.map(p => p[property]))
+                                ...new Set(projects.map(p => p[property]))
                               ]
                                 .filter(value => value !== null)
                                 .sort()}


### PR DESCRIPTION
- Fixes #1647
### What changes did you make?

- There was a problem with the implementation. When a filter by text already existed and the popup was opened, the uniqueValues list was based on the sortedProjects, which was already filtered by the previously selected text. This meant that the drop-down list to choose from only included the text strings that already met the previous sort string, so it was not possible to remove the filter or remove characters from the search string. The only way to change the search string was to push "reset", then "apply", then re-open the text popup.
- Fixed by making the uniqueValues based on (unsorted / unfiltered) projects.
-

