### PR TITLE
fix: ping designers if role includes front-end

### DIFF
--- a/.github/scripts/find-label-in-gh-issue.cjs
+++ b/.github/scripts/find-label-in-gh-issue.cjs
@@ -13,7 +13,7 @@ module.exports = async ({ github, context, issueNumber }) => {
     const hasUILabel = issue.data.labels.some(label => 
       label.name.toLowerCase().includes('ui') || 
       label.name.toLowerCase().includes('design') ||
-      label.name.toLowerCase().includes('frontend') 
+      label.name.toLowerCase().includes('front-end') 
     );
     
     if (!hasUILabel) {


### PR DESCRIPTION
- Fixes #2342 

### What changes did you make?

- this changes the way the shell reads the PR to not confuse variables enclosed in backticks with shell execution commands.
- it now creates an ephemeral txt file that it will read instead of reading the PR directly which will get cleaned up when the worker spins down.
- this new script change also makes it case insensitive when looking for the phrases before the issue number at the top of the PR.
- BELOW IS JUST A TEST OF A PR THAT FAILED BEFORE, PLEASE IGNORE THE CONTENT. IT IS FOR TESTING PURPOSES ONLY


### What changes did you make?
- Remove "Date" in "Date Admin Saved" as suggested by UX
- Change the `colWidth` of "Visibility", "Created On", "Last Saved", and "Admin Saved"
- Change the content of "Created On" data cell to left aligned as in Figma 
- Change `width: "135rem"` to `width: "100%"` for the tableAdmin and table to make the column widths expand to fill the entire available horizontal space

### Why did you make the changes (we will use this info to test)?
- To make the filter icon sizes consistent 

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>


</details>

<details>
<summary>Visuals after changes are applied</summary>

![image](https://github.com/user-attachments/assets/e8416cc6-ec95-488d-be57-f931704eff34)
![image](https://github.com/user-attachments/assets/0557246d-ac89-4cf9-9a75-e77b43b2f6fb)

</details>

