### PR TITLE
Add new prop to align reset buttons

### DIFF
--- a/client/src/components/ProjectWizard/RuleInput/ParkingProvidedRuleInput.jsx
+++ b/client/src/components/ProjectWizard/RuleInput/ParkingProvidedRuleInput.jsx
@@ -42,6 +42,9 @@ const useStyles = createUseStyles(theme => ({
   },
   error: {
     color: theme.colors.warning
+  },
+  resetButtonWrapper: {
+    width: "100%"
   }
 }));
 
@@ -76,11 +79,11 @@ const ParkingProvidedRuleInput = ({ rule, onInputChange, resetProject }) => {
 
   return (
     <div className={classes.parkingProvidedWrapper}>
-      <div className={classes.pkgSelectContainer}>
+      <div className={classes.resetButtonWrapper}>
         <ResetButtons
-          className={classes.alignRight}
           uncheckAll={handleClear}
           resetProject={resetProject}
+          rightAlignStyle={{ marginRight: "-2em" }}
         />
       </div>
       <label htmlFor={code} className={clsx(classes.label, requiredStyle)}>

--- a/client/src/components/ProjectWizard/WizardPages/Level0Page.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/Level0Page.jsx
@@ -32,10 +32,13 @@ const useStyles = createUseStyles({
   },
   warningIcon: {
     float: "left"
+  },
+  alignClearRight: {
+    marginRight: "1em"
   }
 });
 
-const Level0Page = ({ isLevel0, uncheckAll, resetProject }) => {
+const Level0Page = ({ isLevel0, resetProject }) => {
   const theme = useTheme();
   const classes = useStyles({ theme });
 
@@ -43,10 +46,9 @@ const Level0Page = ({ isLevel0, uncheckAll, resetProject }) => {
     <>
       {isLevel0 && (
         <div className={classes.level0NavButtons}>
-          <div className={classes.pkgSelectContainer}>
+          <div>
             <ResetButtons
-              className={classes.alignRight}
-              uncheckAll={uncheckAll}
+              rightAlignStyle={{ marginRight: "1.1em" }}
               resetProject={resetProject}
             />
           </div>

--- a/client/src/components/ProjectWizard/WizardPages/Level0Page.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/Level0Page.jsx
@@ -32,9 +32,6 @@ const useStyles = createUseStyles({
   },
   warningIcon: {
     float: "left"
-  },
-  alignClearRight: {
-    marginRight: "1em"
   }
 });
 

--- a/client/src/components/ProjectWizard/WizardPages/ProjectDescriptions.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectDescriptions.jsx
@@ -34,12 +34,9 @@ function ProjectDescriptions(props) {
       <h3 style={theme.typography.subHeading}>
         First, let&rsquo;s get some information about your project
       </h3>
-      <div
-        className={classes.pkgSelectContainer}
-        style={{ marginBottom: "1em" }}
-      >
+      <div style={{ marginBottom: "1em" }}>
         <ResetButtons
-          className={classes.alignRight}
+          rightAlignStyle={{ marginRight: "1.1em" }}
           uncheckAll={uncheckAll}
           resetProject={resetProject}
         />

--- a/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectMeasures.jsx
@@ -89,14 +89,11 @@ function ProjectMeasure(props) {
           </div>
         </>
       )}
-      <div
-        className={classes.pkgSelectContainer}
-        style={{ marginTop: "1em", marginBottom: "1em" }}
-      >
+      <div style={{ marginTop: "1em", marginBottom: "1em" }}>
         <ResetButtons
-          className={classes.alignRight}
           uncheckAll={uncheckAll}
           resetProject={resetProject}
+          rightAlignStyle={{ marginRight: "0.4em" }}
         />
       </div>
       {(allowResidentialPackage || allowSchoolPackage) && (

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSpecifications.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSpecifications.jsx
@@ -41,7 +41,7 @@ function ProjectSpecifications(props) {
       </h3>
       <div className={classes.resetContainer}>
         <ResetButtons
-          className={classes.alignRight}
+          rightAlignStyle={{ marginRight: "0.3em" }}
           uncheckAll={uncheckAll}
           resetProject={resetProject}
         />

--- a/client/src/components/ProjectWizard/WizardPages/ResetButtons.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ResetButtons.jsx
@@ -28,7 +28,7 @@ const useStyles = createUseStyles({
 
 const ResetButtons = props => {
   const classes = useStyles();
-  const { uncheckAll, resetProject } = props;
+  const { uncheckAll, resetProject, rightAlignStyle } = props;
   return (
     <div className={classes.resetFlexContainer}>
       <button
@@ -39,7 +39,11 @@ const ResetButtons = props => {
         Reset Project
       </button>
       {uncheckAll && (
-        <button className={classes.unSelectButton} onClick={uncheckAll}>
+        <button
+          className={classes.unSelectButton}
+          style={rightAlignStyle}
+          onClick={uncheckAll}
+        >
           Clear Page
         </button>
       )}
@@ -49,7 +53,8 @@ const ResetButtons = props => {
 
 ResetButtons.propTypes = {
   uncheckAll: PropTypes.func,
-  resetProject: PropTypes.func.isRequired
+  resetProject: PropTypes.func.isRequired,
+  rightAlignStyle: PropTypes.object
 };
 
 export default ResetButtons;


### PR DESCRIPTION
Fixes #2099

### What changes did you make?

- Added the prop `rightAlignStyle' for the `ResetButtons` component so that the right margin of the "Clear Page" button could be specified independently on each wizard page.  

### Why did you make the changes (we will use this info to test)?

- Previously the appearance of the buttons did not match the design depicted in      ,  and the right margin could not be adjusted on a per page basis, because ResetButtons didn't utilize the className prop.  



### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

#### Page 1
<details><summary>Before</summary>

![before2099Page1](https://github.com/user-attachments/assets/c1feb425-ac5c-46fa-af16-ef3027df2a70)

</details> 
<details><summary>After</summary>

![alignPg1](https://github.com/user-attachments/assets/f19abf66-a028-4f84-82a5-9de9d4cbea3a)

</details> 

#### Page 2
<details><summary>Before</summary>

![before2099Page2](https://github.com/user-attachments/assets/5a3dd32d-6873-4f5f-bd9b-284b07677518)

</details> 
<details><summary>After</summary>

![alignPg2](https://github.com/user-attachments/assets/5004a8ca-24ef-435a-a48f-247a2a3a1d74)

</details> 

#### Page 3
<details><summary>Before</summary>

![before2099Page3](https://github.com/user-attachments/assets/0cea3c55-1e4a-418c-af63-271edd5899f2)

</details> 
<details><summary>After</summary>

![alignPg3](https://github.com/user-attachments/assets/f0613dba-537e-4c8a-aeca-a4c510beeda6)

</details> 
#### No Visual Change to Page 3 Error (Level0)

#### Page 4
<details><summary>Before</summary>

![before2099Page4](https://github.com/user-attachments/assets/2b3508c0-1379-4ea2-a08a-07b8a415c5ad)

</details> 
<details><summary>After</summary>

![ResetPg4NoQual](https://github.com/user-attachments/assets/a02a355f-1984-48e3-b547-bb19a1d3a805)

</details> 