### PR TITLE
fix: truncate admin notes

### DIFF
--- a/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
@@ -31,8 +31,15 @@ const useStyles = createUseStyles({
     flexDirection: "row",
     alignItems: "center",
     height: "2rem",
+    gap: "0.2em",
     "&:hover": {
       backgroundColor: "lightblue"
+    },
+    "& span": {
+      maxWidth: "25ch",
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis"
     }
   },
   toggleButton: {


### PR DESCRIPTION
- Fixes #2170 
- Fixes #2177 
- Fixes #2178

### What changes did you make?

- See Issues

### Why did you make the changes (we will use this info to test)?

- See Issues

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
