### PR TITLE
2182 top-aligned data cell within project rows

### DIFF
--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -147,7 +147,7 @@ const useStyles = createUseStyles({
     },
     "& tr td": {
       padding: "12px",
-      verticalAlign: "middle"
+      verticalAlign: "top"
     },
     "& tr:hover": {
       background: "#B2C0D3"


### PR DESCRIPTION

- Fixes #2182

### What changes did you make?
- Change `verticalAlign: "middle"` to `verticalAlign: "top"` for the data cell in the table body  


### Why did you make the changes (we will use this info to test)?

- When a project row has more than one line of text within a column, elements in most columns become vertically center-aligned. For readability reasons, elements should instead be top-aligned.

<details>
<summary>Visuals before and after changes are applied</summary>

![image](https://github.com/user-attachments/assets/ca485924-b3ee-4b5c-bc6a-14bf3690b568)


</details>
