### PR TITLE
Fixed bug in RuleInput to show val error when tabbing through reqd field

### DIFF
--- a/client/src/components/ProjectWizard/RuleInput/RuleInput.jsx
+++ b/client/src/components/ProjectWizard/RuleInput/RuleInput.jsx
@@ -187,6 +187,7 @@ const RuleInput = ({
         dataType === "number" ? (
           <div
             className={clsx(classes.rowContainer, classes.numberFieldWrapper)}
+            onBlur={onBlur}
           >
             <RuleLabel
               id={id}
@@ -261,6 +262,7 @@ const RuleInput = ({
         ) : dataType === "choice" ? (
           <div
             className={clsx(classes.rowContainer, classes.selectFieldWrapper)}
+            onBlur={onBlur}
           >
             <RuleLabel
               id={id}


### PR DESCRIPTION
- Fixes #2352
### What changes did you make?

- See issue

### Why did you make the changes (we will use this info to test)?

- See issue

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

Appearance after entering condo units, then tabbing through the required parking (note that keyboard focus is on the next input)
![image](https://github.com/user-attachments/assets/5f8596b0-bd22-4dca-9217-0b4c63076419)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
Appearance after entering condo units, then tabbing through the required parking (note that keyboard focus is on the next input)
![image](https://github.com/user-attachments/assets/3bcd5616-f01b-4410-99de-03237674aed5)

</details>
