### PR TITLE
1897 Add padding to dropdowns to match the style guide

### DIFF
--- a/client/src/components/UI/UniversalSelect.jsx
+++ b/client/src/components/UI/UniversalSelect.jsx
@@ -71,7 +71,7 @@ export default function UniversalSelect({
         option: (provided, state) => ({
           ...provided,
           fontSize: "15px", // Set your desired font size for options
-          padding: "2px", // Set padding to 0 for options
+          padding: "8px", // Set padding to 8 for options
           backgroundColor: state.isSelected
             ? "#1967D2ff"
             : state.isFocused
@@ -87,7 +87,7 @@ export default function UniversalSelect({
         }),
         menu: provided => ({
           ...provided,
-          padding: "0", // Set padding of the dropdown menu to 0
+          padding: "8px", // Set padding of the dropdown menu to 8
           border: "1px solid black",
           boxShadow: "none",
           marginTop: "1px",

--- a/client/src/components/UI/UniversalSelect.jsx
+++ b/client/src/components/UI/UniversalSelect.jsx
@@ -87,7 +87,7 @@ export default function UniversalSelect({
         }),
         menu: provided => ({
           ...provided,
-          padding: "8px", // Set padding of the dropdown menu to 8
+          padding: "0", // Set padding of the dropdown menu to 0
           border: "1px solid black",
           boxShadow: "none",
           marginTop: "1px",


### PR DESCRIPTION
- Fixes #1897 

### What changes did you make?

- Added 8px padding to dropdown field and options on these pages: 
[Projects page](http://192.168.1.145:3000/projects )  and [Page 4](http://192.168.1.145:3000/calculation/4/0).  

### Why did you make the changes (we will use this info to test)?

- To improve the readibility of dropdown options and reduce visual clutter.


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Page4Before](https://github.com/user-attachments/assets/2c2a0e4c-4951-49a0-93c2-4533cca86abf)
![itemsPerPageBefore](https://github.com/user-attachments/assets/be920a1d-6518-4e04-8292-f966af03c295)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Page4After](https://github.com/user-attachments/assets/14c86ed6-beda-4fa7-9a1f-457c6823ccf9)
![itemsPerPageAfter](https://github.com/user-attachments/assets/190f8c61-a7f1-48ce-a0b0-e3b9f242220d)


</details>
