### PR TITLE
Display lastname, firstname format for CreatedBy column

### DIFF
--- a/client/src/components/Projects/ProjectTableRow.jsx
+++ b/client/src/components/Projects/ProjectTableRow.jsx
@@ -291,7 +291,7 @@ const ProjectTableRow = ({
       <td className={classes.td}>{project.address}</td>
       <td className={classes.td}>{fallbackToBlank(formInputs.VERSION_NO)}</td>
       <td className={classes.td}>
-        {`${project.firstName} ${project.lastName}`}
+        {`${project.lastName}, ${project.firstName}`}
       </td>
       <td className={classes.tdRightAlign}>
         {formatDate(project.dateCreated)}


### PR DESCRIPTION
- Fixes #2011

### What changes did you make?

- In the Created By column on the My Projects display, show names in lastname, firstname format.


### Why did you make the changes (we will use this info to test)?

- See Issue


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)![image](https://github.com/user-attachments/assets/cf1bfb75-5c61-4163-b0d1-337de9690c15)
</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/6aa20a9e-398c-4367-a69b-c2a9ba86e216)

</details>
