### PR TITLE
Increase min font size to 16px on Calculation Summary Page

### DIFF
--- a/client/src/components/ProjectWizard/WizardFooter.jsx
+++ b/client/src/components/ProjectWizard/WizardFooter.jsx
@@ -25,7 +25,6 @@ const useStyles = createUseStyles({
     padding: "0px 12px"
   },
   lastSaved: {
-    fontSize: "14px",
     color: "#6F6C64"
   },
   lastSavedContainer: {

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/LandUses.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/LandUses.jsx
@@ -11,12 +11,10 @@ const useStyles = createUseStyles({
     margin: "4px auto"
   },
   ruleName: {
-    minWidth: "270px",
-    fontSize: "14px"
+    minWidth: "270px"
   },
   value: {
     display: "flex",
-    fontSize: "14px",
     justifyContent: "flex-end",
     marginRight: "6.5rem"
   }

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/MeasureSelected.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/MeasureSelected.jsx
@@ -5,7 +5,6 @@ import { roundToTwo } from "../../helpers";
 
 const useStyles = createUseStyles({
   rule: {
-    fontSize: "0.875rem",
     display: "flex",
     alignItems: "center",
     justifyContent: "space-between",

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectDetail.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectDetail.jsx
@@ -10,8 +10,7 @@ const useStyles = createUseStyles({
     alignItems: "center",
     justifyContent: "space-between",
     minHeight: "24px",
-    margin: "4px auto",
-    fontSize: "0.875rem"
+    margin: "4px auto"
   },
   ruleName: {
     flexBasis: "80%"
@@ -19,7 +18,7 @@ const useStyles = createUseStyles({
   pointsContainer: {
     display: "flex",
     justifyContent: "flex-end",
-    flaxBasis: "20%"
+    flexBasis: "20%"
   },
   measureDetails: {
     textAlign: "right",

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfo.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfo.jsx
@@ -7,8 +7,7 @@ const useStyles = createUseStyles({
     display: "flex",
     alignItems: "baseline",
     maxHeight: "20px",
-    width: "50%",
-    fontSize: "0.875rem"
+    width: "50%"
   },
   projectInfoCategory: {
     fontWeight: "600",
@@ -18,7 +17,6 @@ const useStyles = createUseStyles({
   },
   projectInfoDetails: {
     color: "rgba(0, 5, 30, 1)",
-    fontFamily: "Calibri",
     fontWeight: 400
   }
 });

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoList.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoList.jsx
@@ -10,7 +10,6 @@ const useStyles = createUseStyles({
   },
   projectInfoCategory: {
     fontWeight: "600",
-    fontSize: "14px",
     textTransform: "uppercase",
     color: "rgba(0, 0, 0, 1)",
     marginRight: "2px"
@@ -18,8 +17,7 @@ const useStyles = createUseStyles({
   projectInfoDetails: {
     color: "#00051e",
     fontFamily: "Calibri",
-    fontWeight: 600,
-    fontSize: "14px"
+    fontWeight: 600
   },
   AINValuesContainer: {
     display: "flex",

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectSummary.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectSummary.jsx
@@ -24,9 +24,6 @@ const useStyles = createUseStyles({
     maxWidth: "600px",
     minWidth: "60vw"
   },
-  // success: {
-  //   color: "#A7C539"
-  // },
   failure: {
     color: "#E46247"
   },
@@ -47,7 +44,6 @@ const useStyles = createUseStyles({
     margin: "4px auto"
   },
   ruleName: {
-    fontSize: "14px",
     minWidth: "270px"
   },
   loaderContainer: {
@@ -57,7 +53,6 @@ const useStyles = createUseStyles({
     justifyContent: "center"
   },
   lastSaved: {
-    fontSize: "14px",
     color: "#6F6C64"
   },
   lastSavedContainer: {
@@ -95,7 +90,6 @@ const useStyles = createUseStyles({
   earnedPoints: {
     fontFamily: "Calibri",
     fontWeight: "500",
-    fontSize: "14px",
     marginTop: "auto",
     marginBottom: "auto",
     color: "#00000",
@@ -103,7 +97,6 @@ const useStyles = createUseStyles({
     minWidth: "6rem"
   },
   summaryContainer: {
-    fontSize: "14px",
     display: "flex",
     minWidth: "180px",
     maxWidth: "100%",
@@ -121,7 +114,6 @@ const useStyles = createUseStyles({
   tempText: {
     fontFamily: "Calibri",
     fontStyle: "italic",
-    fontSize: "14px",
     color: "#C35302"
   }
 });


### PR DESCRIPTION
- Fixes #2051

### What changes did you make?

- Increased minimum font size for all text on the Project Summary Page

### Why did you make the changes (we will use this info to test)?

- See Issue


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/d22e2648-3b64-47f2-b989-f3a96248afe8)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/d4e00850-7c88-4e1b-a7e2-4d1c23603243)

</details>
