### PR TITLE
added clipping CSS code to text cells in My Projects, Submissions, Ma…

### DIFF
--- a/client/src/components/Feedback/ProjectList.jsx
+++ b/client/src/components/Feedback/ProjectList.jsx
@@ -24,7 +24,10 @@ const useStyles = createUseStyles(theme => ({
     padding: "0em 1em 0.4rem 0em",
     width: "20rem",
     minWidth: "20rem",
-    maxWidth: "25rem"
+    maxWidth: "25rem",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis"
   },
   dateCell: {
     padding: "0em 1em 0.4rem 0em",

--- a/client/src/components/Projects/ProjectTableRow.jsx
+++ b/client/src/components/Projects/ProjectTableRow.jsx
@@ -27,7 +27,10 @@ const useStyles = createUseStyles(theme => ({
   td: {
     padding: "0.2em",
     textAlign: "left",
-    width: "5%"
+    width: "5%",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis"
   },
   tdRightAlign: {
     padding: "0.2em",

--- a/client/src/components/Submissions/SubmissionTableRow.jsx
+++ b/client/src/components/Submissions/SubmissionTableRow.jsx
@@ -14,7 +14,10 @@ const useStyles = createUseStyles(theme => ({
   td: {
     padding: "0.2em",
     textAlign: "left",
-    width: "5%"
+    width: "5%",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis"
   },
   tdRightAlign: {
     padding: "0.2em",

--- a/client/src/components/Submissions/SubmissionsPage.jsx
+++ b/client/src/components/Submissions/SubmissionsPage.jsx
@@ -158,7 +158,10 @@ const useStyles = createUseStyles(theme => ({
   td: {
     padding: "0.2em",
     textAlign: "left",
-    width: "5%"
+    width: "5%",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis"
   },
   tdRightAlign: {
     padding: "0.2em",


### PR DESCRIPTION
- Fixes #2501

### What changes did you make?

- Added CSS code whiteSpace, overflow, and textOverflow to text cells to clip the contents.

### Why did you make the changes (we will use this info to test)?

- When there is too much content, the row size would increase, limiting the number of projects that can be seen.
- This also fixes any overlapping content that might occur.

### Issue-Specific User Account

The following accounts were used to text the changes.
tdm@hackforla.org
tdm-dev+admin@hackforla.org

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1431" alt="Screenshot 2025-05-13 at 9 17 30 AM" src="https://github.com/user-attachments/assets/07db4eb1-3c3b-483a-a426-c97b9e1383b4" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1434" alt="Screenshot 2025-05-13 at 9 10 56 AM" src="https://github.com/user-attachments/assets/6dab306f-81dc-4aba-9171-65c4225d24f9" />

</details>
