### PR TITLE
Make Login screen use standard button styles

### DIFF
--- a/client/src/components/Authorization/Login.jsx
+++ b/client/src/components/Authorization/Login.jsx
@@ -183,8 +183,7 @@ const Login = () => {
                     onMouseOut={() => setWithoutSavingWarningIsVisible(false)}
                   >
                     <Button
-                      color="colorDefault"
-                      variant="outlined"
+                      variant="secondary"
                       onClick={() => {
                         navigate("/calculation/1/0");
                       }}
@@ -196,7 +195,7 @@ const Login = () => {
                     id="cy-login-submit"
                     type="submit"
                     disabled={isDisabled}
-                    color="colorPrimary"
+                    variant="primary"
                   >
                     {isSubmitting ? "Please wait..." : "Login"}
                   </Button>


### PR DESCRIPTION
- Fixes #2414

### What changes did you make?

- Change Login page to use standard primary and secondary styles.

### Why did you make the changes (we will use this info to test)?

- See Issue


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
