### PR TITLE
Change button label from Done to Proceed on 2 Modals

### DIFF
--- a/client/src/components/Modals/ActionProjectSnapshot.jsx
+++ b/client/src/components/Modals/ActionProjectSnapshot.jsx
@@ -75,7 +75,7 @@ export default function SnapshotProjectModal({
             variant="primary"
             disabled={!snapshotProjectName}
           >
-            Done
+            Proceed
           </Button>
         </div>
       </div>

--- a/client/src/components/Modals/ActionProjectSnapshot.jsx
+++ b/client/src/components/Modals/ActionProjectSnapshot.jsx
@@ -7,6 +7,13 @@ import { MdCameraAlt } from "react-icons/md";
 import ModalDialog from "../UI/AriaModal/ModalDialog";
 
 const useStyles = createUseStyles(theme => ({
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    maxWidth: "30rem",
+    margin: "0 2rem"
+  },
   buttonFlexBox: {
     display: "flex",
     flexDirection: "row",

--- a/client/src/components/Modals/ActionSnapshotRename.jsx
+++ b/client/src/components/Modals/ActionSnapshotRename.jsx
@@ -9,7 +9,9 @@ const useStyles = createUseStyles(theme => ({
   container: {
     display: "flex",
     flexDirection: "column",
-    alignItems: "center"
+    alignItems: "center",
+    maxWidth: "30rem",
+    margin: "0 2rem"
   },
   buttonFlexBox: {
     display: "flex",

--- a/client/src/components/Modals/ActionSnapshotRename.jsx
+++ b/client/src/components/Modals/ActionSnapshotRename.jsx
@@ -79,7 +79,7 @@ export default function RenameSnapshotModal({
             variant="primary"
             disabled={!snapshotProjectName}
           >
-            Done
+            Proceed
           </Button>
         </div>
       </div>


### PR DESCRIPTION
- Fixes #2159

### What changes did you make?

- See Issue
- Also constrained the width of the dialog, as it can get quite wide if the project name is long.

### Why did you make the changes (we will use this info to test)?

- See Issue

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/750e192d-7487-4269-a80d-b5bb2dc4471a)

![image](https://github.com/user-attachments/assets/9410c26f-3075-4737-9022-0c4d592a4e77)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![image](https://github.com/user-attachments/assets/d2c17e2a-1426-495e-993f-387d73810998)

![image](https://github.com/user-attachments/assets/0adcca9b-205b-4bdf-8c9b-376e7f6f9356)

</details>
