### PR TITLE
Fixed: Security Roles table header does not stick to the top of the viewport

### DIFF
--- a/client/src/components/Layout/ContentContainer.jsx
+++ b/client/src/components/Layout/ContentContainer.jsx
@@ -11,7 +11,7 @@ const useStyles = createUseStyles({
   },
   content: {
     boxSizing: "border-box",
-    overflow: "auto",
+    // overflow: "auto",
     flexBasis: "auto",
     flexGrow: "1",
     flexShrink: "1",

--- a/client/src/components/Roles.jsx
+++ b/client/src/components/Roles.jsx
@@ -52,6 +52,8 @@ const useStyles = createUseStyles({
     fontWeight: "bold",
     backgroundColor: "#0f2940",
     color: "white",
+    position: "sticky",
+    top: "0",
     "& td": {
       padding: ".4em"
     }
@@ -190,7 +192,7 @@ const Roles = ({ contentContainerRef }) => {
   return (
     <ContentContainer
       contentContainerRef={contentContainerRef}
-      // className={classes.main}
+      customStyle={{ overflow: "none" }}
     >
       {redirectPath ? <Navigate to="{redirectPath}" /> : null}
       <h1 className={classes.pageTitle}>Security Roles</h1>

--- a/client/src/components/Roles.jsx
+++ b/client/src/components/Roles.jsx
@@ -190,10 +190,7 @@ const Roles = ({ contentContainerRef }) => {
   };
 
   return (
-    <ContentContainer
-      contentContainerRef={contentContainerRef}
-      customStyle={{ overflow: "none" }}
-    >
+    <ContentContainer contentContainerRef={contentContainerRef}>
       {redirectPath ? <Navigate to="{redirectPath}" /> : null}
       <h1 className={classes.pageTitle}>Security Roles</h1>
       <div className={classes.pageSubtitle}>


### PR DESCRIPTION
- Fixed #2053

### What changes did you make?

- Added sticky to header of roles table. Visible only in security admin role login > Security page

### Why did you make the changes (we will use this info to test)?

- Bug fix request so users can see what information of roles if a long list is presented

### Issue-Specific User Account
Must use: Security Admin
Can see credentials on 1pass

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

https://github.com/hackforla/tdm-calculator/issues/2053

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
[![image](Paste_Your_Image_Link_Here_After_Attaching_Files)](https://github.com/user-attachments/assets/cd5dc922-bf15-4d83-8495-19b9b8b19d15)

</details>
