### PR TITLE
Limit Provided Parking maxlength=7

### DIFF
--- a/client/src/components/ProjectWizard/RuleInput/ParkingProvidedRuleInput.jsx
+++ b/client/src/components/ProjectWizard/RuleInput/ParkingProvidedRuleInput.jsx
@@ -101,6 +101,7 @@ const ParkingProvidedRuleInput = ({ rule, onInputChange, resetProject }) => {
           data-testid={code}
           max={maxValue}
           onBlur={onBlur}
+          maxLength="7"
         />
         <span className={classes.unit}>&nbsp;{units}</span>
       </div>


### PR DESCRIPTION
- Fixes #2052

### What changes did you make?

- Slight change to also limit the number of digits that can be typed into the Provided Parking field on the Target Points page.


### Why did you make the changes (we will use this info to test)?

- Part of original request for Issue #2052
-
-

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>


![Screenshot 2025-02-13 120007](https://github.com/user-attachments/assets/0cbfad79-df17-4600-89ff-c75a067b2e76)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  

![Screenshot 2025-02-13 120045](https://github.com/user-attachments/assets/c258cd93-7d9c-4cc1-b818-ef670858bff0)


</details>
