### PR TITLE
Allow users to view shapshots shared with them on My Projects Page

### DIFF
--- a/server/db/migration/V20250330.1839__allow_users_to_see_shared_snapshots_on_myprojects_2257.sql
+++ b/server/db/migration/V20250330.1839__allow_users_to_see_shared_snapshots_on_myprojects_2257.sql
@@ -1,0 +1,78 @@
+/****** Object:  StoredProcedure [dbo].[Project_SelectAll]    Script Date: 3/30/2025 6:17:48 PM ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE OR ALTER   PROC [dbo].[Project_SelectAll]
+   @loginId int = null
+AS
+BEGIN
+   IF EXISTS(SELECT 1 FROM Login WHERE id = @LoginId AND isAdmin = 1)
+   BEGIN
+      -- Admin can see all projects
+      SELECT
+         p.id
+			, p.name
+			, p.address
+			, p.formInputs
+			, p.targetPoints
+			, p.earnedPoints
+			, p.projectLevel
+			, p.loginId
+			, p.calculationId
+			, p.dateCreated
+			, p.dateModified
+			, p.description
+			, author.firstName
+			, author.lastName
+			, p.dateHidden
+			, p.dateTrashed
+			, p.dateSnapshotted
+			, p.dateSubmitted
+         , p.droId  -- New column
+         , p.adminNotes  -- New column
+         , p.dateModifiedAdmin  -- New column
+      FROM Project p
+      JOIN Login author ON p.loginId = author.id;
+   END
+   ELSE
+   BEGIN
+      -- User can only see their own projects or projects 
+	  -- explicitly shared with them
+      SELECT
+         p.id
+			, p.name
+			, p.address
+			, p.formInputs
+			, p.targetPoints
+			, p.earnedPoints
+			, p.projectLevel
+			, p.loginId
+			, p.calculationId
+			, p.dateCreated
+			, p.dateModified
+			, p.description
+			, author.firstName
+			, author.lastName
+			, p.dateHidden
+			, p.dateTrashed
+			, p.dateSnapshotted
+			, p.dateSubmitted
+         , p.droId  -- New column
+         , p.adminNotes  -- New column
+         , p.dateModifiedAdmin  -- New column
+      FROM Project p
+      JOIN Login author ON p.loginId = author.id
+      WHERE author.id = ISNULL(307, author.id) OR EXISTS
+	  (
+		SELECT 1 from ProjectShare ps 
+		JOIN Login viewer ON viewer.email = ps.email
+		WHERE p.id = ps.projectId AND viewer.id = 307
+	  )
+   END
+END;
+GO
+
+


### PR DESCRIPTION
- Fixes #2257

### What changes did you make?

- On My Projects page for non-admin users, include snapshots belonging to other users that are shared with them.

### Why did you make the changes (we will use this info to test)?

- Requested by Issue

### Issue-Specific User Account

Need to use any account that has had one or more snapshots shared with it (e.g., tdm-dev+user2@hackforla.org on the dev environment)

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/a5716d0c-e532-4c20-bcd3-c214610964b1)

</details>
