### PR TITLE
Fix to PR2200

### DIFF
--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -693,7 +693,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
       return false;
 
     // fullName attr allows searching by full name, not just by first or last name
-    p["fullname"] = `${p["firstName"]} ${p["lastName"]}`;
+    p["fullname"] = `${p["lastName"]}, ${p["firstName"]}`;
     if (
       criteria.author &&
       !p.fullname.toLowerCase().includes(criteria.author.toLowerCase())


### PR DESCRIPTION
- Fixes PR #2200
### What changes did you make?

- Fix filtering by author

### Why did you make the changes (we will use this info to test)?

- PR #2200 changed the format of the author search criteria for Last Name, First Name, but did not change the filter function to match, so the criteria were entered OK, but the filter bay author was broken and returned no results.



