### PR TITLE
Add sort icon to column headers on My Project page

### DIFF
--- a/client/src/components/Projects/ColumnHeaderPopups/ProjectTableColumnHeader.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/ProjectTableColumnHeader.jsx
@@ -2,7 +2,12 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import "react-datepicker/dist/react-datepicker.css";
-import { MdFilterAlt, MdOutlineFilterAlt } from "react-icons/md";
+import {
+  MdFilterAlt,
+  MdOutlineFilterAlt,
+  MdOutlineSwitchRight,
+  MdOutlineSwitchLeft
+} from "react-icons/md";
 import { createUseStyles } from "react-jss";
 import { Popover } from "react-tiny-popover";
 import DatePopup from "./DatePopup";
@@ -14,6 +19,7 @@ import { useTheme } from "react-jss";
 const useStyles = createUseStyles(theme => ({
   iconNoFilter: {
     color: theme.colorWhite,
+    fontSize: "1.2rem",
     "&:hover": {
       backgroundColor: theme.colorWhite,
       color: theme.colorLADOT,
@@ -22,9 +28,14 @@ const useStyles = createUseStyles(theme => ({
     }
   },
   iconFilter: {
+    fontSize: "1.2rem",
     backgroundColor: "transparent",
     color: "theme.colorWhite",
     marginLeft: "0.5rem"
+  },
+  sortIcon: {
+    fontSize: "1.2rem",
+    transform: "rotate(90deg)"
   },
   reactTinyPopoverContainer: {
     color: "orange"
@@ -57,6 +68,13 @@ const ColumnHeader = React.forwardRef((props, ref) => {
       onClick={props.onClick}
     >
       <span>{props.header.label}</span>
+      {props.orderBy === props.header.id ? (
+        props.order === "asc" ? (
+          <MdOutlineSwitchRight className={classes.sortIcon} />
+        ) : (
+          <MdOutlineSwitchLeft className={classes.sortIcon} />
+        )
+      ) : null}
       {props.isFilterApplied() ? (
         <MdFilterAlt
           className={classes.iconFilter}
@@ -77,7 +95,9 @@ ColumnHeader.displayName = "ColumnHeader";
 ColumnHeader.propTypes = {
   onClick: PropTypes.func,
   header: PropTypes.any,
-  isFilterApplied: PropTypes.func
+  isFilterApplied: PropTypes.func,
+  order: PropTypes.string,
+  orderBy: PropTypes.string
 };
 
 const ProjectTableColumnHeader = ({
@@ -224,6 +244,8 @@ const ProjectTableColumnHeader = ({
             onClick={() => setIsPopoverOpen(!isPopoverOpen)}
             header={header}
             isFilterApplied={() => isFilterApplied()}
+            order={order}
+            orderBy={orderBy}
           ></ColumnHeader>
         </Popover>
       ) : (


### PR DESCRIPTION
- Fixes #1996

### What changes did you make?

- Add Icon to column header for the primary sort criterion
- Note that the My Projects page implements a multi-column sort, but the icon only indicates the primary sort column

### Why did you make the changes (we will use this info to test)?

- See Issue


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/8a69148c-8a41-425c-85e9-d5f4fa904200)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/3d8c1656-537f-437d-917c-46a2b4354d67)

</details>
