### PR TITLE
2508 Additional project tab designs

### DIFF
--- a/client/src/components/Modals/ActionProjectsCsv.jsx
+++ b/client/src/components/Modals/ActionProjectsCsv.jsx
@@ -37,6 +37,12 @@ const useStyles = createUseStyles(theme => ({
     color: theme.colorBlack,
     marginBottom: "0",
     verticalAlign: "middle"
+  },
+  radioButtonContainer: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.5em",
+    margin: "0.5em"
   }
 }));
 
@@ -70,13 +76,27 @@ const CsvModal = ({
 
   const handleGenerateButton = async () => {
     setLoading(true);
-    const projectSet = project
-      ? [project]
-      : projectCollection === "All"
-        ? projects
-        : projectCollection == "Filtered"
-          ? filteredProjects
-          : checkedProjects;
+    let projectSet;
+    const activeProjects = projects.filter(p => !p.dateTrashed);
+
+    if (project) {
+      projectSet = [project];
+    } else {
+      switch (projectCollection) {
+        case "All":
+          projectSet = projects;
+          break;
+        case "Filtered":
+          projectSet = filteredProjects;
+          break;
+        case "All Active":
+          projectSet = activeProjects;
+          break;
+        default:
+          projectSet = checkedProjects;
+      }
+    }
+
     let csvData = null;
     csvData = await getCsvForProjects(projectSet, progressCallback);
     setLoading(false);
@@ -112,34 +132,33 @@ const CsvModal = ({
             <div style={theme.typography.subHeading}>
               Choose a set of Projects to include
             </div>
-            <div style={{ marginLeft: "10%", width: "35%" }}>
+            <div className={classes.radioButtonContainer}>
               {checkedProjects && checkedProjects.length > 0 && (
-                <div style={{ margin: "0.5em" }}>
-                  <RadioButton
-                    label={"Checked Projects "}
-                    value="Checked"
-                    checked={projectCollection === "Checked"}
-                    onChange={handleOptionChange}
-                  />
-                </div>
+                <RadioButton
+                  label={"Checked Projects"}
+                  value="Checked"
+                  checked={projectCollection === "Checked"}
+                  onChange={handleOptionChange}
+                />
               )}
-
-              <div style={{ margin: "0.5em" }}>
-                <RadioButton
-                  label="Filtered Projects"
-                  value="Filtered"
-                  checked={projectCollection === "Filtered"}
-                  onChange={handleOptionChange}
-                />
-              </div>
-              <div style={{ margin: "0.5em" }}>
-                <RadioButton
-                  label="All Projects"
-                  value="All"
-                  checked={projectCollection === "All"}
-                  onChange={handleOptionChange}
-                />
-              </div>
+              <RadioButton
+                label="Filtered Projects"
+                value="Filtered"
+                checked={projectCollection === "Filtered"}
+                onChange={handleOptionChange}
+              />
+              <RadioButton
+                label="All Projects (Exclude Deleted Projects)"
+                value="All Active"
+                checked={projectCollection === "All Active"}
+                onChange={handleOptionChange}
+              />
+              <RadioButton
+                label="All Projects (Include Deleted Projects)"
+                value="All"
+                checked={projectCollection === "All"}
+                onChange={handleOptionChange}
+              />
             </div>
           </>
         )}

--- a/client/src/components/Projects/MultiProjectToolbarMenu.jsx
+++ b/client/src/components/Projects/MultiProjectToolbarMenu.jsx
@@ -289,7 +289,7 @@ MultiProjectToolbarMenu.propTypes = {
   criteria: PropTypes.object.isRequired,
   checkedProjectsStatusData: PropTypes.object.isRequired,
   pdfProjectData: PropTypes.object,
-  isActiveProjectsTab: PropTypes.string.isRequired
+  isActiveProjectsTab: PropTypes.bool.isRequired
 };
 
 export default MultiProjectToolbarMenu;

--- a/client/src/components/Projects/ProjectTableRow.jsx
+++ b/client/src/components/Projects/ProjectTableRow.jsx
@@ -467,7 +467,7 @@ ProjectTableRow.propTypes = {
   ).isRequired,
   onDroChange: PropTypes.func.isRequired,
   onAdminNoteUpdate: PropTypes.func.isRequired,
-  isActiveProjectsTab: PropTypes.string.isRequired
+  isActiveProjectsTab: PropTypes.bool.isRequired
 };
 
 export default ProjectTableRow;

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -78,7 +78,7 @@ const useStyles = createUseStyles({
     fontSize: "14pt",
     fontWeight: "bold",
     display: "flex",
-    justifyContent: "center",
+    justifyContent: "right",
     width: "100%",
     gap: "10px",
     borderBottom: "2px solid #e6ebf0"

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -921,7 +921,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
       id: "dateSnapshotted",
       label: "Status",
       popupType: "status",
-      colWidth: `${isActiveProjectsTab ? "7rem" : "12rem"}`
+      colWidth: "12rem"
     },
     { id: "name", label: "Project Name", popupType: "text", colWidth: "20rem" },
     { id: "address", label: "Address", popupType: "text", colWidth: "20rem" },

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -952,7 +952,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
       ? [
           {
             id: "dateTrashed",
-            label: "Date Trashed",
+            label: "Date Deleted",
             popupType: "datetime",
             startDatePropertyName: "startDateTrashed",
             endDatePropertyName: "endDateTrashed",

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -115,7 +115,7 @@ const useStyles = createUseStyles({
     transition: "flex-basis 0.5s ease-in-out"
   },
   pageTitle: {
-    marginTop: "2em"
+    marginTop: "20px"
   },
   searchBarWrapper: {
     position: "relative",

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -97,8 +97,10 @@ const useStyles = createUseStyles({
   },
   inactivePageTab: {
     color: "#808589",
-    backgroundColor: "#e6ebf0",
-    cursor: "pointer"
+    cursor: "pointer",
+    "&:hover": {
+      backgroundColor: "#e6ebf0"
+    }
   },
   filter: {
     overflow: "hidden",

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -1114,6 +1114,13 @@ const ProjectsPage = ({ contentContainerRef }) => {
                       flexBasis: "33%"
                     }}
                   >
+                    <Button
+                      onClick={resetFiltersSort}
+                      isDisplayed={true}
+                      variant="tertiary"
+                    >
+                      RESET FILTERS/SORT
+                    </Button>
                     {!isActiveProjectsTab && (
                       <Button
                         onClick={handleDeleteModalOpen}
@@ -1124,13 +1131,6 @@ const ProjectsPage = ({ contentContainerRef }) => {
                         Restore
                       </Button>
                     )}
-                    <Button
-                      onClick={resetFiltersSort}
-                      isDisplayed={true}
-                      variant="tertiary"
-                    >
-                      RESET FILTERS/SORT
-                    </Button>
                   </div>
                 </div>
               </div>

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -214,7 +214,7 @@ const useStyles = createUseStyles({
     overflow: "auto", // changed to allow Universal Select to show above the page container when expanded
     width: "calc(100vw - 20px)",
     margin: "20px 0px",
-    height: "calc(100vh - 275px - 11.34em)"
+    height: "calc(100vh - 200px - 11.34em)"
   },
   fixTableHead: {
     overflowY: "auto",

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -74,6 +74,10 @@ const useStyles = createUseStyles({
     flexDirection: "column",
     alignItems: "center"
   },
+  pageTitle: {
+    marginTop: "20px",
+    marginBottom: "-35px"
+  },
   pageTabsDiv: {
     fontSize: "14pt",
     fontWeight: "bold",
@@ -84,11 +88,13 @@ const useStyles = createUseStyles({
     borderBottom: "2px solid #e6ebf0"
   },
   pageTab: {
-    padding: "10px",
     borderTop: "2px solid #e6ebf0",
     borderLeft: "2px solid #e6ebf0",
     borderRight: "2px solid #e6ebf0",
-    borderRadius: "2px 2px 0 0"
+    borderRadius: "2px 2px 0 0",
+    height: "50px",
+    width: "185px",
+    textAlign: "center"
   },
   activePageTab: {
     position: "relative",
@@ -115,9 +121,6 @@ const useStyles = createUseStyles({
     flexShrink: 0,
     flexGrow: 0,
     transition: "flex-basis 0.5s ease-in-out"
-  },
-  pageTitle: {
-    marginTop: "20px"
   },
   searchBarWrapper: {
     position: "relative",
@@ -152,7 +155,7 @@ const useStyles = createUseStyles({
     tableLayout: "fixed"
   },
   table: {
-    minWidth: "115rem",
+    minWidth: "110rem",
     width: "100%",
     tableLayout: "fixed"
   },
@@ -923,7 +926,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
       id: "dateSnapshotted",
       label: "Status",
       popupType: "status",
-      colWidth: "12rem"
+      colWidth: `${isActiveProjectsTab ? "7rem" : "12rem"}`
     },
     { id: "name", label: "Project Name", popupType: "text", colWidth: "20rem" },
     { id: "address", label: "Address", popupType: "text", colWidth: "20rem" },

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -150,7 +150,7 @@ const useStyles = createUseStyles({
     tableLayout: "fixed"
   },
   table: {
-    minWidth: "110rem",
+    minWidth: "115rem",
     width: "100%",
     tableLayout: "fixed"
   },

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -76,7 +76,7 @@ const useStyles = createUseStyles({
   },
   pageTitle: {
     marginTop: "20px",
-    marginBottom: "-35px"
+    marginBottom: "-45px"
   },
   pageTabsDiv: {
     fontSize: "14pt",
@@ -84,24 +84,31 @@ const useStyles = createUseStyles({
     display: "flex",
     justifyContent: "right",
     width: "100%",
-    gap: "10px",
+    gap: "7px",
     borderBottom: "2px solid #e6ebf0"
   },
   pageTab: {
+    height: "50px",
+    width: "185px",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    boxSizing: "border-box"
+  },
+  activePageTab: {
     borderTop: "2px solid #e6ebf0",
     borderLeft: "2px solid #e6ebf0",
     borderRight: "2px solid #e6ebf0",
     borderRadius: "2px 2px 0 0",
-    height: "50px",
-    width: "185px",
-    textAlign: "center"
-  },
-  activePageTab: {
     position: "relative",
     zIndex: 1,
     boxShadow: "0 2px 0 white"
   },
   inactivePageTab: {
+    borderTop: "2px solid transparent",
+    borderLeft: "2px solid transparent",
+    borderRight: "2px solid transparent",
+    borderRadius: "2px 2px 0 0",
     color: "#808589",
     cursor: "pointer",
     "&:hover": {

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -166,7 +166,7 @@ const useStyles = createUseStyles({
     top: 0,
     zIndex: 1,
     fontWeight: "bold",
-    backgroundColor: "#002E6D",
+    backgroundColor: "#0F2940",
     color: "white",
     "& td": {
       padding: "12px"


### PR DESCRIPTION
- Fixes #2508 

### What changes did you make?

- Tab styling:
  - Moved tabs to the right side of the page
  - Updated tab dimensions to match design
  - Added gray background on hover, white background for inactive tab
  - Updated header marginTop
  - Moved tabs up to be in line with My Projects header
- Table header:
  - Update column header from Date Trashed to Date Deleted
  - Update table header color
- Moved Restore button to the right of Reset Filters/Sort button
- Revise radio buttons/filtered options for CSV download
- Updated margin between page nav buttons and footer (by updating tableContainer height)

### Why did you make the changes (we will use this info to test)?

- Follow-ups to #2375 (design updates made after initial handoff)

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

active projects:
![Screen Shot 2025-05-14 at 8 04 47 PM](https://github.com/user-attachments/assets/856630f8-40a0-44ed-a6e4-cc03ca1659b2)

deleted projects:
![Screen Shot 2025-05-14 at 8 07 31 PM](https://github.com/user-attachments/assets/6487fb32-d769-4636-99cc-f69a7eb6cb7a)

</details>

<details>
<summary>Visuals after changes are applied</summary>

active projects:
![Screen Shot 2025-05-14 at 8 05 29 PM](https://github.com/user-attachments/assets/ea19f23e-e43b-4d69-8aba-a2f0d20b3da4)

deleted projects:
![Screen Shot 2025-05-14 at 8 07 08 PM](https://github.com/user-attachments/assets/1c1036b4-342f-4f6f-81d8-29014bc4deb9)

</details>
