### PR TITLE
Allow user to edit DRO on their own projects on My Projects Page

### DIFF
--- a/client/src/components/Projects/ProjectTableRow.jsx
+++ b/client/src/components/Projects/ProjectTableRow.jsx
@@ -1,8 +1,8 @@
-import React from "react";
+import React, { useState, useRef, useEffect, useContext } from "react";
 import { Link } from "react-router-dom";
 import { createUseStyles, useTheme } from "react-jss";
-import { useState, useRef, useEffect } from "react";
 import PropTypes from "prop-types";
+import UserContext from "../../contexts/UserContext";
 import Popup from "reactjs-popup";
 import "reactjs-popup/dist/index.css";
 import {
@@ -178,12 +178,16 @@ const ProjectTableRow = ({
   handleHide,
   handleCheckboxChange,
   checkedProjectIds,
-  isAdmin,
   droOptions,
   onDroChange, // New prop
   onAdminNoteUpdate, // New prop
   isActiveProjectsTab
 }) => {
+  const theme = useTheme();
+  const classes = useStyles(theme);
+  const userContext = useContext(UserContext);
+  const loginId = userContext?.account?.id;
+  const isAdmin = userContext?.account?.isAdmin || false;
   const {
     showWarningModal,
     setShowWarningModal,
@@ -200,8 +204,7 @@ const ProjectTableRow = ({
     handleDoNotDiscard,
     textUpdated
   } = useAdminNotesModal(project, onAdminNoteUpdate);
-  const theme = useTheme();
-  const classes = useStyles(theme);
+
   const formInputs = JSON.parse(project.formInputs);
   const printRef = useRef();
   const [projectRules, setProjectRules] = useState(null);
@@ -322,7 +325,9 @@ const ProjectTableRow = ({
       <td className={classes.td}>{dateSubmittedDisplay()}</td>
       {/* DRO Column */}
       <td className={classes.td}>
-        {isAdmin && droOptions.length > 0 ? (
+        {/* Dro is editable if user is an admin OR user is the author and project is not submitted */}
+        {droOptions.length > 0 &&
+        (isAdmin || (project.loginId === loginId && !project.dateSubmitted)) ? (
           <div style={{ width: "100px" }}>
             <UniversalSelect
               value={selectedDro}
@@ -346,7 +351,7 @@ const ProjectTableRow = ({
           <span>{droName}</span>
         )}
       </td>
-      {isAdmin && ( // onSave={handleSave}  isEditing={isEditing}
+      {isAdmin && (
         <div>
           <button
             onClick={handleAdminNotesModalOpen}
@@ -454,7 +459,6 @@ ProjectTableRow.propTypes = {
   handleHide: PropTypes.func.isRequired,
   handleCheckboxChange: PropTypes.func.isRequired,
   checkedProjectIds: PropTypes.arrayOf(PropTypes.number).isRequired,
-  isAdmin: PropTypes.bool.isRequired,
   droOptions: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number.isRequired,

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -289,7 +289,6 @@ const ProjectsPage = ({ contentContainerRef }) => {
   const [currentPage, setCurrentPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
   const [droOptions, setDroOptions] = useState([]);
-  const [droNameMap, setDroNameMap] = useState({});
   const projectsPerPage = perPage;
   const isAdmin = userContext.account?.isAdmin || false;
   const loginId = userContext.account?.id || null;
@@ -326,14 +325,6 @@ const ProjectsPage = ({ contentContainerRef }) => {
     };
     fetchDroOptions();
   }, []);
-
-  useEffect(() => {
-    const droMap = {};
-    droOptions.forEach(dro => {
-      droMap[dro.id] = dro.name;
-    });
-    setDroNameMap(droMap);
-  }, [droOptions]);
 
   const perPageOptions = [
     { value: projects.length.toString(), label: "All" },
@@ -709,7 +700,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
     try {
       const updatedDroId = newDroId === "" ? null : newDroId;
       await projectService.updateDroId(projectId, updatedDroId);
-      await updateProjects(); // Refresh the project list
+      await updateProjects();
     } catch (error) {
       console.error("Error updating DRO ID:", error);
     }
@@ -718,7 +709,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
   const handleAdminNoteUpdate = async (projectId, newAdminNote) => {
     try {
       await projectService.updateAdminNotes(projectId, newAdminNote);
-      await updateProjects(); // Refresh the project list
+      await updateProjects();
     } catch (error) {
       console.error("Error updating admin notes:", error);
     }
@@ -1215,11 +1206,6 @@ const ProjectsPage = ({ contentContainerRef }) => {
                             droOptions={droOptions}
                             onDroChange={handleDroChange}
                             onAdminNoteUpdate={handleAdminNoteUpdate}
-                            droName={
-                              isAdmin
-                                ? null
-                                : droNameMap[project.droId] || "N/A"
-                            } // Pass the droName
                             isActiveProjectsTab={isActiveProjectsTab}
                           />
                         ))


### PR DESCRIPTION
- Fixes #2347
- Fixes #2721

### What changes did you make?

- added logic to allow users to edit the dro on the My Projects page for thier own projects that have not yet been submitted.

### Why did you make the changes (we will use this info to test)?

- See Issue

### Issue-Specific User Account

Non-admin users

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/8ae78602-bad9-49dd-b70e-c29a2f976143)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/b2089978-05cb-44b5-9317-645ac0c6f492)

</details>

