### PR TITLE
Make text filtering case insensitive

### DIFF
--- a/client/src/components/Projects/ColumnHeaderPopups/MultiSelectText.js
+++ b/client/src/components/Projects/ColumnHeaderPopups/MultiSelectText.js
@@ -37,7 +37,7 @@ const MultiSelectText = ({ options, selectedOptions, setSelectedOptions }) => {
 
   const filteredOptions = options
     .filter(o => !!o)
-    .filter(opt => opt.includes(searchString));
+    .filter(opt => opt.toLowerCase().includes(searchString.toLowerCase()));
 
   const onChangeSearchString = e => {
     setSearchString(e.target.value);


### PR DESCRIPTION
Fixes #1850

### What changes did you make?

- Make the search for list items on the Text Popup case-insensitive.
-
-


