### PR TITLE
changed theme color to critical color for error message

### DIFF
--- a/client/src/components/Authorization/SendEmailForm.jsx
+++ b/client/src/components/Authorization/SendEmailForm.jsx
@@ -34,7 +34,7 @@ export const useStyles = createUseStyles(theme => ({
   errorMessage: {
     margin: "8px auto",
     width: "403px",
-    color: theme.colorWarning
+    color: theme.colorCritical
   },
   authText: {
     color: theme.colors.secondary.gray,


### PR DESCRIPTION
Fixes #2047 

### What changes did you make?

- Changed "Email is required" error text to have the color #C3391D

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Text-color-before](https://github.com/user-attachments/assets/6287c4fc-db02-493f-8b6a-9dd48448059e)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Text-color-after](https://github.com/user-attachments/assets/4aa7dff4-6ba1-486b-b48e-a5978a3ee111)

</details>
