### PR TITLE
Update Styling for the FAQ Answers

### DIFF
--- a/client/src/components/Faq/Answer.jsx
+++ b/client/src/components/Faq/Answer.jsx
@@ -12,17 +12,46 @@ const useStyles = createUseStyles(theme => ({
   answerInput: {
     width: "100%",
     display: "flex",
-    flexDirection: "column"
+    fontSize: '16px',
+    flexDirection: "column",
+    '& .ql-editor ol, & .ql-editor ul': {
+      fontSize: '16px',
+    },
+    '& .ql-editor li': {
+      fontSize: '16px',
+    },
   },
   answerText: {
     ...theme.typography.subHeading,
     textAlign: "inherit",
     padding: 8,
     fontWeight: 22,
+    fontSize: '16px',
+    margin: 0,
     cursor: admin => (admin ? "pointer" : "default"),
     "&:hover": {
       textDecoration: admin => admin && "underline"
-    }
+    },
+    '& .ql-editor p': {
+      margin: '0',
+      padding: '0',
+    },
+    '& .ql-indent-1': {
+      marginLeft: '3em',
+    },
+    '& .ql-indent-2': {
+      marginLeft: '6em',
+    },
+    '& .ql-editor ol, & .ql-editor ul': {
+      fontSize: '16px',
+      margin: '0 !important',
+      padding: '0',
+      listStylePosition: 'inside',
+    },
+    '& .ql-editor li': {
+      margin: '0 !important',
+      padding: '0',
+    },
   },
   externalLinkIcon: {
     fontSize: "14px",

--- a/client/src/components/Faq/Answer.jsx
+++ b/client/src/components/Faq/Answer.jsx
@@ -12,46 +12,46 @@ const useStyles = createUseStyles(theme => ({
   answerInput: {
     width: "100%",
     display: "flex",
-    fontSize: '16px',
+    fontSize: "16px",
     flexDirection: "column",
-    '& .ql-editor ol, & .ql-editor ul': {
-      fontSize: '16px',
+    "& .ql-editor ol, & .ql-editor ul": {
+      fontSize: "16px"
     },
-    '& .ql-editor li': {
-      fontSize: '16px',
-    },
+    "& .ql-editor li": {
+      fontSize: "16px"
+    }
   },
   answerText: {
     ...theme.typography.subHeading,
     textAlign: "inherit",
     padding: 8,
     fontWeight: 22,
-    fontSize: '16px',
+    fontSize: "16px",
     margin: 0,
     cursor: admin => (admin ? "pointer" : "default"),
     "&:hover": {
       textDecoration: admin => admin && "underline"
     },
-    '& .ql-editor p': {
-      margin: '0',
-      padding: '0',
+    "& .ql-editor p": {
+      margin: "0",
+      padding: "0"
     },
-    '& .ql-indent-1': {
-      marginLeft: '3em',
+    "& .ql-indent-1": {
+      marginLeft: "3em"
     },
-    '& .ql-indent-2': {
-      marginLeft: '6em',
+    "& .ql-indent-2": {
+      marginLeft: "6em"
     },
-    '& .ql-editor ol, & .ql-editor ul': {
-      fontSize: '16px',
-      margin: '0 !important',
-      padding: '0',
-      listStylePosition: 'inside',
+    "& .ql-editor ol, & .ql-editor ul": {
+      fontSize: "16px",
+      margin: "0 !important",
+      padding: "0",
+      listStylePosition: "inside"
     },
-    '& .ql-editor li': {
-      margin: '0 !important',
-      padding: '0',
-    },
+    "& .ql-editor li": {
+      margin: "0 !important",
+      padding: "0"
+    }
   },
   externalLinkIcon: {
     fontSize: "14px",

--- a/client/src/components/UI/Quill.jsx
+++ b/client/src/components/UI/Quill.jsx
@@ -49,7 +49,10 @@ const Quill = props => {
             }
           }
         }
-      }
+      },
+      clipboard: {
+        matchVisual: false
+      },
     }),
     [props.modules]
   );
@@ -70,7 +73,7 @@ const Quill = props => {
 
       {showLinkDialog && (
         <div className="linkDialog">
-          <input
+          <input class="linkInputBox"
             type="text"
             value={linkValue}
             onChange={onChangeLink}

--- a/client/src/components/UI/Quill.jsx
+++ b/client/src/components/UI/Quill.jsx
@@ -52,7 +52,7 @@ const Quill = props => {
       },
       clipboard: {
         matchVisual: false
-      },
+      }
     }),
     [props.modules]
   );
@@ -73,7 +73,8 @@ const Quill = props => {
 
       {showLinkDialog && (
         <div className="linkDialog">
-          <input class="linkInputBox"
+          <input
+            className="linkInputBox"
             type="text"
             value={linkValue}
             onChange={onChangeLink}

--- a/client/src/styles/AdminQuill.scss
+++ b/client/src/styles/AdminQuill.scss
@@ -15,6 +15,10 @@
   width: 300px;
 }
 
+.linkInputBox {
+  width: 92%;
+}
+
 .dialogActions {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
- Fixes #2484 

### What changes did you make?

- Add styling to keep the applied indentation on the page
- Add styling to keep consistent font size in the Quill editor and on the page
- Add styling to prevent additional lines being added above lists when the Quill editor is pressed again and again
- Add styling to keep the "Tooltip" input box a similar size to the dropdown below it 

### Why did you make the changes (we will use this info to test)?

- So that the page works as expected and looks orderly.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![Before 1 - Editor](https://github.com/user-attachments/assets/13ca1085-bf56-4580-990a-bd9a92356bef)
![Before 2 - On Page](https://github.com/user-attachments/assets/3dfa8f4d-81ac-43b8-b460-18fbbb1a8c46)
![Before 3 - Additional Lines](https://github.com/user-attachments/assets/a3683a7b-b141-4768-b31b-6d0a0663acd9)
![Before 4 - Input Box](https://github.com/user-attachments/assets/95b6da99-e83b-4fa0-aa25-a15e64dbb4f6)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![After 1 - Editor](https://github.com/user-attachments/assets/9434ca4e-9ee4-490b-b09b-e2d56e1d6642)
![After 2 - On Page](https://github.com/user-attachments/assets/8c0e4a4c-51b3-49ab-94b8-c9b6a87ba068)
![After 3 - Input Box](https://github.com/user-attachments/assets/ad6a4fc7-accd-4bdd-83ad-5185907a15f6)


</details>
