### PR TITLE
Fix missing footer on Calculation Summary Page and PDF

### DIFF
--- a/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
@@ -87,17 +87,10 @@ export function TdmCalculationContainer({ contentContainerRef }) {
           }
         } else {
           projectResponse = await projectService.getById(projectId);
-
-          // setLoginId(projectResponse.data.loginId);
-          // setDateModified(formatDatetime(projectResponse.data.dateModified));
-          // setDateSnapshotted(
-          //   formatDatetime(projectResponse.data?.dateSnapshotted)
-          // );
-          // setDateSubmitted(formatDatetime(projectResponse.data?.dateSubmitted));
           setShareView(false);
         }
         if (projectResponse) {
-          setProject(projectResponse);
+          setProject(projectResponse.data);
           inputs = JSON.parse(projectResponse.data.formInputs);
           setStrategiesInitialized(true);
         }


### PR DESCRIPTION
Fixes #2028

### What changes did you make?

- Fixed a bug  introduced in PR #1988 that caused the symptoms listed in the next section.

### Why did you make the changes (we will use this info to test)?

- A bug was introduced in PR #1988 that caused the Save Project Button to always be disabled, preventing users from saving changes to projects.
- The same bug also caused the footer on Page 5 of the Calculation Wizard and the PDF Printout to not appear
-

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/60dda8bd-a285-4123-9a97-44e4eb629acd)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/7e45f4b7-a01b-408a-9552-0a43fcc2b4fd)

</details>
