### PR TITLE
Disable Residential Pkg if no parking provided

### DIFF
--- a/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationContainer.jsx
@@ -285,7 +285,18 @@ export function TdmCalculationContainer({ contentContainerRef }) {
     const lowParkRatio = rules.find(
       r => r.code === "CALC_PARK_RATIO" && r.value < 110
     );
-    return !!(projectLevel === 1 && applicableLandUse && lowParkRatio);
+    // Must provide some parking, in order for the package to apply, since
+    // one strategy in the package is Pricing/Unbundling, and that can only apply if
+    // some parking is provided
+    const parkingProvided = rules.find(
+      r => r.code === "PARK_SPACES" && r.value > 0
+    );
+    return !!(
+      projectLevel === 1 &&
+      applicableLandUse &&
+      lowParkRatio &&
+      parkingProvided
+    );
   })();
 
   const allowSchoolPackage = (() => {


### PR DESCRIPTION
- Fixes #2448

### What changes did you make?

- Disable Residential Package on Strategies Page when no parking is provided

### Why did you make the changes (we will use this info to test)?

- The Residential Package cannot be applied when no parking provided, since the package includes the Pricing/Unbundling strategy which cannot be used if there is no parking to Price/Unbundle.

### Issue-Specific User Account
(any)

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/e46b15f9-7f05-4915-82d4-2a06f87367df)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
