### PR TITLE
Tristan Camacho's proposed changes to the Bug template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -9,7 +9,8 @@ assignees: ''
 
 ---
 
-#### Description
+#### Describe the bug
+<!-- REPLACE THIS TEXT - A clear and concise description of what the bug is, who it affects, how it affects users. (optional: what is the user's goal? -->
 
 
 #### Steps to Reproduce

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -14,6 +14,12 @@ assignees: ''
 
 
 #### Steps to Reproduce
+<!-- REPLACE THE FOLLOWNG TEXT:
+- 1. Go to '...'
+- 2. Click on '....'
+- 3. Scroll down to '....'
+- 4. See error 
+-->
 1. 
 
 #### Actual Result

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Lists out information that would be help developers quickly identify and fix
-  potentail problems.
+  potential problems.
 title: 'Bug: '
 labels: 'bug, feature: missing, level: missing, milestone: missing, priority: MUST
   HAVE, role: missing, size: missing'
@@ -9,49 +9,32 @@ assignees: ''
 
 ---
 
-#### Describe the bug 
-
-REPLACE THIS TEXT - A clear and concise description of what the bug is, who it affects, how it affects users.
-
-(optional) REPLACE THIS TEXT - What is the user's goal?
+#### Description
 
 
-#### Steps to reproduce the issue
+#### Steps to Reproduce
+1. 
 
-(if applicable, please specify platform (iOS, Android, Windows, Mac version) and brower)
-
-REPLACE THE FOLLOWNG TEXT:
-- 1. Go to '...'
-- 2. Click on '....'
-- 3. Scroll down to '....'
-- 4. See error 
+#### Actual Result
 
 
-#### What's the expected result?
+<details><summary></summary>
 
-REPLACE THIS TEXT - What is supposed to happen after following the above steps?
 
-(if you have a suggested solution, you can add it here)
+</details>
 
-#### What's the actual result?
+#### Expected Result
 
-REPLACE THIS TEXT - What is supposed actually happening after following the above steps?
 
-#### Additional details / screenshot
+#### Device Configuration
+- Device: 
+- OS version: 
+- Browser: 
+- Browser version: 
 
-REPLACE THIS TEXT - Screenshot (drag in)
-REPLACE THIS TEXT - Video recording (drag in)
-
-#### Device configuration
-
-REPLACE THE FOLLOWNG TEXT:
-- Device: [e.g. type of smartphone, tablet, desktop computer]
-- OS version: [e.g. iOS, Android version #]
-- Browser [e.g. Chrome, Firefox, Safari, etc.]
-- Browser version [e.g. 22]
-
----
-- [ ] Review with product and dev. Update if needed based on feedback
-- [ ] Once finalized, add before and after images to the [staging deck on this slide]() 
-   - [ ] if no slide has been made, make one in [the staging deck](https://docs.google.com/presentation/d/1crZ3IxqA4hAu3qzD7ns93Ieuqjwh6wyEtuX_46cP-fg)
+#### Action Items
+- [ ] Fix bug.
+- [ ] Review with development lead.
+- [ ] Review with product, development, and research teams. Update if needed based on feedback.
+- [ ] Once finalized, add a slide to [the staging deck](https://docs.google.com/presentation/d/1crZ3IxqA4hAu3qzD7ns93Ieuqjwh6wyEtuX_46cP-fg).
 - [ ] Get Stakeholder sign-off via the stakeholder meeting slide deck.


### PR DESCRIPTION
### What changes did you make?
- Removed a lot of the boilerplate text. It's useful the first time the template is used, but becomes an annoyance every time thereafter.
- Reversed the order of the Expected Results and Actual Results. In my experience prior to TDM, the Actual Results always came first. That's more of my personal preference simply out of habit and I think makes sense because it's the order that the developer will experience the bug when following the steps: first they'll see the bug, and then they'll imagine what it's supposed to look like afterward.
- Added "detail" element formatting to put evidence of the defect in screenshot or video format.