### PR TITLE
2415-fix-pagination-dropdown-menu.

### DIFF
--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -1142,6 +1142,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
                   onChange={e => handlePerPageChange(e.target.value)}
                   name="perPage"
                   className={classes.dropContent}
+                  maxMenuHeight={"60px"}
                 />
                 <span className={classes.itemsPerPage}>Items per page</span>
               </div>

--- a/client/src/components/UI/UniversalSelect.jsx
+++ b/client/src/components/UI/UniversalSelect.jsx
@@ -17,7 +17,9 @@ UniversalSelect.propTypes = {
   id: PropTypes.string,
   disabled: PropTypes.bool,
   autoFocus: PropTypes.bool,
-  className: PropTypes.string
+  className: PropTypes.string,
+  isSearchable: PropTypes.bool,
+  maxMenuHeight: PropTypes.number
 };
 
 export default function UniversalSelect({
@@ -29,7 +31,9 @@ export default function UniversalSelect({
   id,
   disabled,
   autoFocus,
-  className
+  className,
+  isSearchable = false,
+  maxMenuHeight
 }) {
   // To make UniversalSelect compatible with a standard react <select> component, the onChange method should be passed
   // an object that at least looks like an event object.
@@ -54,7 +58,9 @@ export default function UniversalSelect({
       name={name}
       inputId={id}
       isDisabled={disabled}
+      isSearchable={isSearchable}
       options={options}
+      maxMenuHeight={maxMenuHeight}
       styles={{
         container: (provided, state) => ({
           ...provided,


### PR DESCRIPTION
- Fixes #2415 

### What changes did you make?

- Added `isSearchable={false}` by default
- Added `maxMenuHeight={60px}` to make the styling look good.

### Why did you make the changes (we will use this info to test)?

- The search feature is unnecessary. For the future, if you want to enable the search feature, add the `isSearchable` prop in the `<UniversalSelect ... />` component.
- `maxMenuHeight`: Prevents the dropdown menu from overlapping the footer and creating white space below it.

### Issue-Specific User Account

- Need to login with TDM account.
- Navigate to "My Projects" in the navbar.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![white](https://github.com/user-attachments/assets/25d58970-83a9-4ec1-b66c-089a95f6d7c2)
![searchfeature](https://github.com/user-attachments/assets/496318d0-acac-40e0-a554-8b733dad53a2)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![perpage](https://github.com/user-attachments/assets/75107e44-e87d-4caf-b699-2c779e6368dc)

</details>
