### PR TITLE
Snapshot should not allow navigating off p5

### DIFF
--- a/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
@@ -82,10 +82,6 @@ export function TdmCalculationContainer({ contentContainerRef }) {
         if (locationPath[1] == "projects") {
           try {
             projectResponse = await projectService.getByIdWithEmail(projectId);
-
-            // if (projectResponse) {
-            //   setShareView(true);
-            // }
           } catch (err) {
             if (err.response.status == 404) {
               navigate(`/login?url=${locationPath[1]}/${locationPath[2]}`);
@@ -96,7 +92,6 @@ export function TdmCalculationContainer({ contentContainerRef }) {
           }
         } else {
           projectResponse = await projectService.getById(projectId);
-          // setShareView(false);
         }
         if (projectResponse) {
           setProject(projectResponse.data);
@@ -114,12 +109,6 @@ export function TdmCalculationContainer({ contentContainerRef }) {
     } catch (err) {
       console.error(JSON.stringify(err, null, 2));
       throw new Error(JSON.stringify(err, null, 2));
-      // const errMessage = account.id
-      //   ? "The project you are trying to view can only be viewed by the user."
-      //   : "You must be logged in to view project.";
-      // toast.add(errMessage);
-      // const redirect = account.id ? "/projects" : "/login";
-      // navigate(redirect);
     }
   }, [engine, projectId, account, setRules, setProject]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
@@ -41,6 +41,7 @@ export function TdmCalculationContainer({ contentContainerRef }) {
   const location = useLocation();
   const userContext = useContext(UserContext);
   const account = userContext ? userContext.account : null;
+  const isAdmin = !!account?.isAdmin;
   const [engine, setEngine] = useState(null);
   const [formInputs, setFormInputs] = useState({});
   const [partialAIN, setPartialAIN] = useState("");
@@ -82,9 +83,9 @@ export function TdmCalculationContainer({ contentContainerRef }) {
           try {
             projectResponse = await projectService.getByIdWithEmail(projectId);
 
-            if (projectResponse) {
-              setShareView(true);
-            }
+            // if (projectResponse) {
+            //   setShareView(true);
+            // }
           } catch (err) {
             if (err.response.status == 404) {
               navigate(`/login?url=${locationPath[1]}/${locationPath[2]}`);
@@ -95,10 +96,11 @@ export function TdmCalculationContainer({ contentContainerRef }) {
           }
         } else {
           projectResponse = await projectService.getById(projectId);
-          setShareView(false);
+          // setShareView(false);
         }
         if (projectResponse) {
           setProject(projectResponse.data);
+          setShareView(projectResponse.data.loginId !== account.id && !isAdmin);
           inputs = JSON.parse(projectResponse.data.formInputs);
           setStrategiesInitialized(true);
         }

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
@@ -68,9 +68,11 @@ const TdmCalculationWizard = props => {
   const toast = useToast();
   const userContext = useContext(UserContext);
   const account = userContext ? userContext.account : null;
+  // const isAdmin = !!account?.isAdmin;
   const params = useParams();
   const navigate = useNavigate();
-  const page = Number(shareView ? 5 : params.page || 1);
+  const page = Number(params.page || 1);
+  // const page = Number(shareView || !isAdmin ? 5 : params.page || 1);
   const projectId = Number(params.projectId);
   const { pathname } = useLocation();
   const [ainInputError, setAINInputError] = useState("");
@@ -238,9 +240,10 @@ const TdmCalculationWizard = props => {
   };
 
   const setDisplaySaveButton = () => {
-    const loggedIn = !!account && !!account.id;
-    const setDisplayed = loggedIn;
-    return !shareView && setDisplayed;
+    return true;
+    // const loggedIn = !!account && !!account.id;
+    // const setDisplayed = loggedIn;
+    // return !shareView && setDisplayed;
   };
 
   const isFinalPage = page === 5;
@@ -276,7 +279,6 @@ const TdmCalculationWizard = props => {
     const projectIdParam = projectId ? `/${projectId}` : "/0";
     if (Number(pageNo) > Number(page)) {
       if (handleValidate()) {
-        // Skip page 4 unless Packages are applicable
         const nextPage = Number(page) + 1;
         navigate(`/calculation/${nextPage}${projectIdParam}`);
       }

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
@@ -68,11 +68,9 @@ const TdmCalculationWizard = props => {
   const toast = useToast();
   const userContext = useContext(UserContext);
   const account = userContext ? userContext.account : null;
-  // const isAdmin = !!account?.isAdmin;
   const params = useParams();
   const navigate = useNavigate();
   const page = Number(params.page || 1);
-  // const page = Number(shareView || !isAdmin ? 5 : params.page || 1);
   const projectId = Number(params.projectId);
   const { pathname } = useLocation();
   const [ainInputError, setAINInputError] = useState("");
@@ -240,10 +238,8 @@ const TdmCalculationWizard = props => {
   };
 
   const setDisplaySaveButton = () => {
-    return true;
-    // const loggedIn = !!account && !!account.id;
-    // const setDisplayed = loggedIn;
-    // return !shareView && setDisplayed;
+    const loggedIn = !!account && !!account.id;
+    return loggedIn;
   };
 
   const isFinalPage = page === 5;

--- a/client/src/components/ProjectWizard/WizardFooter.jsx
+++ b/client/src/components/ProjectWizard/WizardFooter.jsx
@@ -154,8 +154,8 @@ const WizardFooter = ({
             {!formattedDateSnapshotted
               ? "Draft"
               : project.loginId === loggedInUserId
-              ? "Snapshot"
-              : "Shared Snapshot"}
+                ? "Snapshot"
+                : "Shared Snapshot"}
           </div>
           {formattedDateSubmitted ? (
             <div>

--- a/client/src/components/ProjectWizard/WizardFooter.jsx
+++ b/client/src/components/ProjectWizard/WizardFooter.jsx
@@ -13,7 +13,7 @@ const useStyles = createUseStyles({
   allButtonsWrapper: {
     display: "flex",
     alignItems: "center",
-    margin: "3em 0",
+    margin: "1.5em 0",
     width: "80%",
     justifyContent: "center"
   },
@@ -22,12 +22,6 @@ const useStyles = createUseStyles({
     margin: "auto",
     fontWeight: "bold",
     padding: "0px 12px"
-  },
-  lastSaved: {
-    color: "#6F6C64"
-  },
-  lastSavedContainer: {
-    margin: "0 auto"
   },
   datesStatus: {
     width: "90%",
@@ -64,6 +58,7 @@ const WizardFooter = ({
   const formattedDateModified = formatDatetime(project.dateModified);
   const userContext = useContext(UserContext);
   const loggedInUserId = userContext.account?.id;
+  const isAdmin = !!userContext.account?.isAdmin;
 
   return (
     <>
@@ -75,15 +70,26 @@ const WizardFooter = ({
                 id="leftNavArrow"
                 navDirection="previous"
                 color="colorPrimary"
-                isVisible={page !== 1}
-                isDisabled={shareView || Number(page) === 1}
+                isVisible={
+                  page !== 1 &&
+                  !project.dateSnapshotted &&
+                  (!shareView || isAdmin)
+                }
+                isDisabled={
+                  (shareView && !isAdmin) ||
+                  project.dateSnapshotted ||
+                  Number(page) === 1
+                }
                 onClick={() => {
                   onPageChange(Number(page) - 1);
                 }}
               />
-              <div className={classes.pageNumberCounter}>
-                Page {pageNumber}/5
-              </div>
+              {(!shareView || isAdmin) && !project.dateSnapshotted ? (
+                <div className={classes.pageNumberCounter}>
+                  Page {pageNumber}/5
+                </div>
+              ) : null}
+              {/* Page {pageNumber}/5 */}
               <NavButton
                 id="rightNavArrow"
                 navDirection="next"
@@ -148,8 +154,8 @@ const WizardFooter = ({
             {!formattedDateSnapshotted
               ? "Draft"
               : project.loginId === loggedInUserId
-                ? "Snapshot"
-                : "Shared Snapshot"}
+              ? "Snapshot"
+              : "Shared Snapshot"}
           </div>
           {formattedDateSubmitted ? (
             <div>

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectSummary.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectSummary.jsx
@@ -52,12 +52,6 @@ const useStyles = createUseStyles({
     display: "flex",
     justifyContent: "center"
   },
-  lastSaved: {
-    color: "#6F6C64"
-  },
-  lastSavedContainer: {
-    margin: "24px auto 0"
-  },
   categoryContainer: {
     marginTop: "25px"
   },
@@ -105,7 +99,6 @@ const useStyles = createUseStyles({
   },
   tempTextContainer: {
     width: "100%",
-    height: "50px",
     display: "flex",
     justifyContent: "center",
     marginTop: "4px",

--- a/server/db/migration/V20250331.2105__fix_to_2257.sql
+++ b/server/db/migration/V20250331.2105__fix_to_2257.sql
@@ -1,0 +1,144 @@
+CREATE  OR ALTER   PROC [dbo].[Project_SelectAll]
+   @loginId int = null
+AS
+BEGIN
+   IF EXISTS(SELECT 1 FROM Login WHERE id = @LoginId AND isAdmin = 1)
+   BEGIN
+      -- Admin can see all projects
+      SELECT
+         p.id
+			, p.name
+			, p.address
+			, p.formInputs
+			, p.targetPoints
+			, p.earnedPoints
+			, p.projectLevel
+			, p.loginId
+			, p.calculationId
+			, p.dateCreated
+			, p.dateModified
+			, p.description
+			, author.firstName
+			, author.lastName
+			, p.dateHidden
+			, p.dateTrashed
+			, p.dateSnapshotted
+			, p.dateSubmitted
+         , p.droId  -- New column
+         , p.adminNotes  -- New column
+         , p.dateModifiedAdmin  -- New column
+      FROM Project p
+      JOIN Login author ON p.loginId = author.id;
+   END
+   ELSE
+   BEGIN
+      -- User can only see their own projects or projects 
+	  -- explicitly shared with them
+      SELECT
+         p.id
+			, p.name
+			, p.address
+			, p.formInputs
+			, p.targetPoints
+			, p.earnedPoints
+			, p.projectLevel
+			, p.loginId
+			, p.calculationId
+			, p.dateCreated
+			, p.dateModified
+			, p.description
+			, author.firstName
+			, author.lastName
+			, p.dateHidden
+			, p.dateTrashed
+			, p.dateSnapshotted
+			, p.dateSubmitted
+         , p.droId  -- New column
+         , p.adminNotes  -- New column
+         , p.dateModifiedAdmin  -- New column
+      FROM Project p
+      JOIN Login author ON p.loginId = author.id
+      WHERE author.id = ISNULL(@loginId, author.id) OR EXISTS
+	  (
+		SELECT 1 from ProjectShare ps 
+		JOIN Login viewer ON viewer.email = ps.email
+		WHERE p.id = ps.projectId AND viewer.id = @loginId
+	  )
+   END
+END;
+GO
+
+CREATE  OR ALTER   PROC [dbo].[Project_SelectById]
+   @loginId int = null,
+   @id int
+AS
+BEGIN
+
+   IF EXISTS(SELECT 1 FROM Login WHERE id = @LoginId AND isAdmin = 1)
+   BEGIN
+      SELECT
+         p.id,
+         p.name,
+         p.address,
+         p.formInputs,
+		 p.targetPoints,
+		 p.earnedPoints,
+		 p.projectLevel,
+         p.loginId,
+         p.calculationId,
+         p.dateCreated,
+         p.dateModified,
+         p.description,
+         l.firstName,
+         l.lastName,
+         p.droId,               -- New column
+         p.adminNotes,           -- New column
+         p.dateModifiedAdmin,    -- New column
+         p.dateHidden,
+         p.dateTrashed,
+         p.dateSnapshotted,
+         p.dateSubmitted
+      FROM Project p
+      JOIN Login l ON p.loginId = l.id
+      WHERE p.id = @id;
+   END
+   ELSE
+   BEGIN
+      SELECT
+         p.id,
+         p.name,
+         p.address,
+         p.formInputs,
+		 p.targetPoints,
+		 p.earnedPoints,
+		 p.projectLevel,
+         p.loginId,
+         p.calculationId,
+         p.dateCreated,
+         p.dateModified,
+         p.description,
+         author.firstName,
+         author.lastName,
+         p.droId,               -- New column
+         p.adminNotes,           -- New column
+         p.dateModifiedAdmin,    -- New column
+         p.dateHidden,
+         p.dateTrashed,
+         p.dateSnapshotted,
+         p.dateSubmitted
+      FROM Project p
+	  JOIN Login author ON p.loginId = author.id
+      WHERE p.id = @id and (author.id = ISNULL(@loginId, author.id) OR EXISTS
+	  (
+		SELECT 1 from ProjectShare ps 
+		JOIN Login viewer ON viewer.email = ps.email
+		WHERE p.id = ps.projectId AND viewer.id = @loginId
+	  ))
+   END
+END;
+GO
+
+
+
+
+


### PR DESCRIPTION
- Fixes #2314

### What changes did you make?

- Fixed bug where a user (admin or not) viewing a snaphot in the Wizard could navigate away from page 5 and start editing the calclulation.

### Why did you make the changes (we will use this info to test)?

- See issue

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

See Issue

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
