### PR TITLE
Change status column sort labelling

### DIFF
--- a/client/src/components/Projects/ColumnHeaderPopups/StatusPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/StatusPopup.jsx
@@ -23,8 +23,6 @@ const StatusPopup = ({
   const [typeSetting, setTypeSetting] = useState(criteria.type);
   const [showDeleted, setShowDeleted] = useState(criteria.status === "all");
 
-  // TODO More state variables for status filtering go here
-
   const setDefault = () => {
     setTypeSetting("all");
     setShowDeleted(false);
@@ -45,7 +43,8 @@ const StatusPopup = ({
       type: typeSetting
     });
     if (newOrder) {
-      setSort(header.id, newOrder);
+      setSort("dateSnapshotted", newOrder, true);
+      // setSort("dateTrashed", newOrder);
     }
     setCheckedProjectIds([]);
     setSelectAllChecked(false);
@@ -70,13 +69,13 @@ const StatusPopup = ({
       <div style={{ display: "flex", flexDirection: "column" }}>
         {/* If there is a dateSnapshotted (i.e., project is snapshot), property value is 1 */}
         <RadioButton
-          label="Sort Drafts First"
+          label="Sort A-Z"
           value="asc"
           checked={newOrder == "asc"}
           onChange={() => setNewOrder("asc")}
         />
         <RadioButton
-          label="Sort Snapshots First"
+          label="Sort Z-A"
           value="desc"
           checked={newOrder === "desc"}
           onChange={() => setNewOrder("desc")}

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -604,15 +604,24 @@ const ProjectsPage = ({ contentContainerRef }) => {
       : (a, b) => -ascCompareBy(a, b, orderBy);
   };
 
-  const setSort = (orderBy, order) => {
+  const setSort = (orderBy, order, isStatus = false) => {
     // If already sorted by the orderBy field, remove that entry from the
     // sort array first
-    let newSortCriteria = sortCriteria.filter(c => c.field !== orderBy);
-    // Add new sort criteria and direction to the sortCriteria and
+    let newSortCriteria = [];
+    if (isStatus) {
+      newSortCriteria = sortCriteria.filter(
+        c => c.field != "dateSnapshotted" && c.field != "dateTrashed"
+      );
+      newSortCriteria.push({ field: "dateTrashed", direction: order });
+      newSortCriteria.push({ field: "dateSnapshotted", direction: order });
+    } else {
+      newSortCriteria = sortCriteria.filter(c => c.field != orderBy);
+      newSortCriteria.push({ field: orderBy, direction: order });
+    }
+
     // save to local storagr
-    newSortCriteria.push({ field: orderBy, direction: order });
-    // and update the sortCriteria state.
     setSessionSortCriteria(newSortCriteria);
+    // and update the sortCriteria state.
     setSortCriteria(newSortCriteria);
   };
 
@@ -770,27 +779,6 @@ const ProjectsPage = ({ contentContainerRef }) => {
       return false;
     }
 
-    // if (userContext.account?.isAdmin) {
-    //   const projectAdminNotes = (p.adminNotes || "").toLowerCase().trim();
-    //   const criteriaAdminNotes = criteria.adminNotes.toLowerCase().trim();
-
-    //   if (
-    //     criteriaAdminNotes &&
-    //     !projectAdminNotes.includes(criteriaAdminNotes)
-    //   ) {
-    //     return false;
-    //   }
-
-    //   if (
-    //     criteria.adminNotesList.length > 0 &&
-    //     !criteria.adminNotesList
-    //       .map(n => n.toLowerCase())
-    //       .includes((p.adminNotes || "").toLowerCase())
-    //   ) {
-    //     return false;
-    //   }
-    // }
-
     if (
       criteria.startDateModifiedAdmin &&
       getDateOnly(p.dateModifiedAdmin) <
@@ -820,7 +808,6 @@ const ProjectsPage = ({ contentContainerRef }) => {
   const resetFiltersSort = () => {
     setFilter(DEFAULT_FILTER_CRITERIA);
     setSortCriteria(DEFAULT_SORT_CRITERIA);
-    setSort(DEFAULT_SORT_CRITERIA[0].field, DEFAULT_SORT_CRITERIA[0].direction);
     setCheckedProjectIds([]);
     setSelectAllChecked(false);
   };
@@ -1157,7 +1144,6 @@ const ProjectsPage = ({ contentContainerRef }) => {
             </div>
           </div>
         </div>
-        ``
       </div>
     </ContentContainerNoSidebar>
   );


### PR DESCRIPTION
- Fixes #2007

### What changes did you make?

- Change the sorting choices for the Status column to "Sort A-Z" and "Sort Z-A", which will sort the possible column values of
"Draft", "Draft (deleted)", "Snapshot", "Snapshot (deleted)" in alphabetical or reverse alphabetical order, respectively.

### Why did you make the changes (we will use this info to test)?

- Because Bonnie wanted it to work this way

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
