### PR TITLE
fix npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "release-notes": "gren release --override",
     "start": "concurrently --names \"BACKEND,FRONTEND\" -c \"bgBlue.bold,bgMagenta.bold\" \"npm run start:backend\" \"npm run start:frontend\" ",
     "start:backend": "cd ./server && npm start",
-    "start:frontend": "wait-on http://localhost:5001/api/rules && cd ./client && npm start",
+    "start:frontend": "wait-on http://localhost:5001/api/calculations && cd ./client && npm start",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
- Fixes #2288 

### What changes did you make?

- On the start:frontend script, replace `http://localhost:5001/api/rules` with `https://localhost:5001/api/calculations`

### Why did you make the changes (we will use this info to test)?

- We need to fix a bad endpoint on the start script so that developers can start both client and server from the root directory.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Before - the client never starts because there is no route for the `/api/rules` endpoint</summary>

![image](https://github.com/user-attachments/assets/22885dc6-17e5-443c-b1cc-610d66d9bf6b)

</details>

<details>
<summary>After - the client starts</summary>
  
![image](https://github.com/user-attachments/assets/a7d60b0c-13c2-463f-87d7-5c79c67407d4)

</details>
