### PR TITLE
Redirect shared snapshot to login with redirect url when email does not have access

### DIFF
--- a/client/src/components/Authorization/Login.jsx
+++ b/client/src/components/Authorization/Login.jsx
@@ -32,6 +32,7 @@ const Login = () => {
   const { search } = useLocation();
   const searchParams = new URLSearchParams(search);
   const projectId = searchParams.get("projectId");
+  const redirectUrl = searchParams.get("url");
   const navigate = useNavigate();
   const [errorMsg, setErrorMsg] = useState("");
   const [withoutSavingWarningIsVisible, setWithoutSavingWarningIsVisible] =
@@ -61,6 +62,8 @@ const Login = () => {
         userContext.updateAccount(loginResponse.user);
         if (projectId) {
           navigate(`/calculation/5/${projectId}`);
+        } else if (redirectUrl) {
+          navigate(`/${redirectUrl}`);
         } else {
           navigate("/calculation/1/0");
         }

--- a/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
@@ -77,13 +77,21 @@ export function TdmCalculationContainer({ contentContainerRef }) {
       let projectResponse = null;
       let inputs = {};
       if (Number(projectId) > 0 && account?.id) {
-        if (location.pathname.split("/")[1] == "projects") {
-          projectResponse = await projectService.getByIdWithEmail(projectId);
+        let locationPath = location.pathname.split("/");
+        if (locationPath[1] == "projects") {
+          try {
+            projectResponse = await projectService.getByIdWithEmail(projectId);
 
-          if (projectResponse) {
-            setShareView(true);
-          } else {
-            navigate("/unauthorized");
+            if (projectResponse) {
+              setShareView(true);
+            }
+          } catch (err) {
+            if (err.response.status == 404) {
+              navigate(`/login?url=${locationPath[1]}/${locationPath[2]}`);
+            } else {
+              console.error(JSON.stringify(err, null, 2));
+              throw new Error(JSON.stringify(err, null, 2));
+            }
           }
         } else {
           projectResponse = await projectService.getById(projectId);

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
@@ -126,7 +126,12 @@ const TdmCalculationWizard = props => {
   useEffect(() => {
     if (projectId && (!account || !account.id)) {
       // user not logged in, existing project -> log in
-      navigate(`/login`);
+      let locationPath = location.pathname.split("/");
+      if (locationPath[1] == "projects" && locationPath[2]) {
+        navigate(`/login?url=${locationPath[1]}/${locationPath[2]}`);
+      } else {
+        navigate(`/login`);
+      }
     } else if (
       // Redirect to Summary Page if project exists,
       // but does not belong to logged-in user
@@ -140,7 +145,7 @@ const TdmCalculationWizard = props => {
       !(account.isAdmin || account.id === loginId)
     ) {
       navigate(`/calculation/6/${projectId}`);
-    }
+    } // eslint-disable-next-line
   }, [projectId, account, loginId, navigate]);
 
   const projectDescriptionRules =


### PR DESCRIPTION
Fixes #2014

### What changes did you make?

- Modified TDM Wizard and container to redirect to login page with the shared snapshots page url stored
- changed response when nothing found in db
- Login page checks for ?url= in url

### Why did you make the changes (we will use this info to test)?

- the login page should remember that they were trying to navigate to the snapshot, and redirect back to the snapshot path after a successful login.

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.
