### PR TITLE
Allow non-owner of project to hide

### DIFF
--- a/client/src/hooks/useCheckedProjectsStatusData.js
+++ b/client/src/hooks/useCheckedProjectsStatusData.js
@@ -51,7 +51,7 @@ const useCheckedProjectsStatusData = (checkedProjects, projects) => {
           p => typeof p[property] === "string"
         );
 
-        return allNull || allString ? true : false;
+        return allNull || allString ? firstVal : false;
       } else {
         return getProjects.every(p => p[property] === firstVal) ? firstVal : "";
       }

--- a/server/db/migration/V20250404.1628__fix_to_2163.sql
+++ b/server/db/migration/V20250404.1628__fix_to_2163.sql
@@ -1,0 +1,24 @@
+CREATE OR ALTER  PROC [dbo].[Project_Hide]
+	@ids AS IdList READONLY
+	, @hide bit
+	, @loginId int
+AS
+BEGIN
+
+  DELETE FROM ProjectHidden
+  WHERE loginId = @loginId AND projectId in (SELECT id from @ids)
+
+  IF @hide = 1
+  BEGIN
+    INSERT INTO ProjectHidden
+    SELECT 
+      @loginId as loginId, 
+      i.id as projectId, 
+      getutcdate() as dateHidden 
+    FROM @ids i 
+  END
+
+END
+GO
+
+


### PR DESCRIPTION
- Fixes #2163
### What changes did you make?

- Modified Project_Hide stored procedure to allow changing dateHidden for projects that dont belong to the user.

### Why did you make the changes (we will use this info to test)?
- To complete issue #2163


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
