### PR TITLE
2065 "Clear Page" button on page3

### DIFF
--- a/client/src/components/ProjectWizard/RuleInput/ParkingProvidedRuleInput.jsx
+++ b/client/src/components/ProjectWizard/RuleInput/ParkingProvidedRuleInput.jsx
@@ -3,16 +3,19 @@ import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
 import clsx from "clsx";
 import debounce from "lodash/debounce";
+import ResetButtons from "../WizardPages/ResetButtons";
 
 const useStyles = createUseStyles(theme => ({
   parkingProvidedWrapper: {
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    margin: "2em"
+    margin: "2em",
+    marginTop: "1em"
   },
   label: {
-    ...theme.typography.heading2
+    ...theme.typography.heading2,
+    marginTop: "1em"
   },
   requiredInputLabel: {
     "&:after": {
@@ -42,7 +45,7 @@ const useStyles = createUseStyles(theme => ({
   }
 }));
 
-const ParkingProvidedRuleInput = ({ rule, onInputChange }) => {
+const ParkingProvidedRuleInput = ({ rule, onInputChange, resetProject }) => {
   const { code, name, value, units, maxValue, validationErrors, required } =
     rule;
   const classes = useStyles();
@@ -61,12 +64,25 @@ const ParkingProvidedRuleInput = ({ rule, onInputChange }) => {
     onDebounceInputChange(e);
   };
 
+  const handleClear = e => {
+    setShowValidationErrors(true);
+    setSpacesProvided("");
+    onDebounceInputChange(e);
+  };
+
   const onBlur = () => {
     setShowValidationErrors(true);
   };
 
   return (
     <div className={classes.parkingProvidedWrapper}>
+      <div className={classes.pkgSelectContainer}>
+        <ResetButtons
+          className={classes.alignRight}
+          uncheckAll={handleClear}
+          resetProject={resetProject}
+        />
+      </div>
       <label htmlFor={code} className={clsx(classes.label, requiredStyle)}>
         {name}
       </label>
@@ -103,7 +119,8 @@ ParkingProvidedRuleInput.propTypes = {
     validationErrors: PropTypes.array,
     required: PropTypes.bool.isRequired
   }).isRequired,
-  onInputChange: PropTypes.func.isRequired
+  onInputChange: PropTypes.func.isRequired,
+  resetProject: PropTypes.func.isRequired
 };
 
 export default ParkingProvidedRuleInput;

--- a/client/src/components/ProjectWizard/WizardPages/ProjectTargetPoints.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectTargetPoints.jsx
@@ -4,7 +4,6 @@ import { createUseStyles, useTheme } from "react-jss";
 import RuleCalculationPanels from "../RuleCalculation/RuleCalculationPanels";
 import Level0Page from "./Level0Page";
 import ParkingProvidedRuleInput from "../RuleInput/ParkingProvidedRuleInput";
-import ResetButtons from "./ResetButtons";
 
 const useStyles = createUseStyles(theme => ({
   projectBox: {
@@ -56,7 +55,6 @@ function ProjectTargetPoints(props) {
     onInputChange,
     isLevel0,
     onParkingProvidedChange,
-    uncheckAll,
     resetProject
   } = props;
   const projectLevel = rules.find(e => e.code === "LEVEL");
@@ -69,11 +67,7 @@ function ProjectTargetPoints(props) {
 
   return (
     <>
-      <Level0Page
-        isLevel0={isLevel0}
-        uncheckAll={uncheckAll}
-        resetProject={resetProject}
-      />
+      <Level0Page isLevel0={isLevel0} resetProject={resetProject} />
 
       {projectLevel && projectLevel.calcValue > 0 && (
         <div>
@@ -86,20 +80,13 @@ function ProjectTargetPoints(props) {
               entered below.
             </span>
           </div>
-          <div className={classes.pkgSelectContainer}>
-            <ResetButtons
-              className={classes.alignRight}
-              uncheckAll={uncheckAll}
-              resetProject={resetProject}
-            />
-          </div>
           {parkingProvidedRuleOnly && (
             <ParkingProvidedRuleInput
               rule={parkingProvidedRuleOnly}
               onInputChange={onParkingProvidedChange}
+              resetProject={resetProject}
             />
           )}
-
           <div className={classes.projectBox}>
             <h4>
               <span className={classes.PLLabel}>Your project level </span>
@@ -129,7 +116,6 @@ ProjectTargetPoints.propTypes = {
   onInputChange: PropTypes.func.isRequired,
   onParkingProvidedChange: PropTypes.func.isRequired,
   isLevel0: PropTypes.bool.isRequired,
-  uncheckAll: PropTypes.func.isRequired,
   resetProject: PropTypes.func.isRequired
 };
 

--- a/client/src/components/ProjectWizard/WizardPages/ResetButtons.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ResetButtons.jsx
@@ -38,15 +38,17 @@ const ResetButtons = props => {
       >
         Reset Project
       </button>
-      <button className={classes.unSelectButton} onClick={uncheckAll}>
-        Clear Page
-      </button>
+      {uncheckAll && (
+        <button className={classes.unSelectButton} onClick={uncheckAll}>
+          Clear Page
+        </button>
+      )}
     </div>
   );
 };
 
 ResetButtons.propTypes = {
-  uncheckAll: PropTypes.func.isRequired,
+  uncheckAll: PropTypes.func,
   resetProject: PropTypes.func.isRequired
 };
 


### PR DESCRIPTION
Fixes #2065

### What changes did you make?

- Created the function `handleClear` for clearing the "parking spaces provided" input on Page 3, and used that in place of `uncheckAll` which was used to clear inputs on the other project wizard pages

### Why did you make the changes (we will use this info to test)?

- Page 3 binds the "parking spaces provided" input differently than the other pages/inputs; it uses a state variable 'spacesProvided'.   The existing handler `uncheckAll` updated the rules array but didn't clear `spacesProvided` and so the "parking spaces provided" input was not cleared. 


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

no visual changes
