### PR TITLE
Add Launch icon to external links 

### DIFF
--- a/client/src/components/Faq/Answer.jsx
+++ b/client/src/components/Faq/Answer.jsx
@@ -3,6 +3,7 @@ import Quill from "../UI/Quill";
 import { createUseStyles } from "react-jss";
 import PropTypes from "prop-types";
 import { Interweave } from "interweave";
+import { MdLaunch } from "react-icons/md";
 
 const useStyles = createUseStyles(theme => ({
   answerContainer: {
@@ -22,6 +23,11 @@ const useStyles = createUseStyles(theme => ({
     "&:hover": {
       textDecoration: admin => admin && "underline"
     }
+  },
+  externalLinkIcon: {
+    fontSize: "14px",
+    padding: " 0 0.4em",
+    color: "#00F"
   }
 }));
 
@@ -78,7 +84,7 @@ export const Answer = ({
           style={{ display: "flex" }}
         >
           <div className={classes.answerText}>
-            <Interweave content={answer} />
+            <Interweave transform={TransformExternalLink} content={answer} />
           </div>
         </div>
       )}
@@ -94,3 +100,17 @@ Answer.propTypes = {
   setIsEditAnswer: PropTypes.func,
   onSetFaq: PropTypes.func
 };
+
+function TransformExternalLink(node, children) {
+  const classes = useStyles();
+  if (node.tagName == "A" && !node.getAttribute("href").startsWith("/")) {
+    return (
+      <span>
+        <a href={node.getAttribute("href")} target="external">
+          {children}
+          <MdLaunch className={classes.externalLinkIcon} />
+        </a>
+      </span>
+    );
+  }
+}

--- a/client/src/components/ToolTip/AccordionToolTip.js
+++ b/client/src/components/ToolTip/AccordionToolTip.js
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
 import clsx from "clsx";
+import { Interweave } from "interweave";
+import { MdLaunch } from "react-icons/md";
 
 const useStyles = createUseStyles({
   accordionTooltipLabel: {
@@ -69,17 +71,31 @@ const AccordionToolTip = ({
             classes.accordionTooltipLabel,
             classes.disabledDescription
           )}
-          dangerouslySetInnerHTML={{ __html: `${description}` }}
-        ></div>
+        >
+          <Interweave transform={TransformExternalLink} content={description} />
+        </div>
       ) : (
-        <div
-          className={clsx(classes.accordionTooltipLabel)}
-          dangerouslySetInnerHTML={{ __html: `${description}` }}
-        ></div>
+        <div className={clsx(classes.accordionTooltipLabel)}>
+          <Interweave transform={TransformExternalLink} content={description} />
+        </div>
       )}
     </>
   );
 };
+
+function TransformExternalLink(node, children) {
+  const classes = useStyles();
+  if (node.tagName == "A" && !node.getAttribute("href").startsWith("/")) {
+    return (
+      <span>
+        <a href={node.getAttribute("href")} target="external">
+          {children}
+          <MdLaunch className={classes.externalLinkIcon} />
+        </a>
+      </span>
+    );
+  }
+}
 
 AccordionToolTip.propTypes = {
   description: PropTypes.string,


### PR DESCRIPTION
Fixes #1797 

### What changes did you make?

- Added launch icons to external links on FAQs and create project page tooltip using Interweave transformer

### Why did you make the changes (we will use this info to test)?

- External links on the FAQs and the create project page tooltip were missing launch icons to differentiate from internal links

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![old_faqs](https://github.com/user-attachments/assets/3ddbd55d-9563-44ba-906a-13a82cabc285)

![old_myprojecttooltip](https://github.com/user-attachments/assets/cd3c7fd7-9dc0-4110-aff1-95dfe26cba1f)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![faqs](https://github.com/user-attachments/assets/e3a53c1a-d85b-4edc-ba22-62bec86f6c0e)

![myprojecttooltip](https://github.com/user-attachments/assets/40b3fb05-08d6-458e-a123-c0b8f787f532)


</details>
