### PR TITLE
Fix "Clear Page" and "Reset Project" on Page 1

### DIFF
--- a/client/src/components/ProjectWizard/RuleInput/MultiInput.jsx
+++ b/client/src/components/ProjectWizard/RuleInput/MultiInput.jsx
@@ -241,6 +241,8 @@ const toOptions = value => {
 const MultiInput = ({
   code,
   value,
+  partialMultiInput: inputValue,
+  onPartialMultiChange,
   validationErrors,
   mask,
   onChange,
@@ -249,8 +251,6 @@ const MultiInput = ({
 }) => {
   const theme = useTheme();
   const classes = useStyles({ theme });
-
-  const [inputValue, setInputValue] = useState("");
   const [hasError, setHasError] = useState(false);
   const valueOptions = toOptions(value);
 
@@ -258,6 +258,7 @@ const MultiInput = ({
     setHasError(false);
     onError(null);
   };
+
   const checkAndCreateTag = () => {
     // don't create duplicate tag
     const indexValue = valueOptions.findIndex(
@@ -269,7 +270,7 @@ const MultiInput = ({
       : valueOptions;
 
     handleChange(newValue);
-    setInputValue("");
+    onPartialMultiChange("");
 
     resetAINError();
   };
@@ -290,11 +291,9 @@ const MultiInput = ({
       })
     );
   };
-  const handleInputChange = inputValue => {
-    setInputValue(inputValue);
-  };
+
   const handleKeyDown = event => {
-    const validLength = matchLength(inputValue);
+    const validLength = matchLength(inputValue || "");
 
     switch (validLength) {
       case 0:
@@ -340,7 +339,7 @@ const MultiInput = ({
       isMulti
       menuIsOpen={false}
       onChange={handleChange}
-      onInputChange={handleInputChange}
+      onInputChange={onPartialMultiChange}
       onKeyDown={handleKeyDown}
       placeholder=""
       value={valueOptions}
@@ -357,6 +356,8 @@ const MultiInput = ({
 MultiInput.propTypes = {
   code: PropTypes.string.isRequired,
   value: PropTypes.any,
+  partialMultiInput: PropTypes.string,
+  onPartialMultiChange: PropTypes.func,
   validationErrors: PropTypes.array,
   mask: PropTypes.string.isRequired,
   onChange: PropTypes.func,

--- a/client/src/components/ProjectWizard/RuleInput/RuleInput.jsx
+++ b/client/src/components/ProjectWizard/RuleInput/RuleInput.jsx
@@ -147,7 +147,9 @@ const RuleInput = ({
     mask,
     link
   },
+  partialMultiInput,
   onPropInputChange,
+  onPartialMultiChange,
   onAINInputError,
   autoFocus,
   showPlaceholder
@@ -348,6 +350,8 @@ const RuleInput = ({
               <MultiInput
                 code={code}
                 value={value}
+                partialMultiInput={partialMultiInput}
+                onPartialMultiChange={onPartialMultiChange}
                 validationErrors={validationErrors}
                 mask={mask}
                 onChange={onInputChange}
@@ -424,7 +428,9 @@ RuleInput.propTypes = {
     mask: PropTypes.string,
     link: PropTypes.string
   }),
+  partialMultiInput: PropTypes.string,
   onPropInputChange: PropTypes.func,
+  onPartialMultiChange: PropTypes.func,
   onAINInputError: PropTypes.func,
   autoFocus: PropTypes.bool,
   showPlaceholder: PropTypes.bool

--- a/client/src/components/ProjectWizard/RuleInput/RuleInputList.jsx
+++ b/client/src/components/ProjectWizard/RuleInput/RuleInputList.jsx
@@ -13,7 +13,9 @@ const useStyles = createUseStyles({
 
 const RuleInputList = ({
   rules,
+  partialMultiInput,
   onInputChange,
+  onPartialMultiChange,
   onAINInputError,
   autoFocus,
   showPlaceholder
@@ -28,7 +30,9 @@ const RuleInputList = ({
               <RuleInput
                 key={rule.id}
                 rule={rule}
+                partialMultiInput={partialMultiInput}
                 onPropInputChange={onInputChange}
+                onPartialMultiChange={onPartialMultiChange}
                 onAINInputError={onAINInputError}
                 autoFocus={autoFocus && !index}
                 showPlaceholder={showPlaceholder}
@@ -41,7 +45,9 @@ const RuleInputList = ({
 };
 RuleInputList.propTypes = {
   rules: PropTypes.array,
+  partialMultiInput: PropTypes.string,
   onInputChange: PropTypes.func.isRequired,
+  onPartialMultiChange: PropTypes.func,
   onAINInputError: PropTypes.func,
   autoFocus: PropTypes.bool,
   showPlaceholder: PropTypes.bool

--- a/client/src/components/ProjectWizard/RuleInput/RuleInputPanels.jsx
+++ b/client/src/components/ProjectWizard/RuleInput/RuleInputPanels.jsx
@@ -6,8 +6,10 @@ import Panels from "../Common/Panels";
 
 const RuleInputPanels = ({
   rules,
+  partialMultiInput,
   suppressHeader,
   onInputChange,
+  onPartialMultiChange,
   onAINInputError,
   showPlaceholder
 }) => {
@@ -25,7 +27,9 @@ const RuleInputPanels = ({
           <RuleInputList
             key={pRules[0].calculationPanelId}
             rules={pRules}
+            partialMultiInput={partialMultiInput}
             onInputChange={onInputChange}
+            onPartialMultiChange={onPartialMultiChange}
             onAINInputError={onAINInputError}
             autoFocus={!index}
             showPlaceholder={showPlaceholder}
@@ -38,8 +42,10 @@ const RuleInputPanels = ({
 
 RuleInputPanels.propTypes = {
   rules: PropTypes.array.isRequired,
+  partialMultiInput: PropTypes.string,
   suppressHeader: PropTypes.bool,
   onInputChange: PropTypes.func.isRequired,
+  onPartialMultiChange: PropTypes.func,
   onAINInputError: PropTypes.func,
   autoFocus: PropTypes.bool,
   showPlaceholder: PropTypes.bool

--- a/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
@@ -44,6 +44,7 @@ export function TdmCalculationContainer({ contentContainerRef }) {
   const account = userContext ? userContext.account : null;
   const [engine, setEngine] = useState(null);
   const [formInputs, setFormInputs] = useState({});
+  const [partialAIN, setPartialAIN] = useState("");
   const projectId = params.projectId ? Number(params.projectId) : 0;
   const [strategiesInitialized, setStrategiesInitialized] = useState(false);
   const [formHasSaved, setFormHasSaved] = useState(true);
@@ -357,6 +358,10 @@ export function TdmCalculationContainer({ contentContainerRef }) {
     recalculate(newFormInputs);
   };
 
+  const onPartialAINChange = value => {
+    setPartialAIN(value);
+  };
+
   // If selecting a particular value for a particular rule needs to cause
   // a change to another input...
   const applySideEffects = (formInputs, ruleCode, value) => {
@@ -425,6 +430,9 @@ export function TdmCalculationContainer({ contentContainerRef }) {
           updateInputs[rules[i].code] = null;
         }
       }
+    }
+    if (filterRules === filters.projectDescriptionRules) {
+      setPartialAIN(""); // Clear incomplete AIN input
     }
     recalculate(updateInputs);
   };
@@ -538,7 +546,9 @@ export function TdmCalculationContainer({ contentContainerRef }) {
     <TdmCalculationWizard
       projectLevel={projectLevel}
       rules={rules}
+      partialAINInput={partialAIN}
       onInputChange={onInputChange}
+      onPartialAINChange={onPartialAINChange}
       onCommentChange={onCommentChange}
       onUncheckAll={onUncheckAll}
       onResetProject={onResetProject}

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
@@ -36,7 +36,9 @@ const TdmCalculationWizard = props => {
   const {
     projectLevel,
     rules,
+    partialAINInput,
     onInputChange,
+    onPartialAINChange,
     onCommentChange,
     onUncheckAll,
     onResetProject,
@@ -259,7 +261,9 @@ const TdmCalculationWizard = props => {
         return (
           <ProjectDescriptions
             rules={projectDescriptionRules}
+            partialAINInput={partialAINInput}
             onInputChange={onInputChange}
+            onPartialAINChange={onPartialAINChange}
             onAINInputError={handleAINInputError}
             uncheckAll={() => onUncheckAll(filters.projectDescriptionRules)}
             resetProject={() => onResetProject()}
@@ -378,7 +382,9 @@ TdmCalculationWizard.propTypes = {
       validationErrors: PropTypes.array
     })
   ).isRequired,
+  partialAINInput: PropTypes.string.isRequired,
   onInputChange: PropTypes.func.isRequired,
+  onPartialAINChange: PropTypes.func.isRequired,
   onCommentChange: PropTypes.func,
   onPkgSelect: PropTypes.func.isRequired,
   onParkingProvidedChange: PropTypes.func.isRequired,

--- a/client/src/components/ProjectWizard/WizardPages/ProjectDescriptions.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectDescriptions.jsx
@@ -19,8 +19,15 @@ const useStyles = createUseStyles({
 });
 
 function ProjectDescriptions(props) {
-  const { rules, onInputChange, onAINInputError, uncheckAll, resetProject } =
-    props;
+  const {
+    rules,
+    partialAINInput,
+    onInputChange,
+    onPartialAINChange,
+    onAINInputError,
+    uncheckAll,
+    resetProject
+  } = props;
   const classes = useStyles();
   const theme = useTheme();
   return (
@@ -44,7 +51,9 @@ function ProjectDescriptions(props) {
       <form noValidate>
         <RuleInputPanels
           rules={rules}
+          partialMultiInput={partialAINInput}
           onInputChange={onInputChange}
+          onPartialMultiChange={onPartialAINChange}
           onAINInputError={onAINInputError}
           suppressHeader={true}
           showPlaceholder={true}
@@ -59,7 +68,9 @@ function ProjectDescriptions(props) {
 }
 ProjectDescriptions.propTypes = {
   rules: PropTypes.array.isRequired,
+  partialAINInput: PropTypes.string,
   onInputChange: PropTypes.func.isRequired,
+  onPartialAINChange: PropTypes.func.isRequired,
   onAINInputError: PropTypes.func.isRequired,
   uncheckAll: PropTypes.func.isRequired,
   resetProject: PropTypes.func.isRequired


### PR DESCRIPTION
Fixes #2066

### What changes did you make?

- The state variable inputValue (representing an incomplete AIN number) was moved up to `TdmCalculatorContainer` so that it could be cleared by the "Clear Page" button.  
- onUncheckAll was modified to handle the case of the incomplete AIN number

### Why did you make the changes (we will use this info to test)?

- Previously "Clear Page" and "Reset Project" did not work if an incomplete AIN number was present on Page 1.  This is because an incomplete AIN number was not in the `formInputs` or `rules` and so it was not cleared in the same manner as other inputs 


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

no visual changes
