### PR TITLE
Make Reset Filters button visible on small-width screens

### DIFF
--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -940,58 +940,67 @@ const ProjectsPage = ({ contentContainerRef }) => {
               <div
                 style={{
                   display: "flex",
-                  flexDirection: "row",
+                  flexWrap: "wrap",
                   justifyContent: "space-between",
-                  width: "100vw"
+                  alignItems: "center",
+                  gap: "15px"
                 }}
               >
-                <MultiProjectToolbarMenu
-                  handleHideBoxes={handleHide}
-                  handleCsvModalOpen={handleCsvModalOpen}
-                  handleDeleteModalOpen={handleDeleteModalOpen}
-                  checkedProjectIds={checkedProjectIds}
-                  criteria={filterCriteria}
-                  checkedProjectsStatusData={checkedProjectsStatusData}
-                  pdfProjectData={projectData}
-                />
-                <div
-                  style={{
-                    display: "flex",
-                    flexDirection: "row",
-                    alignSelf: "center",
-                    justifyContent: "center",
-                    flexBasis: "33%"
-                  }}
-                >
-                  <div className={classes.searchBarWrapper}>
-                    <input
-                      className={classes.searchBar}
-                      type="search"
-                      id="filterText"
-                      name="filterText"
-                      placeholder="Search by Name; Address; Description; Alt#" // redundant with FilterDrawer
-                      value={filterCriteria.filterText}
-                      onChange={e => handleFilterTextChange(e.target.value)}
-                    />
-                    <MdOutlineSearch className={classes.searchIcon} />
+                <div>
+                  {/*first*/}
+                  <MultiProjectToolbarMenu
+                    handleHideBoxes={handleHide}
+                    handleCsvModalOpen={handleCsvModalOpen}
+                    handleDeleteModalOpen={handleDeleteModalOpen}
+                    checkedProjectIds={checkedProjectIds}
+                    criteria={filterCriteria}
+                    checkedProjectsStatusData={checkedProjectsStatusData}
+                    pdfProjectData={projectData}
+                  />
+                </div>
+                <div>
+                  {/*{" second div"}*/}
+                  <div
+                    style={{
+                      display: "flex",
+                      flexDirection: "row",
+                      alignSelf: "center",
+                      justifyContent: "center",
+                      flexBasis: "33%"
+                    }}
+                  >
+                    <div className={classes.searchBarWrapper}>
+                      <input
+                        className={classes.searchBar}
+                        type="search"
+                        id="filterText"
+                        name="filterText"
+                        placeholder="Search by Name; Address; Description; Alt#" // redundant with FilterDrawer
+                        value={filterCriteria.filterText}
+                        onChange={e => handleFilterTextChange(e.target.value)}
+                      />
+                      <MdOutlineSearch className={classes.searchIcon} />
+                    </div>
                   </div>
                 </div>
-
-                <div
-                  style={{
-                    paddingRight: "1.5em",
-                    display: "flex",
-                    justifyContent: "flex-end",
-                    flexBasis: "33%"
-                  }}
-                >
-                  <Button
-                    onClick={resetFiltersSort}
-                    isDisplayed={true}
-                    variant="tertiary"
+                <div>
+                  {" "}
+                  <div
+                    style={{
+                      paddingRight: "1.5em",
+                      display: "flex",
+                      justifyContent: "flex-end",
+                      flexBasis: "33%"
+                    }}
                   >
-                    RESET FILTERS/SORT
-                  </Button>
+                    <Button
+                      onClick={resetFiltersSort}
+                      isDisplayed={true}
+                      variant="tertiary"
+                    >
+                      RESET FILTERS/SORT
+                    </Button>
+                  </div>
                 </div>
               </div>
               <div>

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -947,7 +947,6 @@ const ProjectsPage = ({ contentContainerRef }) => {
                 }}
               >
                 <div>
-                  {/*first*/}
                   <MultiProjectToolbarMenu
                     handleHideBoxes={handleHide}
                     handleCsvModalOpen={handleCsvModalOpen}
@@ -959,7 +958,6 @@ const ProjectsPage = ({ contentContainerRef }) => {
                   />
                 </div>
                 <div>
-                  {/*{" second div"}*/}
                   <div
                     style={{
                       display: "flex",
@@ -984,7 +982,6 @@ const ProjectsPage = ({ contentContainerRef }) => {
                   </div>
                 </div>
                 <div>
-                  {" "}
                   <div
                     style={{
                       paddingRight: "1.5em",


### PR DESCRIPTION
- Fixes #2174 

### What changes did you make?

- Add an outer div to allow flex wrap. 
- so the Reset Filters/Sort button is fully visible when the viewport width is less than 890px

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.
angelawlee07@gmail.com
### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](
<img width="636" alt="Screenshot 2025-04-13 at 5 36 53 PM" src="https://github.com/user-attachments/assets/72572368-69fd-46ed-8060-990e712ef4c9" />
)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  ![image](
<img width="779" alt="Screenshot 2025-04-13 at 5 26 39 PM" src="https://github.com/user-attachments/assets/a5579a30-59ea-4196-b621-a959979fa8dd" />
)
![image](
<img width="506" alt="Screenshot 2025-04-13 at 5 26 23 PM" src="https://github.com/user-attachments/assets/5def0f55-fa2a-4d69-b341-64791f86b9ac" />
)

</details>
