### PR TITLE
Adjust spacing of header and navbar for smaller screens

### DIFF
--- a/client/src/components/Layout/Header.jsx
+++ b/client/src/components/Layout/Header.jsx
@@ -22,17 +22,17 @@ const useStyles = createUseStyles({
     "& h4": {
       color: "white"
     },
-    "@media (max-width:900px)": {
+    "@media (max-width:1024px)": {
       paddingRight: 0
     },
-    "@media (max-width:768px)": {
+    "@media (max-width:900px)": {
       paddingLeft: 0,
       flexWrap: "wrap",
       overflow: "hidden",
       maxHeight: 54.4,
       transition: "max-height .5s ease-in-out",
       "&.navbarOpen": {
-        maxHeight: 301.6
+        maxHeight: "fit-content"
       }
     }
   },
@@ -54,7 +54,7 @@ const useStyles = createUseStyles({
     color: "white",
     fontSize: "2em"
   },
-  "@media (max-width: 768px)": {
+  "@media (max-width: 900px)": {
     logoContainer: {
       justifySelf: "start"
     },

--- a/client/src/components/Layout/NavBar.jsx
+++ b/client/src/components/Layout/NavBar.jsx
@@ -20,10 +20,10 @@ const useStyles = createUseStyles({
     "@media print": {
       display: "none"
     },
-    "@media (max-width:900px)": {
+    "@media (max-width:1024px)": {
       marginLeft: "1em"
     },
-    "@media (max-width:768px)": {
+    "@media (max-width:900px)": {
       marginLeft: 0
     }
   },
@@ -34,7 +34,7 @@ const useStyles = createUseStyles({
     "&:hover": {
       color: "#a7c539"
     },
-    "@media (max-width:900px)": {
+    "@media (max-width:1024px)": {
       marginRight: "1em"
     }
   },
@@ -52,7 +52,7 @@ const useStyles = createUseStyles({
     }
   },
   linkBlock: {
-    "@media (max-width:768px)": {
+    "@media (max-width:900px)": {
       borderTop: "2px solid #0f2940",
       width: "100%",
       paddingTop: ".5em",
@@ -71,14 +71,14 @@ const useStyles = createUseStyles({
     marginLeft: "2em",
     paddingRight: 0,
     marginRight: "1em",
-    "@media (max-width:900px)": {
+    "@media (max-width:1024px)": {
       marginLeft: "1em"
     },
-    "@media (max-width:768px)": {
+    "@media (max-width:900px)": {
       marginLeft: 0
     }
   },
-  "@media (max-width:768px)": {
+  "@media (max-width:900px)": {
     navbar: {
       flexDirection: "column",
       minWidth: "100%"
@@ -101,7 +101,7 @@ const NavBar = ({ navbarOpen, setNavbarOpen }) => {
   const account = userContext.account;
 
   const handleHamburgerMenuClick = () => {
-    setNavbarOpen(window.innerWidth < 768 ? !navbarOpen : false);
+    setNavbarOpen(window.innerWidth < 900 ? !navbarOpen : false);
   };
 
   return (


### PR DESCRIPTION
- Fixes #2173 

### What changes did you make?
- Changed hamburger menu trigger from 768p to 900px
- Changed spacing in navbar and header
- Updated `max-height` of open menu from hardcoded value to `fit-content` 

### Why did you make the changes (we will use this info to test)?
- When the viewport width becomes less than the combined length of all the navigation bar buttons but greater than 768px, the My Account and Logout buttons aren't fully visible and therefore cannot be accessed without the user changing the viewport width.
- `Logout` wasn't visible when the menu was open. [The original value](https://github.com/hackforla/tdm-calculator/pull/327) was from when there were fewer links.


### Screenshots of Proposed Changes Of The Website

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![before](https://github.com/user-attachments/assets/1b5d85a0-0fa9-4b33-bb30-cc8ab7d3fd7e)

</details>



<details>
<summary>Visuals after changes are applied</summary>

Changes show two different viewport sizes that now display the hamburger menu which will appear up to 900px, and condensed spacing in the header through 1024px. 

![after 800px](https://github.com/user-attachments/assets/7a2ab681-d0c8-474e-93ad-5a1b9a5c0739)

![after 990px](https://github.com/user-attachments/assets/d075a782-5c34-424f-a426-a56bfba9e2e8)

</details>
