### PR TITLE
Remove Icon from Edit Note button on modal dialog for edting admin notes

### DIFF
--- a/client/src/components/Projects/AdminNotesModal.jsx
+++ b/client/src/components/Projects/AdminNotesModal.jsx
@@ -3,7 +3,7 @@ import { PropTypes } from "prop-types";
 import Button from "../Button/Button";
 import { createUseStyles } from "react-jss";
 // import ModalDialog from "../UI/AriaModal/ModalDialog";
-import { MdEdit, MdOutlineClose } from "react-icons/md";
+import { MdOutlineClose } from "react-icons/md";
 import AriaModal from "react-aria-modal";
 import clsx from "clsx";
 
@@ -365,7 +365,6 @@ const AdminNotesModal = ({
               id="editButton"
               color="#A7C539"
             >
-              <MdEdit />
               EDIT NOTE
             </button>
           </div>


### PR DESCRIPTION
- Fixes #2068

### What changes did you make?

- Remove Icon from Edit Note button on modal dialog for editing Admin Notes on My Project Page


### Why did you make the changes (we will use this info to test)?

- See Issue
-
-

### Issue-Specific User Account

Any admin user

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/48604e46-5bcc-4caa-a441-d07c4515d0ce)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![image](https://github.com/user-attachments/assets/8e76a8f4-346a-4da1-87a1-e3d526aaf69f)

</details>
