### PR TITLE
Fix sass @import deprecation warings

### DIFF
--- a/client/src/styles/App.scss
+++ b/client/src/styles/App.scss
@@ -1,11 +1,12 @@
+@use "sass:meta";
+@use "_variables.scss";
 @import url("https://fonts.googleapis.com/css?family=Montserrat:900&display=swap");
-@import "./reset.scss";
-@import "_variables.scss";
+@include meta.load-css("reset.scss");
 // import scss files below
 
 body {
-  background: $color-background;
-  font-family: $font;
+  background: variables.$color-background;
+  font-family: variables.$font;
   -webkit-text-size-adjust: 100%;
   color: #474747;
   overflow-y: scroll;
@@ -94,7 +95,7 @@ abbr {
 }
 
 button {
-  font-family: $font;
+  font-family: variables.$font;
   font-weight: bold;
   font-size: 16px;
 }
@@ -102,7 +103,7 @@ button {
 input,
 select,
 textarea {
-  font-family: $font;
+  font-family: variables.$font;
   font-size: 16px;
   margin: 0 1px 0;
 }
@@ -148,8 +149,8 @@ input[type="checkbox"] {
 // default styles for  links, buttons, etc here?
 // import individual scss files below
 #root {
-  color: $color-primary;
-  background-color: $color-background;
+  color: variables.$color-primary;
+  background-color: variables.$color-background;
 }
 
 #ladot-logo {
@@ -219,4 +220,4 @@ button.link {
 }
 
 // add any override to the default styles in the individual component styles
-@import "./AuthForms.scss"; // Login and Register components
+@include meta.load-css("AuthForms.scss"); // Login and Register components

--- a/client/src/styles/AuthForms.scss
+++ b/client/src/styles/AuthForms.scss
@@ -1,4 +1,4 @@
-@import "./_partials.scss";
+@use "_partials.scss";
 
 .auth-form {
   width: 500px;

--- a/client/src/styles/_partials.scss
+++ b/client/src/styles/_partials.scss
@@ -1,4 +1,4 @@
-@import "./variables.scss";
+@use "variables.scss";
 // for form inputs styles
 // use custom widths in respective components
 %form-inputs {
@@ -6,9 +6,9 @@
   background-color: white;
   border: 1px solid lightgrey;
   box-sizing: border-box;
-  color: $color-primary;
+  color: variables.$color-primary;
   display: block;
-  font-family: $font;
+  font-family: variables.$font;
   font-size: 1rem;
   font-weight: 400;
   height: 2.9em;
@@ -19,8 +19,8 @@
 
 //for buttons and React Links that look like buttons
 %button-shared {
-  background-color: $color-form-lightgrey;
-  border-color: $color-form-lightgrey; 
+  background-color: variables.$color-form-lightgrey;
+  border-color: variables.$color-form-lightgrey; 
   color: black;
   font-size: 1em;
   font-weight: bold;

--- a/client/src/styles/_variables.scss
+++ b/client/src/styles/_variables.scss
@@ -1,4 +1,4 @@
-@import "./_variables_ladot.scss";
+@use "_variables_ladot.scss";
 @font-face {
   font-family: "Calibri";
   src: url("fonts/calibri.eot"); /* IE9 Compat Modes */
@@ -37,6 +37,6 @@ $color-form-lightgrey: $color-lightgrey;
 
 // using temp color variables until we get feedback/wireframes from ui/ux designers:
 // $color-link: $color-express-park-1 ;
-$color-button: $color-express-park-9;
+$color-button: variables_ladot.$color-express-park-9;
 
 $color-highlight: #a7c539; // Color for Prev/Next  buttons


### PR DESCRIPTION
- Fixes #2359

### What changes did you make?

- migrated sass @import rules to @use

### Why did you make the changes (we will use this info to test)?

- The @import rule is deprecated and will be removed in a future release

### Testing

- I'm not sure how to get the warnings to display yet
- But otherwise, the imported variables like background color should still work after this change.

