### PR TITLE
2181 Change colWidth to make the filter icon sizes consistent

### DIFF
--- a/client/src/components/Projects/ProjectTableRow.jsx
+++ b/client/src/components/Projects/ProjectTableRow.jsx
@@ -295,9 +295,7 @@ const ProjectTableRow = ({
       <td className={classes.td}>
         {`${project.lastName}, ${project.firstName}`}
       </td>
-      <td className={classes.tdRightAlign}>
-        {formatDate(project.dateCreated)}
-      </td>
+      <td className={classes.td}>{formatDate(project.dateCreated)}</td>
       <td className={classes.td}>
         <span>{formatDate(project.dateModified)}</span>
       </td>

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -104,12 +104,12 @@ const useStyles = createUseStyles({
   },
   tableAdmin: {
     minWidth: "135rem",
-    width: "135rem",
+    width: "100%",
     tableLayout: "fixed"
   },
   table: {
     minWidth: "110rem",
-    width: "110rem",
+    width: "100%",
     tableLayout: "fixed"
   },
   tr: {
@@ -831,7 +831,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
       id: "dateHidden",
       label: "Visibility",
       popupType: "visibility",
-      colWidth: "7rem"
+      colWidth: "8rem"
     },
     {
       id: "dateSnapshotted",
@@ -854,7 +854,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
       popupType: "datetime",
       startDatePropertyName: "startDateCreated",
       endDatePropertyName: "endDateCreated",
-      colWidth: "8rem"
+      colWidth: "10rem"
     },
     {
       id: "dateModified",
@@ -862,7 +862,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
       popupType: "datetime",
       startDatePropertyName: "startDateModified",
       endDatePropertyName: "endDateModified",
-      colWidth: "8rem"
+      colWidth: "10rem"
     },
     {
       id: "dateSubmitted",
@@ -891,9 +891,9 @@ const ProjectsPage = ({ contentContainerRef }) => {
           },
           {
             id: "dateModifiedAdmin",
-            label: "Date Admin Saved",
+            label: "Admin Saved",
             popupType: "datetime",
-            colWidth: "15rem"
+            colWidth: "10rem"
           }
         ]
       : []),
@@ -917,7 +917,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
     indexOfLastPost
   );
 
-  document.body.style.overflowX = "hidden"; // prevent page level scrolling, becauase the table is scrollable
+  document.body.style.overflowX = "hidden"; // prevent page level scrolling, because the table is scrollable
 
   return (
     <ContentContainerNoSidebar contentContainerRef={contentContainerRef}>


### PR DESCRIPTION
- Fixes #2181

### What changes did you make?
- Remove "Date" in "Date Admin Saved" as suggested by UX
- Change the `colWidth` of "Visibility", "Created On", "Last Saved", and "Admin Saved"
- Change the content of "Created On" data cell to left aligned as in Figma 
- Change `width: "135rem"` to `width: "100%"` for the tableAdmin and table to make the column widths expand to fill the entire available horizontal space

### Why did you make the changes (we will use this info to test)?
- To make the filter icon sizes consistent 

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>


</details>

<details>
<summary>Visuals after changes are applied</summary>

![image](https://github.com/user-attachments/assets/e8416cc6-ec95-488d-be57-f931704eff34)
![image](https://github.com/user-attachments/assets/0557246d-ac89-4cf9-9a75-e77b43b2f6fb)

</details>
