### PR TITLE
Affordable housing selection shoudl default to N/A

### DIFF
--- a/server/db/migration/V20240919.1358__fix_fix_default_affordable_housing_selection_1854.sql
+++ b/server/db/migration/V20240919.1358__fix_fix_default_affordable_housing_selection_1854.sql
@@ -1,0 +1,7 @@
+UPDATE calculationRule SET 
+choices = '[{"id": "0", "name": "N/A"},
+    {"id": "1", "name": "State Density Bonus"},
+    {"id": "2", "name": "TOC Tiers 1-3"},
+    {"id": "3", "name": "TOC Tier 4"},
+    {"id": "4", "name": "100% Affordable"}]'
+where calculationId = 1 and code = 'STRATEGY_AFFORDABLE'


### PR DESCRIPTION
Fixes #1854

### What changes did you make?

- Change Affordable Housing strategy to default to "N/A" instead of showing "Select..."

### Why did you make the changes (we will use this info to test)?

- To be consistent with other drop-downs


