### PR TITLE
2315 Fix project filters persisting across logins

### DIFF
--- a/client/src/components/Authorization/Logout.jsx
+++ b/client/src/components/Authorization/Logout.jsx
@@ -1,11 +1,20 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import * as accountService from "../../services/account.service";
+import {
+  SORT_CRITERIA_STORAGE_TAG,
+  FILTER_CRITERIA_STORAGE_TAG
+} from "../../helpers/Constants";
 
 const Logout = () => {
   const navigate = useNavigate();
   const handleLogout = async () => {
     await accountService.logout();
+
+    // Reset filters/sort from "/projects" page
+    sessionStorage.removeItem(SORT_CRITERIA_STORAGE_TAG);
+    sessionStorage.removeItem(FILTER_CRITERIA_STORAGE_TAG);
+
     // Redirect to the "/login" page after the logout
     navigate("/login");
   };

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -27,9 +27,11 @@ import UniversalSelect from "../UI/UniversalSelect";
 import ProjectTableColumnHeader from "./ColumnHeaderPopups/ProjectTableColumnHeader";
 import Button from "../Button/Button";
 import useSessionStorage from "../../hooks/useSessionStorage";
+import {
+  SORT_CRITERIA_STORAGE_TAG,
+  FILTER_CRITERIA_STORAGE_TAG
+} from "../../helpers/Constants";
 
-const SORT_CRITERIA_STORAGE_TAG = "myProjectsSortCriteria";
-const FILTER_CRITERIA_STORAGE_TAG = "myProjectsFilterCriteria";
 const DEFAULT_SORT_CRITERIA = [{ field: "dateModified", direction: "desc" }];
 const DEFAULT_FILTER_CRITERIA = {
   filterText: "",

--- a/client/src/helpers/Constants.js
+++ b/client/src/helpers/Constants.js
@@ -1,1 +1,10 @@
-export const ENABLE_UPDATE_TOTALS = false;
+const ENABLE_UPDATE_TOTALS = false;
+
+const SORT_CRITERIA_STORAGE_TAG = "myProjectsSortCriteria";
+const FILTER_CRITERIA_STORAGE_TAG = "myProjectsFilterCriteria";
+
+export {
+  ENABLE_UPDATE_TOTALS,
+  SORT_CRITERIA_STORAGE_TAG,
+  FILTER_CRITERIA_STORAGE_TAG
+};


### PR DESCRIPTION
- Fixes #2315 

### What changes did you make?

- moved sessionStorage keys for sort/filter settings from ProjectsPage component to helpers/Constants
- remove items from sessionStorage upon logout

### Why did you make the changes (we will use this info to test)?

- Filters should not persist across multiple logins from different users