### PR TITLE
made error messages left aligned on new account page

### DIFF
--- a/client/src/components/Authorization/Register.jsx
+++ b/client/src/components/Authorization/Register.jsx
@@ -14,6 +14,9 @@ const useStyles = createUseStyles({
   },
   authText: {
     color: "#979797"
+  },
+  invalidFeedback: {
+    color: "#ff0418"
   }
 });
 
@@ -121,7 +124,7 @@ const Register = props => {
                     <ErrorMessage
                       name="firstName"
                       component="div"
-                      className="invalid-feedback"
+                      className={classes.invalidFeedback}
                     />
                   </div>
                   <div className="form-group">
@@ -136,7 +139,7 @@ const Register = props => {
                     <ErrorMessage
                       name="lastName"
                       component="div"
-                      className="invalid-feedback"
+                      className={classes.invalidFeedback}
                     />
                   </div>
                   <div className="form-group">
@@ -151,7 +154,7 @@ const Register = props => {
                     <ErrorMessage
                       name="email"
                       component="div"
-                      className="invalid-feedback"
+                      className={classes.invalidFeedback}
                     />
                   </div>
                   <div className="form-group">
@@ -167,7 +170,7 @@ const Register = props => {
                     <ErrorMessage
                       name="password"
                       component="div"
-                      className="invalid-feedback"
+                      className={classes.invalidFeedback}
                     />
                   </div>
                   <div className="form-group">
@@ -185,7 +188,7 @@ const Register = props => {
                     <ErrorMessage
                       name="passwordConfirm"
                       component="div"
-                      className="invalid-feedback"
+                      className={classes.invalidFeedback}
                     />
                   </div>
 


### PR DESCRIPTION
- Fixes #2152
- Fixes #2045

### What changes did you make?

- Left aligned the error messages on the registration page

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![error-before](https://github.com/user-attachments/assets/c030f718-4de3-4cc1-a6ff-124aea2df6c8)

</details>

<details>
<summary>Visuals after changes are applied</summary>
 
![image](https://github.com/user-attachments/assets/193b52cd-f781-471f-a98e-edfcaf32609d)

</details>
