### PR TITLE
Add docker database container

### DIFF
--- a/server/db/docker-compose.yml
+++ b/server/db/docker-compose.yml
@@ -1,7 +1,8 @@
-version: "3.2"
 services:
   db:
-    image: "mcr.microsoft.com/mssql/server:2017-latest"
+    image: "mcr.microsoft.com/mssql/server:2019-latest"
+    volumes:
+      - sqlvolume:/var/opt/mssql
     ports:
       # exposed on localhost 1434
       - "1434:1433"
@@ -9,4 +10,6 @@ services:
       ACCEPT_EULA: Y
       SA_PASSWORD: Dogfood1!
       MSSQL_PID: Express
-    command: ls
+
+volumes:
+  sqlvolume:


### PR DESCRIPTION
- Fixes #765

### What changes did you make?

- Updated docker-compose service for local database
  - Updated database version
  - Moved data storage into a docker volume

### Why did you make the changes (we will use this info to test)?

- docker-compose allows a backend developer to start a local database more quickly without dealing with OS issues.
- Storing the data in a docker volume allows database image upgrades without destroying the data.

### Documentation

This needs to be added to or updated in the wiki. Should this be done before or after the PR?

How to use it

   ```
   # Start the database container
   # The data will be stored in a docker volume separate from the db container
   cd server/db
   docker-compose up

   # create the database
   docker-compose exec db /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P Dogfood1! -Q "CREATE DATABASE tdmdev;"

   # apply the migration files
   npm run flyway:migrate

   # Stop the container and delete the data volume
   # Omit the -v to preserve the data
   docker-compose down db -v
   ```