### PR TITLE
Implemented changes to reset buttons

### DIFF
--- a/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
@@ -274,6 +274,8 @@ const TdmCalculationWizard = props => {
             onParkingProvidedChange={onParkingProvidedChange}
             onInputChange={onInputChange}
             isLevel0={isLevel0}
+            uncheckAll={onUncheckAll}
+            resetProject={onResetProject}
           />
         );
 

--- a/client/src/components/ProjectWizard/WizardPages/Level0Page.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/Level0Page.jsx
@@ -4,6 +4,7 @@ import PlanningIcon from "../../../images/planning.png";
 import { createUseStyles, useTheme } from "react-jss";
 import { MdLaunch } from "react-icons/md";
 import { MdWarning } from "react-icons/md";
+import ResetButtons from "./ResetButtons";
 
 const useStyles = createUseStyles({
   level0NavButtons: {
@@ -34,7 +35,7 @@ const useStyles = createUseStyles({
   }
 });
 
-const Level0Page = ({ isLevel0 }) => {
+const Level0Page = ({ isLevel0, uncheckAll, resetProject }) => {
   const theme = useTheme();
   const classes = useStyles({ theme });
 
@@ -42,6 +43,13 @@ const Level0Page = ({ isLevel0 }) => {
     <>
       {isLevel0 && (
         <div className={classes.level0NavButtons}>
+          <div className={classes.pkgSelectContainer}>
+            <ResetButtons
+              className={classes.alignRight}
+              uncheckAll={uncheckAll}
+              resetProject={resetProject}
+            />
+          </div>
           <div className={classes.level0Container}>
             <img src={PlanningIcon} alt="planningIcon" />
             <h1 style={theme.typography.heading1}>Your project level is 0!</h1>
@@ -75,7 +83,9 @@ const Level0Page = ({ isLevel0 }) => {
 };
 
 Level0Page.propTypes = {
-  isLevel0: PropTypes.bool.isRequired
+  isLevel0: PropTypes.bool.isRequired,
+  uncheckAll: PropTypes.func.isRequired,
+  resetProject: PropTypes.func.isRequired
 };
 
 export default Level0Page;

--- a/client/src/components/ProjectWizard/WizardPages/ProjectDescriptions.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectDescriptions.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import RuleInputPanels from "../RuleInput/RuleInputPanels";
 import DiscoverTooltips from "./DiscoverTooltips";
 import { createUseStyles, useTheme } from "react-jss";
+import ResetButtons from "./ResetButtons";
 
 const useStyles = createUseStyles({
   disclaimer: {
@@ -18,7 +19,8 @@ const useStyles = createUseStyles({
 });
 
 function ProjectDescriptions(props) {
-  const { rules, onInputChange, onAINInputError } = props;
+  const { rules, onInputChange, onAINInputError, uncheckAll, resetProject } =
+    props;
   const classes = useStyles();
   const theme = useTheme();
   return (
@@ -29,8 +31,18 @@ function ProjectDescriptions(props) {
           Calculator
         </span>
       </div>
-      <div style={theme.typography.subHeading}>
+      <h3 style={theme.typography.subHeading}>
         First, let&rsquo;s get some information about your project
+      </h3>
+      <div
+        className={classes.pkgSelectContainer}
+        style={{ marginBottom: "1em" }}
+      >
+        <ResetButtons
+          className={classes.alignRight}
+          uncheckAll={uncheckAll}
+          resetProject={resetProject}
+        />
       </div>
       <form noValidate>
         <RuleInputPanels
@@ -51,7 +63,9 @@ function ProjectDescriptions(props) {
 ProjectDescriptions.propTypes = {
   rules: PropTypes.array.isRequired,
   onInputChange: PropTypes.func.isRequired,
-  onAINInputError: PropTypes.func.isRequired
+  onAINInputError: PropTypes.func.isRequired,
+  uncheckAll: PropTypes.func.isRequired,
+  resetProject: PropTypes.func.isRequired
 };
 
 export default ProjectDescriptions;

--- a/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.jsx
@@ -89,7 +89,10 @@ function ProjectMeasure(props) {
           </div>
         </>
       )}
-      <div className={classes.pkgSelectContainer}>
+      <div
+        className={classes.pkgSelectContainer}
+        style={{ marginTop: "1em", marginBottom: "1em" }}
+      >
         <ResetButtons
           className={classes.alignRight}
           uncheckAll={uncheckAll}

--- a/client/src/components/ProjectWizard/WizardPages/ProjectTargetPoints.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectTargetPoints.jsx
@@ -4,6 +4,7 @@ import { createUseStyles, useTheme } from "react-jss";
 import RuleCalculationPanels from "../RuleCalculation/RuleCalculationPanels";
 import Level0Page from "./Level0Page";
 import ParkingProvidedRuleInput from "../RuleInput/ParkingProvidedRuleInput";
+import ResetButtons from "./ResetButtons";
 
 const useStyles = createUseStyles(theme => ({
   projectBox: {
@@ -50,7 +51,14 @@ const useStyles = createUseStyles(theme => ({
 function ProjectTargetPoints(props) {
   const classes = useStyles();
   const theme = useTheme();
-  const { rules, onInputChange, isLevel0, onParkingProvidedChange } = props;
+  const {
+    rules,
+    onInputChange,
+    isLevel0,
+    onParkingProvidedChange,
+    uncheckAll,
+    resetProject
+  } = props;
   const projectLevel = rules.find(e => e.code === "LEVEL");
   const targetValue = rules.find(e => e.code === "INPUT_TARGET_POINTS_PARK");
 
@@ -61,7 +69,11 @@ function ProjectTargetPoints(props) {
 
   return (
     <>
-      <Level0Page isLevel0={isLevel0} />
+      <Level0Page
+        isLevel0={isLevel0}
+        uncheckAll={uncheckAll}
+        resetProject={resetProject}
+      />
 
       {projectLevel && projectLevel.calcValue > 0 && (
         <div>
@@ -73,6 +85,13 @@ function ProjectTargetPoints(props) {
               Target Points (left panel) may be adjusted based on parking spaces
               entered below.
             </span>
+          </div>
+          <div className={classes.pkgSelectContainer}>
+            <ResetButtons
+              className={classes.alignRight}
+              uncheckAll={uncheckAll}
+              resetProject={resetProject}
+            />
           </div>
           {parkingProvidedRuleOnly && (
             <ParkingProvidedRuleInput
@@ -109,7 +128,9 @@ ProjectTargetPoints.propTypes = {
   rules: PropTypes.array.isRequired,
   onInputChange: PropTypes.func.isRequired,
   onParkingProvidedChange: PropTypes.func.isRequired,
-  isLevel0: PropTypes.bool.isRequired
+  isLevel0: PropTypes.bool.isRequired,
+  uncheckAll: PropTypes.func.isRequired,
+  resetProject: PropTypes.func.isRequired
 };
 
 export default ProjectTargetPoints;

--- a/client/src/components/ProjectWizard/WizardPages/ResetButtons.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ResetButtons.jsx
@@ -14,13 +14,15 @@ const useStyles = createUseStyles({
     backgroundColor: "transparent",
     border: "0",
     cursor: "pointer",
-    textDecoration: "underline"
+    textDecoration: "underline",
+    fontWeight: "normal"
   },
   resetProjectButton: {
     backgroundColor: "transparent",
     border: "0",
     cursor: "pointer",
-    textDecoration: "underline"
+    textDecoration: "underline",
+    fontWeight: "normal"
   }
 });
 

--- a/client/src/components/ProjectWizard/WizardPages/ResetButtons.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ResetButtons.jsx
@@ -37,7 +37,7 @@ const ResetButtons = props => {
         Reset Project
       </button>
       <button className={classes.unSelectButton} onClick={uncheckAll}>
-        Reset Page
+        Clear Page
       </button>
     </div>
   );


### PR DESCRIPTION
Fixes #1993 

### What changes did you make?

- Change the "Reset Page" button to "Clear page" on Page 2 & 4
- Add the "Reset Project" & "Clear page" buttons to Page 1 & 3

### Why did you make the changes (we will use this info to test)?

- UXR recommendation

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

Screenshots:
<details><summary>Page 1</summary>

![image](https://github.com/user-attachments/assets/eaf9cbf1-40a8-4a1d-aaae-8698afa5ba7c)

</details> 
<details><summary>Page 2</summary>

![image](https://github.com/user-attachments/assets/4a14977a-4624-40f1-b379-6f6c37d9bdb8)

</details> 
<details><summary>Page 3 with Target Points</summary>

![image](https://github.com/user-attachments/assets/02f53656-32a6-4bdf-9ca5-dab886187229)

</details> 
<details><summary>Page 3 Level 0</summary>

![image](https://github.com/user-attachments/assets/2bb667e8-1f36-4992-a2f7-bae698088da1)

</details> 

<details><summary>Page 4</summary>

![image](https://github.com/user-attachments/assets/b942eb10-ac2b-42dc-a608-836a2bdeff33)

</details> 
