### PR TITLE
Update search logic to match against "description" property 

### DIFF
--- a/client/src/components/Projects/ProjectsPage.js
+++ b/client/src/components/Projects/ProjectsPage.js
@@ -62,7 +62,7 @@ const useStyles = createUseStyles({
   },
   searchBar: {
     maxWidth: "100%",
-    width: "25em",
+    width: "27em",
     padding: "12px 12px 12px 48px",
     marginRight: "0.5rem"
   },
@@ -739,7 +739,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
                       type="search"
                       id="filterText"
                       name="filterText"
-                      placeholder="S Address; Description; Alt#" // redundant with FilterDrawer
+                      placeholder="Search by Name; Address; Description; Alt#" // redundant with FilterDrawer
                       value={filterText}
                       onChange={e => handleFilterTextChange(e.target.value)}
                     />

--- a/client/src/components/Projects/ProjectsPage.js
+++ b/client/src/components/Projects/ProjectsPage.js
@@ -62,7 +62,7 @@ const useStyles = createUseStyles({
   },
   searchBar: {
     maxWidth: "100%",
-    width: "20em",
+    width: "25em",
     padding: "12px 12px 12px 48px",
     marginRight: "0.5rem"
   },
@@ -571,7 +571,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
     // criteria in FilterDrawer, and we could get rid of the search box
     // above the grid.
     if (filterText !== "") {
-      let ids = ["name", "address", "fullName", "alternative"];
+      let ids = ["name", "address", "fullName", "alternative", "description"];
 
       return ids.some(id => {
         let colValue = String(p[id]).toLowerCase();
@@ -708,7 +708,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
                       type="search"
                       id="filterText"
                       name="filterText"
-                      placeholder="Search"
+                      placeholder="S Address; Description; Alt#" // redundant with FilterDrawer
                       value={filterText}
                       onChange={e => handleFilterTextChange(e.target.value)}
                     />


### PR DESCRIPTION
Fixes #1649

### What changes did you make?

- added "description" to the project properties that are compared against the search input text.  
- changed the "placeholder text" in the Search text box to "Search by Name; Address; Description; Alt#"
- increased the width of the search input box to provide space for longer placeholder text

### Why did you make the changes (we will use this info to test)?

- To enable users to more effectively search for projects
   - To enable testing searches against the description field, I created a new project "Testing Issue 1649" with a description including these words: "GitHub", "repository", "Search", "Text", "hackforla/tdm-calculator"
- Changes to placeholder text was made to conform to the Figma prototype


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/b58eaa11-1346-48c2-ab7d-3d4a35bc8b4a)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/1f23457f-6e05-4008-9668-c1d7c24b7c60)


</details>
