### PR TITLE
fix: truncate admin notes

### DIFF
--- a/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
@@ -31,8 +31,15 @@ const useStyles = createUseStyles({
     flexDirection: "row",
     alignItems: "center",
     height: "2rem",
+    gap: "0.2em",
     "&:hover": {
       backgroundColor: "lightblue"
+    },
+    "& span": {
+      maxWidth: "25ch",
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis"
     }
   },
   toggleButton: {


### PR DESCRIPTION
- Fixes #2043 

### What changes did you make?
- Truncate text on the admin notes popup in the `my projects` page

### Why did you make the changes (we will use this info to test)?
- Bug fix.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

<img width="370" alt="Screenshot 2025-03-16 at 6 04 19 PM" src="https://github.com/user-attachments/assets/0dbd5b7e-58ed-4544-8322-604b98eb1d0d" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="455" alt="Screenshot 2025-03-16 at 6 01 35 PM" src="https://github.com/user-attachments/assets/cc5c76e6-0641-43a3-aea4-b0861b63a9aa" />

</details>
