### PR TITLE
Allow for an set up conditionally required rules

### DIFF
--- a/client/src/components/ProjectWizard/RuleInput/ProjectLevelRuleInput.jsx
+++ b/client/src/components/ProjectWizard/RuleInput/ProjectLevelRuleInput.jsx
@@ -126,7 +126,7 @@ const ProjectLevelRuleInput = ({
                 autoComplete="off"
                 disabled={!display}
                 placeholder={
-                  showPlaceholder ? (required ? "required" : "optional") : ""
+                  showPlaceholder ? (required ? "required" : "") : ""
                 }
               />
             </div>

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSpecifications.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSpecifications.jsx
@@ -50,6 +50,7 @@ function ProjectSpecifications(props) {
         rules={rules}
         onInputChange={onInputChange}
         page={page}
+        showPlaceholder={true}
       />
     </div>
   );

--- a/client/src/services/tdm-engine.js
+++ b/client/src/services/tdm-engine.js
@@ -164,6 +164,7 @@ class Engine {
       name,
       value,
       dataType,
+      display,
       required,
       minStringLength,
       maxStringLength,
@@ -175,8 +176,11 @@ class Engine {
     } = rule;
     const validationErrors = [];
 
-    if (required && !value) {
-      validationErrors.push(`${name} is required`);
+    if (required && !value && display) {
+      // There are some edge cases like PARK_CONDO where a rule is
+      // required, but only if is applicable (i.e., display == true)
+      const name1 = name.replace("..... ", "");
+      validationErrors.push(`${name1} is required`);
     } else if (value) {
       if (minStringLength) {
         if (typeof value === "string" && value.length < minStringLength) {

--- a/server/db/migration/V20250430.1543__conditionally-reqd_rules_2467.sql
+++ b/server/db/migration/V20250430.1543__conditionally-reqd_rules_2467.sql
@@ -1,0 +1,5 @@
+update CalculationRule set
+	required = 1
+where calculationId = 1 and code in 
+('PARK_CONDO', 'CLASSROOM_SCHOOL', 'SF_TRADE_SCHOOL',
+'HS_AUDITORIUM_SEATS', 'HS_AUDITORIUM_SF', 'BED_HOSPITAL')


### PR DESCRIPTION
- Fixes #2467

### What changes did you make?

- Made required fields on Page 2 "conditionally" required, i.e., required only if they are applicable because the related input rule has a value.

### Why did you make the changes (we will use this info to test)?

- See Issue

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
