### PR TITLE
fix: chromium only - allow only numbers on parking provided

### DIFF
--- a/client/src/components/ProjectWizard/RuleInput/ParkingProvidedRuleInput.jsx
+++ b/client/src/components/ProjectWizard/RuleInput/ParkingProvidedRuleInput.jsx
@@ -20,7 +20,7 @@ const useStyles = createUseStyles(theme => ({
   requiredInputLabel: {
     "&:after": {
       content: '" *"',
-      color: theme.colorCritical
+      color: theme.colors.warning
     }
   },
   inputContainer: {
@@ -33,7 +33,14 @@ const useStyles = createUseStyles(theme => ({
     textAlign: "right",
     margin: ".5em auto",
     height: 45,
-    width: "50%"
+    width: "50%",
+    "&::-webkit-outer-spin-button, &::-webkit-inner-spin-button": {
+      "-webkit-appearance": "none"
+    },
+    // Firefox input type number still allows letters, but will validate on submit
+    "&[type=number]": {
+      "-moz-appearance": "textfield"
+    }
   },
   unit: {
     ...theme.typography.heading2,
@@ -41,7 +48,7 @@ const useStyles = createUseStyles(theme => ({
     marginLeft: "-80px"
   },
   error: {
-    color: theme.colorCritical
+    color: theme.colors.warning
   },
   resetButtonWrapper: {
     width: "100%"
@@ -93,12 +100,13 @@ const ParkingProvidedRuleInput = ({ rule, onInputChange, resetProject }) => {
         <input
           className={classes.input}
           autoFocus
-          type="text"
+          type="number"
           value={spacesProvided}
           onChange={handleChange}
           name={code}
           id={code}
           data-testid={code}
+          min={0}
           max={maxValue}
           onBlur={onBlur}
           maxLength="7"

--- a/client/src/components/ProjectWizard/RuleInput/ParkingProvidedRuleInput.jsx
+++ b/client/src/components/ProjectWizard/RuleInput/ParkingProvidedRuleInput.jsx
@@ -20,7 +20,7 @@ const useStyles = createUseStyles(theme => ({
   requiredInputLabel: {
     "&:after": {
       content: '" *"',
-      color: theme.colors.warning
+      color: theme.colorCritical
     }
   },
   inputContainer: {
@@ -48,7 +48,7 @@ const useStyles = createUseStyles(theme => ({
     marginLeft: "-80px"
   },
   error: {
-    color: theme.colors.warning
+    color: theme.colorCritical
   },
   resetButtonWrapper: {
     width: "100%"


### PR DESCRIPTION
- Fixes #2154 

### What changes did you make?
- Change parking provided input to be type of number. 

### Why did you make the changes (we will use this info to test)?
- On chromium browsers this will not allow the user to input any letters. On firefox it will still allow the user to input letters but it will not let them advance (it disables the next and save buttons).


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

<img width="623" alt="Screenshot 2025-03-16 at 12 48 04 AM" src="https://github.com/user-attachments/assets/fb485338-7938-41d8-99e8-5311e592a0e6" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="826" alt="Screenshot 2025-03-16 at 12 45 26 AM" src="https://github.com/user-attachments/assets/52f65f6c-f841-4150-836d-b77b6c28ae74" />

</details>
