### PR TITLE
fix: parking strategy 5 does not wipe on clear page click

### DIFF
--- a/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
@@ -425,7 +425,11 @@ export function TdmCalculationContainer({ contentContainerRef }) {
   const onUncheckAll = filterRules => {
     let updateInputs = { ...formInputs };
     for (let i = 0; i < rules.length; i++) {
-      if (filterRules(rules[i]) && rules[i].code !== "STRATEGY_BIKE_4") {
+      if (
+        filterRules(rules[i]) &&
+        rules[i].code !== "STRATEGY_BIKE_4" &&
+        rules[i].code !== "STRATEGY_PARKING_5"
+      ) {
         if (updateInputs[rules[i].code]) {
           updateInputs[rules[i].code] = null;
         }


### PR DESCRIPTION
- Fixes #2129 

### What changes did you make?
- Reduced Parking Supply no longer wipes when `Clear Page` is clicked

### Why did you make the changes (we will use this info to test)?
- Reduced Parking Supply is calculated based on the user's answer on page 3, so it should stay as long as page 3 has an answer.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

https://github.com/user-attachments/assets/217f2261-8461-4b1c-9a55-38b537339e31

</details>

<details>
<summary>Visuals after changes are applied</summary>
 
https://github.com/user-attachments/assets/05116b5e-0189-428b-8858-6b87ef0e2e1c

</details>
