### PR TITLE
2176 remove paddingBottom and left from useStyles.

### DIFF
--- a/client/src/components/ProjectWizard/WizardPages/DiscoverTooltips.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/DiscoverTooltips.jsx
@@ -6,9 +6,7 @@ const useStyles = createUseStyles(theme => ({
     width: "calc((100% / 14.5) * 3);",
     background: theme.colors.secondary.lightGray,
     padding: "1em",
-    paddingBottom: "1em",
     position: "absolute",
-    left: "23.5px",
     textAlign: "initial"
   },
   title: {
@@ -19,10 +17,10 @@ const useStyles = createUseStyles(theme => ({
     fontWeight: 700
   }
 }));
-
 const DiscoverTooltips = () => {
   const theme = useTheme();
   const classes = useStyles(theme);
+  console.debug("Window width: ", window.innerWidth);
   return (
     <div className={classes.container}>
       <p className={classes.title}>

--- a/client/src/components/ProjectWizard/WizardPages/DiscoverTooltips.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/DiscoverTooltips.jsx
@@ -20,7 +20,6 @@ const useStyles = createUseStyles(theme => ({
 const DiscoverTooltips = () => {
   const theme = useTheme();
   const classes = useStyles(theme);
-  console.debug("Window width: ", window.innerWidth);
   return (
     <div className={classes.container}>
       <p className={classes.title}>


### PR DESCRIPTION
- Fixes #2176 

### What changes did you make?

- Delete `paddingBottom: 1em` and `left: 22.5px` from useStyles in `DiscoverTooltips.jsx`

### Why did you make the changes (we will use this info to test)?

- The `paddingBottom` is unused because the `padding: 1em` already includes it. 
- Make Page 1/5 be fully visible. The smaller screen looks better after deleting the left position in CSS.

### Issue-Specific User Account

- You need to log in with TDM user account. 
- Decrease the browser's viewport width to 900px.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![picturebefore](https://github.com/user-attachments/assets/28f09301-938c-4af9-b791-3bc18f5ac88b)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![pictureafter](https://github.com/user-attachments/assets/0007bc0c-d991-4f70-8cd0-9fbef8afc90c)

</details>
