### PR TITLE
Allow clearing CSV file download filename

### DIFF
--- a/client/src/components/Modals/ActionProjectsCsv.jsx
+++ b/client/src/components/Modals/ActionProjectsCsv.jsx
@@ -52,10 +52,10 @@ const CsvModal = ({
   const [csvData, setCsvData] = useState(null);
   const [projectCollection, setProjectCollection] = useState("");
   const [loading, setLoading] = useState(false);
-  const [filename, setFilename] = useState("");
+  const [filename, setFilename] = useState(new Date().toISOString());
   const [progress, setProgress] = useState(0);
 
-  if (filename === "") {
+  if (filename === "dummy") {
     setFilename(new Date().toISOString());
   }
 
@@ -93,7 +93,7 @@ const CsvModal = ({
         onClose();
         setCsvData(null);
         setProjectCollection("");
-        setFilename("");
+        setFilename("dummy");
       }}
       initialFocus="#filename"
     >
@@ -168,7 +168,7 @@ const CsvModal = ({
                 onClose();
                 setCsvData(null);
                 setProjectCollection("");
-                setFilename("");
+                setFilename("dummy");
               }}
               variant="secondary"
               id="cancelButton"
@@ -176,11 +176,14 @@ const CsvModal = ({
               Cancel
             </Button>
 
-            {(project || projectCollection) && !loading && !csvData && (
-              <Button onClick={handleGenerateButton} variant="primary">
-                Generate File
-              </Button>
-            )}
+            {(project || projectCollection) &&
+              !loading &&
+              !csvData &&
+              !!filename && (
+                <Button onClick={handleGenerateButton} variant="primary">
+                  Generate File
+                </Button>
+              )}
 
             {(project || projectCollection) && !loading && csvData ? (
               <CSVLink


### PR DESCRIPTION
- Fixes #2142

### What changes did you make?

- Allow clearing the filename
- but if filename is cleared, hide the generate file button, since that would be an error

### Why did you make the changes (we will use this info to test)?

- See Issue




### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)


<details>
<summary>Visuals before changes are applied</summary>


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/c9aba1c4-d4de-4147-a3b3-df66af761f5e)

</details>
