### PR TITLE
update classes to prevent cutoff of left side of project table

### DIFF
--- a/client/src/components/Layout/ContentContainer.jsx
+++ b/client/src/components/Layout/ContentContainer.jsx
@@ -7,7 +7,7 @@ const useStyles = createUseStyles({
     flex: "1",
     display: "flex",
     flexDirection: "row",
-    minHeight: "calc(100vh - 103px)"
+    minHeight: "calc(100vh - 67px - 5em)"
   },
   content: {
     boxSizing: "border-box",

--- a/client/src/components/Layout/ContentContainer.jsx
+++ b/client/src/components/Layout/ContentContainer.jsx
@@ -7,7 +7,7 @@ const useStyles = createUseStyles({
     flex: "1",
     display: "flex",
     flexDirection: "row",
-    minHeight: "calc(100vh - 67px - 5em)"
+    minHeight: "calc(100vh - 71px - 5em)"
   },
   content: {
     boxSizing: "border-box",

--- a/client/src/components/Layout/ContentContainer.jsx
+++ b/client/src/components/Layout/ContentContainer.jsx
@@ -7,7 +7,7 @@ const useStyles = createUseStyles({
     flex: "1",
     display: "flex",
     flexDirection: "row",
-    minHeight: "calc(100vh - 103px - 48px)"
+    minHeight: "calc(100vh - 103px)"
   },
   content: {
     boxSizing: "border-box",

--- a/client/src/components/Layout/ContentContainerNoSidebar.jsx
+++ b/client/src/components/Layout/ContentContainerNoSidebar.jsx
@@ -9,7 +9,8 @@ const useStyles = createUseStyles({
     justifyContent: "flex-start",
     alignItems: "center",
     minHeight: "calc(100vh - 103px - 48px)",
-    margin: "auto"
+    margin: "auto",
+    width: "100%"
   }
 });
 

--- a/client/src/components/Layout/ContentContainerNoSidebar.jsx
+++ b/client/src/components/Layout/ContentContainerNoSidebar.jsx
@@ -9,8 +9,7 @@ const useStyles = createUseStyles({
     justifyContent: "flex-start",
     alignItems: "center",
     minHeight: "calc(100vh - 103px - 48px)",
-    margin: "auto",
-    width: "100%"
+    margin: "auto"
   }
 });
 

--- a/client/src/components/Layout/ContentContainerNoSidebar.jsx
+++ b/client/src/components/Layout/ContentContainerNoSidebar.jsx
@@ -8,7 +8,7 @@ const useStyles = createUseStyles({
     flexDirection: "column",
     justifyContent: "flex-start",
     alignItems: "center",
-    minHeight: "calc(100vh - 103px)",
+    minHeight: "calc(100vh - 67px - 5em)",
     margin: "auto",
     width: "100%"
   }

--- a/client/src/components/Layout/ContentContainerNoSidebar.jsx
+++ b/client/src/components/Layout/ContentContainerNoSidebar.jsx
@@ -8,7 +8,7 @@ const useStyles = createUseStyles({
     flexDirection: "column",
     justifyContent: "flex-start",
     alignItems: "center",
-    minHeight: "calc(100vh - 103px - 48px)",
+    minHeight: "calc(100vh - 103px)",
     margin: "auto",
     width: "100%"
   }

--- a/client/src/components/Layout/ContentContainerNoSidebar.jsx
+++ b/client/src/components/Layout/ContentContainerNoSidebar.jsx
@@ -8,7 +8,7 @@ const useStyles = createUseStyles({
     flexDirection: "column",
     justifyContent: "flex-start",
     alignItems: "center",
-    minHeight: "calc(100vh - 67px - 5em)",
+    minHeight: "calc(100vh - 71px - 5em)",
     margin: "auto",
     width: "100%"
   }

--- a/client/src/components/Projects/ColumnHeaderPopups/ProjectTableColumnHeader.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/ProjectTableColumnHeader.jsx
@@ -112,6 +112,7 @@ const ProjectTableColumnHeader = ({
     <div style={{ width: "100%", height: "100%" }}>
       {header.id !== "checkAllProjects" && header.id !== "contextMenu" ? (
         <Popover
+          containerStyle={{ zIndex: 2 }}
           isOpen={isPopoverOpen}
           positions={["bottom", "left", "right", "top"]} // preferred positions by priority
           align="start"

--- a/client/src/components/Projects/MultiProjectToolbarMenu.jsx
+++ b/client/src/components/Projects/MultiProjectToolbarMenu.jsx
@@ -23,7 +23,8 @@ const useStyles = createUseStyles({
     flexDirection: "row",
     alignItems: "center",
     marginLeft: "0.5em",
-    marginBottom: "-1em"
+    marginBottom: "-1em",
+    padding: "0 5em 0 0.5em "
   },
   list: {
     display: "flex",
@@ -35,7 +36,7 @@ const useStyles = createUseStyles({
   },
   button: {
     border: "none",
-    padding: 0,
+    padding: "0",
     background: "none"
   },
   multiStatus: {

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -918,7 +918,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
                   display: "flex",
                   flexDirection: "row",
                   justifyContent: "flex-start",
-                  maxWidth: "100vh"
+                  width: "100vw"
                 }}
               >
                 <MemoizedMultiProjectToolbar

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -915,7 +915,8 @@ const ProjectsPage = ({ contentContainerRef }) => {
                 style={{
                   display: "flex",
                   flexDirection: "row",
-                  justifyContent: "flex-start"
+                  justifyContent: "flex-start",
+                  maxWidth: "100vh"
                 }}
               >
                 <MemoizedMultiProjectToolbar

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -879,6 +879,8 @@ const ProjectsPage = ({ contentContainerRef }) => {
     indexOfLastPost
   );
 
+  document.body.style.overflowX = "hidden"; // prevent page level scrolling, becauase the table is scrollable
+
   return (
     <ContentContainerNoSidebar contentContainerRef={contentContainerRef}>
       <div className={classes.outerDiv}>

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -86,6 +86,9 @@ const useStyles = createUseStyles({
     textAlign: "left"
   },
   thead: {
+    position: "sticky",
+    top: 0,
+    zIndex: 1,
     fontWeight: "bold",
     backgroundColor: "#002E6D",
     color: "white",
@@ -123,7 +126,12 @@ const useStyles = createUseStyles({
     overflow: "auto", // changed to allow Universal Select to show above the page container when expanded
     width: "100%",
     margin: "20px 0px",
-    maxWidth: "100vw"
+    maxWidth: "100vw",
+    height: "60vh"
+  },
+  fixTableHead: {
+    overflowY: "auto",
+    height: "4em"
   },
   pageContainer: {
     display: "flex",
@@ -969,18 +977,20 @@ const ProjectsPage = ({ contentContainerRef }) => {
                         {headerData.map(header => {
                           return (
                             <td key={header.id}>
-                              <ProjectTableColumnHeader
-                                projects={projects}
-                                filter={filter}
-                                header={header}
-                                criteria={criteria}
-                                setCriteria={setCriteria}
-                                setSort={setSort}
-                                order={order}
-                                orderBy={orderBy}
-                                setCheckedProjectIds={setCheckedProjectIds}
-                                setSelectAllChecked={setSelectAllChecked}
-                              />
+                              <th className={classes.stickyTh}>
+                                <ProjectTableColumnHeader
+                                  projects={projects}
+                                  filter={filter}
+                                  header={header}
+                                  criteria={criteria}
+                                  setCriteria={setCriteria}
+                                  setSort={setSort}
+                                  order={order}
+                                  orderBy={orderBy}
+                                  setCheckedProjectIds={setCheckedProjectIds}
+                                  setSelectAllChecked={setSelectAllChecked}
+                                />
+                              </th>
                             </td>
                           );
                         })}

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -125,9 +125,8 @@ const useStyles = createUseStyles({
   },
   tableContainer: {
     overflow: "auto", // changed to allow Universal Select to show above the page container when expanded
-    width: "100%",
+    width: "calc(100vw - 20px)",
     margin: "20px 0px",
-    maxWidth: "100vw",
     height: "calc(100vh - 275px - 11.34em)"
   },
   fixTableHead: {

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -120,9 +120,10 @@ const useStyles = createUseStyles({
     textAlign: "center"
   },
   tableContainer: {
-    overflow: "visible", // changed to allow Universal Select to show above the page container when expanded
+    overflow: "auto", // changed to allow Universal Select to show above the page container when expanded
     width: "100%",
-    margin: "20px 0px"
+    margin: "20px 0px",
+    maxWidth: "100vw"
   },
   pageContainer: {
     display: "flex",
@@ -960,67 +961,71 @@ const ProjectsPage = ({ contentContainerRef }) => {
                   </div>
                 </div>
               </div>
-              <div className={classes.tableContainer}>
-                <table className={classes.table}>
-                  <thead className={classes.thead}>
-                    <tr className={classes.tr}>
-                      {headerData.map(header => {
-                        return (
-                          <td key={header.id}>
-                            <ProjectTableColumnHeader
-                              projects={projects}
-                              filter={filter}
-                              header={header}
-                              criteria={criteria}
-                              setCriteria={setCriteria}
-                              setSort={setSort}
-                              order={order}
-                              orderBy={orderBy}
-                              setCheckedProjectIds={setCheckedProjectIds}
-                              setSelectAllChecked={setSelectAllChecked}
-                            />
-                          </td>
-                        );
-                      })}
-                    </tr>
-                  </thead>
-                  <tbody className={classes.tbody}>
-                    {projects.length ? (
-                      currentProjects.map(project => (
-                        <ProjectTableRow
-                          key={project.id}
-                          project={project}
-                          handleCsvModalOpen={handleCsvModalOpen}
-                          handleCopyModalOpen={handleCopyModalOpen}
-                          handleDeleteModalOpen={handleDeleteModalOpen}
-                          handleSnapshotModalOpen={handleSnapshotModalOpen}
-                          handleRenameSnapshotModalOpen={
-                            handleRenameSnapshotModalOpen
-                          }
-                          handleShareSnapshotModalOpen={
-                            handleShareSnapshotModalOpen
-                          }
-                          handleHide={handleHide}
-                          handleCheckboxChange={handleCheckboxChange}
-                          checkedProjectIds={checkedProjectIds}
-                          isAdmin={isAdmin}
-                          droOptions={droOptions}
-                          onDroChange={handleDroChange} // Pass the DRO change handler
-                          onAdminNoteUpdate={handleAdminNoteUpdate} // Pass the admin note update handler
-                          droName={
-                            isAdmin ? null : droNameMap[project.droId] || "N/A"
-                          } // Pass the droName
-                        />
-                      ))
-                    ) : (
-                      <tr>
-                        <td colSpan={9} className={classes.tdNoSavedProjects}>
-                          No Saved Projects
-                        </td>
+              <div>
+                <div className={classes.tableContainer}>
+                  <table className={classes.table}>
+                    <thead className={classes.thead}>
+                      <tr className={classes.tr}>
+                        {headerData.map(header => {
+                          return (
+                            <td key={header.id}>
+                              <ProjectTableColumnHeader
+                                projects={projects}
+                                filter={filter}
+                                header={header}
+                                criteria={criteria}
+                                setCriteria={setCriteria}
+                                setSort={setSort}
+                                order={order}
+                                orderBy={orderBy}
+                                setCheckedProjectIds={setCheckedProjectIds}
+                                setSelectAllChecked={setSelectAllChecked}
+                              />
+                            </td>
+                          );
+                        })}
                       </tr>
-                    )}
-                  </tbody>
-                </table>
+                    </thead>
+                    <tbody className={classes.tbody}>
+                      {projects.length ? (
+                        currentProjects.map(project => (
+                          <ProjectTableRow
+                            key={project.id}
+                            project={project}
+                            handleCsvModalOpen={handleCsvModalOpen}
+                            handleCopyModalOpen={handleCopyModalOpen}
+                            handleDeleteModalOpen={handleDeleteModalOpen}
+                            handleSnapshotModalOpen={handleSnapshotModalOpen}
+                            handleRenameSnapshotModalOpen={
+                              handleRenameSnapshotModalOpen
+                            }
+                            handleShareSnapshotModalOpen={
+                              handleShareSnapshotModalOpen
+                            }
+                            handleHide={handleHide}
+                            handleCheckboxChange={handleCheckboxChange}
+                            checkedProjectIds={checkedProjectIds}
+                            isAdmin={isAdmin}
+                            droOptions={droOptions}
+                            onDroChange={handleDroChange} // Pass the DRO change handler
+                            onAdminNoteUpdate={handleAdminNoteUpdate} // Pass the admin note update handler
+                            droName={
+                              isAdmin
+                                ? null
+                                : droNameMap[project.droId] || "N/A"
+                            } // Pass the droName
+                          />
+                        ))
+                      ) : (
+                        <tr>
+                          <td colSpan={9} className={classes.tdNoSavedProjects}>
+                            No Saved Projects
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
               </div>
               <div className={classes.pageContainer}>
                 <Pagination

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -929,10 +929,10 @@ const ProjectsPage = ({ contentContainerRef }) => {
                     />
                     <MdOutlineSearch className={classes.searchIcon} />
                   </div>
-                  <div>
+                  <div style={{ marginRight: "0.75em" }}>
                     <TertiaryButton
                       onClick={resetFiltersSort}
-                      style={{ height: "40px" }}
+                      style={{ height: "40px", marginRight: "1em" }}
                       isDisplayed={true}
                     >
                       RESET FILTERS/SORT
@@ -960,7 +960,8 @@ const ProjectsPage = ({ contentContainerRef }) => {
                                     sortCriteria[sortCriteria.length - 1].field
                                   }
                                   order={
-                                    sortCriteria[sortCriteria.length - 1].direction
+                                    sortCriteria[sortCriteria.length - 1]
+                                      .direction
                                   }
                                   setCheckedProjectIds={setCheckedProjectIds}
                                   setSelectAllChecked={setSelectAllChecked}

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -127,7 +127,7 @@ const useStyles = createUseStyles({
     width: "100%",
     margin: "20px 0px",
     maxWidth: "100vw",
-    height: "60vh"
+    height: "calc(100vh - 275px - 11.34em)"
   },
   fixTableHead: {
     overflowY: "auto",

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -8,7 +8,7 @@ body {
   font-family: $font;
   -webkit-text-size-adjust: 100%;
   color: #474747;
-  overflow: hidden;
+  overflow-y: scroll;
 }
 
 h1 {

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -8,6 +8,7 @@ body {
   font-family: $font;
   -webkit-text-size-adjust: 100%;
   color: #474747;
+  overflow-y: hidden;
 }
 
 h1 {

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -8,7 +8,7 @@ body {
   font-family: $font;
   -webkit-text-size-adjust: 100%;
   color: #474747;
-  overflow-y: hidden;
+  overflow: hidden;
 }
 
 h1 {

--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -8,7 +8,6 @@ body {
   font-family: $font;
   -webkit-text-size-adjust: 100%;
   color: #474747;
-  overflow-y: scroll;
 }
 
 h1 {


### PR DESCRIPTION
Fixes #1927

### What changes did you make?
- use JavaScript to modify style of the `body` element in `<ProjectTable>`, to prevent page-wide scrolling
- enable scrolling on `div.tableContainer`
- make table headings "sticky" so they are always visible regardless of vertical scroll position
- changes to the zIndex (stacking order) of header and popover so that popovers appear "on top" of the table heading.   
- change minHeight on contentContainer because the previous value did not adjust with user's selection of font size
- At screen widths less than 800px, the toolbar, input field, and button directly above the table become cut off.  Regardless of how scrolling is implemented, the design and implementation of those elements should be revisited to be responsive at smaller screen sizes.  

### Why did you make the changes (we will use this info to test)?
- When the browser window was not extra wide, there was a horizontal scroll bar, but the user could not scroll far enough to the left to reveal the left-most columns.  
- the requirement to make table headings "sticky" was not in the issue but was requested in [comment]( https://github.com/hackforla/tdm-calculator/pull/1934#issuecomment-2458583512)


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/07852158-71bf-407a-9932-c8d720eaa01f)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/47b1c6a1-9b62-4a45-b469-974e6499486b)


</details>
