### PR TITLE
fix(login): apply secondary style to 'Continue Without Saving' button

### DIFF
--- a/client/src/components/Authorization/Login.jsx
+++ b/client/src/components/Authorization/Login.jsx
@@ -183,8 +183,7 @@ const Login = () => {
                     onMouseOut={() => setWithoutSavingWarningIsVisible(false)}
                   >
                     <Button
-                      color="colorDefault"
-                      variant="outlined"
+                      variant="secondary"
                       onClick={() => {
                         navigate("/calculation/1/0");
                       }}


### PR DESCRIPTION
- Fixes #2399  

### What changes did you make?

- Updated the `Continue Without Saving` button in `client/src/components/Authorization/Login.jsx` to use the `secondary` variant.
- Removed the `color="colorDefault"` attribute from that button.

### Why did you make the changes (we will use this info to test)?

- The button was not matching the secondary button style defined in our design system.  
- This change ensures the outline, typography, padding, and hover state conform to spec.

### Issue-Specific User Account

N/A (no new temporary account required)

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

Before - Continue Without Saving Button

(RC: contributor uploaded an "after" image, I've replaced it with the correct "before".)

`![Screenshot From 2025-04-18 11-34-18](https://github.com/user-attachments/assets/3347afb1-8ffb-41ce-81d8-8ac87c57f13a)`

![image](https://github.com/user-attachments/assets/77924782-8cb8-4dd7-9be3-97d71a6f4344)


</details>

<details>
<summary>Visuals after changes are applied</summary>

After - Continue Without Saving Button
![Screenshot From 2025-04-18 11-34-26](https://github.com/user-attachments/assets/cf789b0a-7264-4ec1-935d-0044b85d0830)


</details>
