### PR TITLE
clear page and reset project buttons on page 1

### DIFF
--- a/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
@@ -256,6 +256,7 @@ const TdmCalculationWizard = props => {
             rules={projectDescriptionRules}
             onInputChange={onInputChange}
             onAINInputError={handleAINInputError}
+            uncheckAll={() => onUncheckAll(filters.projectDescriptionRules)}
           />
         );
       case 2:

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
@@ -257,6 +257,7 @@ const TdmCalculationWizard = props => {
             onInputChange={onInputChange}
             onAINInputError={handleAINInputError}
             uncheckAll={() => onUncheckAll(filters.projectDescriptionRules)}
+            resetProject={() => onResetProject()}
           />
         );
       case 2:


### PR DESCRIPTION
Fixes #2067

### What changes did you make?

- props supporting reset/clear buttons on Page 1 

### Why did you make the changes (we will use this info to test)?

- Reset Project and Clear Page did not function on Page 1 of the Project Wizard
- Reset Project should clear data from all pages for a new project, or reset to saved state for an existing project.  In either case,  navigate to the first page.  


