### PR TITLE
fix: prevent calendar from jumping on small screen heights

### DIFF
--- a/client/src/components/UI/DateRangePicker.jsx
+++ b/client/src/components/UI/DateRangePicker.jsx
@@ -64,6 +64,16 @@ const DateRangePicker = ({
           dateFormat="yyyy-MM-dd"
           placeholderText={startDatePlaceholder || ""}
           popperPlacement="bottom-start"
+          popperModifiers={[
+            {
+              name: "flip",
+              enabled: false
+            },
+            {
+              name: "hide",
+              enabled: false
+            }
+          ]}
           onCalendarOpen={handleCalendarOpen}
           onCalendarClose={handleCalendarClose}
           onClick={e => {
@@ -87,6 +97,16 @@ const DateRangePicker = ({
           dateFormat="yyyy-MM-dd"
           placeholderText={endDatePlaceholder || ""}
           popperPlacement="bottom-end"
+          popperModifiers={[
+            {
+              name: "flip",
+              enabled: false
+            },
+            {
+              name: "hide",
+              enabled: false
+            }
+          ]}
           onCalendarOpen={handleCalendarOpen}
           onCalendarClose={handleCalendarClose}
           // withPortal


### PR DESCRIPTION
- Fixes #2201

### What changes did you make?
- Prevent calendar from jumping to top of input on screen resize or smaller screens

### Why did you make the changes (we will use this info to test)?
- bug fix

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

https://github.com/user-attachments/assets/1679e26d-0be9-483c-9d82-2163cfe821b8

</details>

<details>
<summary>Visuals after changes are applied</summary>

https://github.com/user-attachments/assets/0ec4d2cf-d71d-4c98-975c-2887d81ae35e


</details>


### For Devs

This issue (in theory) was a quick fix. But I had to go one level deeper to find the popover library that `react-datepicker` was using in order to find how to stop that behavior in it's docs: [Floating UI Docs](https://floating-ui.com/docs/getting-started)

While solving this issue I found another that should be a different ticket (if it's something we want to try to fix, it may be a bigger lift): If the screen height is less than the height popover for any item in the `project column header` the popover will auto close as soon as it's opened.
