### PR TITLE
feat: add warning modal when reset project is clicked

### DIFF
--- a/client/src/components/Modals/WarningProjectReset.jsx
+++ b/client/src/components/Modals/WarningProjectReset.jsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { PropTypes } from "prop-types";
+import Button from "../Button/Button";
+import { MdWarning } from "react-icons/md";
+import { createUseStyles } from "react-jss";
+import ModalDialog from "../UI/AriaModal/ModalDialog";
+import { formatDatetime } from "../../helpers/util";
+import { useNavigate } from "react-router-dom";
+
+const useStyles = createUseStyles(theme => ({
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    marginBottom: "1rem"
+  },
+  warningIcon: {
+    height: "80px",
+    width: "80px",
+    color: theme.colorCritical,
+    textAlign: "center"
+  },
+  buttonFlexBox: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "center",
+    margin: 0
+  },
+  heading1: { ...theme.typography.heading1, marginBottom: "1.5rem" },
+  subheading: {
+    ...theme.typography.subHeading,
+    width: "30rem",
+    lineHeight: "1.5rem"
+  }
+}));
+
+const ResetProjectModal = ({ mounted, onClose, project, resetProject }) => {
+  const classes = useStyles();
+  const navigate = useNavigate();
+
+  const formattedDateModified =
+    project.dateModified && formatDatetime(project.dateModified);
+
+  const handleReset = () => {
+    if (project.dateModified) {
+      resetProject();
+      onClose();
+    } else {
+      resetProject();
+      navigate(`/calculation/1/${project.id}`);
+      onClose();
+    }
+  };
+
+  return (
+    <ModalDialog
+      mounted={mounted}
+      onClose={onClose}
+      omitCloseBox={true}
+      initialFocus="#cancelButton"
+    >
+      {project.dateModified ? (
+        <div className={classes.container}>
+          <MdWarning alt="Warning" className={classes.warningIcon} />
+          <div>
+            <p className={classes.heading1}>Reset project</p>
+          </div>
+          <div style={{ marginBottom: "1rem" }}>
+            <p className={classes.subheading}>
+              All unsaved data from this project will be lost.
+            </p>
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+            <strong>Date Last Saved: </strong>
+            <p>{formattedDateModified} Pacific Time</p>
+          </div>
+        </div>
+      ) : (
+        <div className={classes.container}>
+          <MdWarning alt="Warning" className={classes.warningIcon} />
+          <div>
+            <p className={classes.heading1}>Delete Project</p>
+          </div>
+          <div>
+            <p className={classes.subheading}>
+              All data from this project will be lost.
+            </p>
+          </div>
+        </div>
+      )}
+      <div className={classes.buttonFlexBox}>
+        <Button onClick={onClose} variant="secondary" id="cancelButton">
+          Cancel
+        </Button>
+
+        <Button onClick={handleReset} variant="warning">
+          Proceed
+        </Button>
+      </div>
+    </ModalDialog>
+  );
+};
+
+ResetProjectModal.propTypes = {
+  mounted: PropTypes.bool,
+  onClose: PropTypes.func,
+  project: PropTypes.object,
+  resetProject: PropTypes.func
+};
+
+export default ResetProjectModal;

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
@@ -25,6 +25,7 @@ import { createUseStyles } from "react-jss";
 import { matchPath } from "react-router-dom";
 import CopyAndEditSnapshotModal from "../Modals/ActionCopyAndEditSnapshot";
 import * as projectService from "../../services/project.service";
+import WarningProjectReset from "../Modals/WarningProjectReset";
 
 const useStyles = createUseStyles({
   wizard: {
@@ -76,6 +77,8 @@ const TdmCalculationWizard = props => {
   const [ainInputError, setAINInputError] = useState("");
   const loginId = project.loginId;
   const [copyAndEditSnapshotModalOpen, setCopyAndEditSnapshotModalOpen] =
+    useState(false);
+  const [resetProjectWarningModalOpen, setResetProjectWarningModalOpen] =
     useState(false);
   const isSnapshotOwner = project?.loginId === account?.id;
 
@@ -298,7 +301,7 @@ const TdmCalculationWizard = props => {
             onPartialAINChange={onPartialAINChange}
             onAINInputError={handleAINInputError}
             uncheckAll={() => onUncheckAll(filters.projectDescriptionRules)}
-            resetProject={() => onResetProject()}
+            resetProject={() => setResetProjectWarningModalOpen(true)}
           />
         );
       case 2:
@@ -307,7 +310,7 @@ const TdmCalculationWizard = props => {
             rules={specificationRules}
             onInputChange={onInputChange}
             uncheckAll={() => onUncheckAll(filters.specificationRules)}
-            resetProject={() => onResetProject()}
+            resetProject={() => setResetProjectWarningModalOpen(true)}
           />
         );
       case 3:
@@ -318,7 +321,7 @@ const TdmCalculationWizard = props => {
             onInputChange={onInputChange}
             isLevel0={isLevel0}
             uncheckAll={onUncheckAll}
-            resetProject={onResetProject}
+            resetProject={() => setResetProjectWarningModalOpen(true)}
           />
         );
 
@@ -333,7 +336,7 @@ const TdmCalculationWizard = props => {
             initializeStrategies={initializeStrategies}
             onPkgSelect={onPkgSelect}
             uncheckAll={() => onUncheckAll(filters.strategyRules)}
-            resetProject={() => onResetProject()}
+            resetProject={() => setResetProjectWarningModalOpen(true)}
             allowResidentialPackage={allowResidentialPackage}
             allowSchoolPackage={allowSchoolPackage}
             residentialPackageSelected={residentialPackageSelected}
@@ -355,6 +358,7 @@ const TdmCalculationWizard = props => {
         return null;
     }
   };
+
   return (
     <div className={classes.wizard}>
       <InapplicableStrategiesModal
@@ -396,6 +400,12 @@ const TdmCalculationWizard = props => {
         isSnapshotOwner={isSnapshotOwner}
         copyAndEditSnapshot={copyAndEditSnapshot}
         projectName={project.name}
+      />
+      <WarningProjectReset
+        mounted={resetProjectWarningModalOpen}
+        project={project}
+        resetProject={() => onResetProject()}
+        onClose={() => setResetProjectWarningModalOpen(false)}
       />
     </div>
   );


### PR DESCRIPTION
- Fixes #1942 

### What changes did you make?
- Added a warning modal when user clicks on reset project while in wizard

### Why did you make the changes (we will use this info to test)?
- feature requested so that users don't accidentally miss-click and lose their entire project.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)


<details>
<summary>Visuals before changes are applied</summary>

 - nothing visual happens, it just instantly resets the project

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1039" alt="Screenshot 2025-03-18 at 11 17 57 PM" src="https://github.com/user-attachments/assets/2802288b-ef68-49c1-b366-42c1ef6f990e" />
<img width="1025" alt="Screenshot 2025-03-18 at 11 17 53 PM" src="https://github.com/user-attachments/assets/59d256ea-b319-48e4-9b9c-15ca2e4aa9c4" />


</details>
