### PR TITLE
1896 communicating unsaved changes faq page

### DIFF
--- a/client/src/components/Faq/FaqConfirmDialog.jsx
+++ b/client/src/components/Faq/FaqConfirmDialog.jsx
@@ -1,0 +1,82 @@
+import React from "react";
+import PropTypes from "prop-types";
+import ModalDialog from "../UI/AriaModal/ModalDialog";
+import Button from "../Button/Button";
+import { createUseStyles } from "react-jss";
+import { MdWarning } from "react-icons/md";
+
+const useStyles = createUseStyles({
+  title: {
+    textAlign: "center"
+  },
+  warningWrapper: {
+    color: "#B64E38",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center"
+  },
+  warningMessage: {
+    verticalAlign: "middle",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: "1em"
+  },
+  modalActions: {
+    display: "flex",
+    justifyContent: "center"
+  },
+  proceedButton: {
+    color: "white",
+    fontWeight: "bold"
+  }
+});
+
+const FaqConfirmDialog = ({ blocker }) => {
+  const classes = useStyles();
+  return (
+    <ModalDialog
+      mounted={blocker.state === "blocked"}
+      onClose={blocker.reset}
+      showCloseBox={false}
+    >
+      <div className={classes.warningWrapper}>
+        <MdWarning alt="Warning" size={70} />
+      </div>
+      <h2 className={classes.title}>
+        <strong>Unsaved changes will be lost</strong>
+      </h2>
+      <p className={classes.warningMessage}>
+        <span>
+          &nbsp; Leaving this page will permanently delete any unsaved changes
+          to the FAQ.
+        </span>
+      </p>
+      <div className={classes.modalActions}>
+        <Button
+          color="colorCancel"
+          variant="outlined"
+          id="modalCancel"
+          data-testid="transitionCancel"
+          onClick={() => blocker.reset()}
+        >
+          <p style={{ fontWeight: "bold" }}>Cancel</p>
+        </Button>
+        <Button
+          color="colorError"
+          id="modalProceed"
+          data-testid="transitionProceed"
+          onClick={() => blocker.proceed()}
+        >
+          <p className={classes.proceedButton}>Proceed</p>
+        </Button>
+      </div>
+    </ModalDialog>
+  );
+};
+
+FaqConfirmDialog.propTypes = {
+  blocker: PropTypes.object.isRequired
+};
+
+export default FaqConfirmDialog;

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
@@ -96,7 +96,6 @@ const TdmCalculationWizard = props => {
           },
           nextLocation.pathname
         );
-
         return (
           currentMatch &&
           nextMatch &&
@@ -104,7 +103,6 @@ const TdmCalculationWizard = props => {
             !projectId)
         );
       };
-
       return formIsDirty && !isSameProject(currentLocation, nextLocation);
     },
     [formIsDirty, projectId]


### PR DESCRIPTION
Fixes #1896 

### What changes did you make?

- Created an FAQ confirm modal that triggers when editing the FAQ page in admin mode

### Why did you make the changes (we will use this info to test)?

- To confirm if user in admin mode wants to navigate away from the FAQ page after making an eidt

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals after changes are applied</summary>
  
![FAQ-confirm-dialog](https://github.com/user-attachments/assets/70fb9622-cc8c-486c-b963-7691e0a26214)

</details>
