### PR TITLE
When clearing page 4, also clear user-defined strategy comment

### DIFF
--- a/client/src/components/ProjectWizard/RuleCalculation/RuleCalculation.jsx
+++ b/client/src/components/ProjectWizard/RuleCalculation/RuleCalculation.jsx
@@ -348,7 +348,7 @@ const RuleCalculation = ({
                 <Popup
                   trigger={
                     <span style={{ cursor: "pointer" }}>
-                      <ToolTipIcon id={id} />
+                      <ToolTipIcon id={id.toString()} />
                     </span>
                   }
                   position="left center"

--- a/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
@@ -435,7 +435,7 @@ export function TdmCalculationContainer({ contentContainerRef }) {
         // In addition to the rule value, also clear
         // the associated comment, if any
         if (updateInputs[rules[i].code + "_comment"]) {
-          updateInputs[rules[i].code + "_comment"] = null;
+          delete updateInputs[rules[i].code + "_comment"];
         }
       }
     }

--- a/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
@@ -432,6 +432,11 @@ export function TdmCalculationContainer({ contentContainerRef }) {
         if (updateInputs[rules[i].code]) {
           updateInputs[rules[i].code] = null;
         }
+        // In addition to the rule value, also clear
+        // the associated comment, if any
+        if (updateInputs[rules[i].code + "_comment"]) {
+          updateInputs[rules[i].code + "_comment"] = null;
+        }
       }
     }
     if (filterRules === filters.projectDescriptionRules) {

--- a/client/src/components/ProjectWizard/WizardPages/Level0Page.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/Level0Page.jsx
@@ -75,7 +75,6 @@ const Level0Page = ({ isLevel0, resetProject }) => {
 
 Level0Page.propTypes = {
   isLevel0: PropTypes.bool.isRequired,
-  uncheckAll: PropTypes.func.isRequired,
   resetProject: PropTypes.func.isRequired
 };
 


### PR DESCRIPTION
- Fixes #2130

### What changes did you make?

- When user clears page 4, it also clears the description of the User-Defined strategy

### Why did you make the changes (we will use this info to test)?

- It was not being cleared.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

https://github.com/user-attachments/assets/50b96e3d-e20e-4c1d-ba66-a49661b46822

</details>

<details>
<summary>Visuals after changes are applied</summary>
  

https://github.com/user-attachments/assets/b2da01d1-b7b1-4f6c-ac88-1e159ce72711



</details>
