### PR TITLE
center select relevant projects table

### DIFF
--- a/client/src/components/Feedback/ProjectList.jsx
+++ b/client/src/components/Feedback/ProjectList.jsx
@@ -10,7 +10,9 @@ const useStyles = createUseStyles({
     lineHeight: "140%"
   },
   table: {
-    overflow: "auto"
+    overflow: "auto",
+    marginLeft: "auto",
+    marginRight: "auto"
   },
   tableHead: {
     textAlign: "left",


### PR DESCRIPTION
- Fixes #2318

### What changes did you make?

- Centered the "Select Relevant Projects" table in the Feedback 

### Why did you make the changes (we will use this info to test)?

- Requested by #2318




<details>
<summary>Visuals before and after changes are applied</summary>

![image](https://github.com/user-attachments/assets/78458caa-1529-445a-b42c-24a719d8fadc)

</details>


