### PR TITLE
created button variant for error with white text

### DIFF
--- a/client/src/components/Button/Button.jsx
+++ b/client/src/components/Button/Button.jsx
@@ -61,6 +61,18 @@ const useStyles = createUseStyles(theme => ({
       backgroundColor: theme.colors.warning, // Solid red background on hover
       boxShadow: "rgba(0, 46, 109, 0.4) 2px 4px 6px" // Heavier box shadow on hover
     }
+  },
+  error: {
+    backgroundColor: theme.colorError,
+    color: "white",
+    borderColor: "rgba(0, 0, 0, .05)", //lightest grey
+    boxShadow: "rgba(0, 46, 109, 0.3) 1px 2px 3px",
+    "&[disabled]:hover": {
+      boxShadow: "rgba(0, 46, 109, 0.3) 1px 2px 3px"
+    },
+    "&:hover": {
+      boxShadow: "rgba(0, 46, 109, 0.6) 2px 4px 6px" // Heavier box shadow on hover
+    }
   }
 }));
 

--- a/client/src/components/Faq/DeleteFaqModal.jsx
+++ b/client/src/components/Faq/DeleteFaqModal.jsx
@@ -46,7 +46,7 @@ const DeleteFaqModal = ({ isModalOpen, closeModal, handleDelete, isFaq }) => {
         <Button onClick={closeModal} variant="outlined" id="cancelButton">
           Cancel
         </Button>
-        <Button onClick={handleDelete} variant="contained" color={"colorError"}>
+        <Button onClick={handleDelete} variant="error">
           Delete
         </Button>
       </div>

--- a/client/src/components/ProjectWizard/NavConfirmDialog.jsx
+++ b/client/src/components/ProjectWizard/NavConfirmDialog.jsx
@@ -54,7 +54,7 @@ const NavConfirmDialog = ({ blocker }) => {
           Cancel
         </Button>
         <Button
-          color="colorError"
+          variant="error"
           id="modalProceed"
           data-testid="transitionProceed"
           onClick={() => blocker.proceed()}

--- a/client/src/components/Projects/CsvModal.jsx
+++ b/client/src/components/Projects/CsvModal.jsx
@@ -165,11 +165,7 @@ const CsvModal = ({
           </Button>
 
           {(project || projectCollection) && !loading && !csvData && (
-            <Button
-              onClick={handleGenerateButton}
-              variant="contained"
-              color={"colorError"}
-            >
+            <Button onClick={handleGenerateButton} variant="error">
               Generate File
             </Button>
           )}

--- a/client/src/components/Projects/DeleteProjectModal.jsx
+++ b/client/src/components/Projects/DeleteProjectModal.jsx
@@ -72,19 +72,11 @@ const DeleteProjectModal = ({ mounted, onClose, project }) => {
           Cancel
         </Button>
         {project.dateTrashed ? (
-          <Button
-            onClick={() => onClose("ok")}
-            variant="contained"
-            color={"colorError"}
-          >
+          <Button onClick={() => onClose("ok")} variant="error">
             Restore
           </Button>
         ) : (
-          <Button
-            onClick={() => onClose("ok")}
-            variant="contained"
-            color={"colorError"}
-          >
+          <Button onClick={() => onClose("ok")} variant="error">
             Delete
           </Button>
         )}


### PR DESCRIPTION
Fixes #1929

### What changes did you make?

- Changed warning buttons with red background to have white text instead of black.
- Changed CSV Download button styles per style guide.
- Changed Share Snapshot button styles per style guide.


### Why did you make the changes (we will use this info to test)?

- UX Research recommended the changes after testing with users.


### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="573" alt="Screenshot 2024-11-12 at 10 50 34 PM" src="https://github.com/user-attachments/assets/076104a2-699f-432a-9bd0-5b3b46cef7aa">

<img width="573" alt="Screenshot 2024-11-12 at 10 50 55 PM" src="https://github.com/user-attachments/assets/381cb706-3b0e-4f49-9c77-e1d2d76fbb82">

<img width="570" alt="Screenshot 2024-11-12 at 10 53 00 PM" src="https://github.com/user-attachments/assets/39a1388f-cd2c-423d-a1b3-6f969c1ff574">

<img width="575" alt="Screenshot 2024-11-12 at 10 53 25 PM" src="https://github.com/user-attachments/assets/88d66e8c-7329-415c-b9a7-088c0752dd6b">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="434" alt="Screenshot 2024-11-12 at 10 49 10 PM" src="https://github.com/user-attachments/assets/d247a221-965b-40bc-87b1-2bb72f3f3c8a">

![image](https://github.com/user-attachments/assets/f41148c1-76af-4bb5-8a9e-74912af686f3)

![image](https://github.com/user-attachments/assets/f526befe-9aeb-4e78-aea2-b0a0732f2e6a)


<img width="435" alt="Screenshot 2024-11-12 at 10 44 41 PM" src="https://github.com/user-attachments/assets/0c1f6bca-7357-4407-aed2-d5ea6de34e75">

<img width="435" alt="Screenshot 2024-11-12 at 10 44 23 PM" src="https://github.com/user-attachments/assets/745bce3f-4eb1-4db5-aed4-98b289381dd5">

![image](https://github.com/user-attachments/assets/080b156e-8c1b-4439-bae1-fc942b10da09)

![image](https://github.com/user-attachments/assets/786f18a9-c865-47c6-8de5-df0a556d5766)



</details>
