### PR TITLE
2524 Update button disabled states

### DIFF
--- a/client/src/components/Button/Button.jsx
+++ b/client/src/components/Button/Button.jsx
@@ -29,8 +29,14 @@ const useStyles = createUseStyles(theme => ({
     border: "none",
     // Following Colors are from https://www.figma.com/design/nD9QK56Mzq7xNSaSUoeGx0/TDM-Calculator?node-id=16061-4518&t=8f3dn1oKCVqu00uc-4
     boxShadow: "0px 4px 4px 0px" + theme.colorDropShadow,
+    "&[disabled]": {
+      color: theme.colorGray,
+      backgroundColor: theme.colorPrimaryDisabled,
+      boxShadow: "none"
+    },
     "&[disabled]:hover": {
-      boxShadow: "3px 4px 4px 0px " + theme.colorDropShadowDisabled
+      boxShadow: "none",
+      cursor: "default"
     },
     "&:hover": {
       boxShadow: "3px 3px 4px 0px" + theme.colorDropShadowHover
@@ -42,8 +48,14 @@ const useStyles = createUseStyles(theme => ({
     border: "1px solid " + theme.colors.primary.black,
     boxShadow: "0px 4px 4px 0px" + theme.colorDropShadow,
     // Following Colors are from https://www.figma.com/design/nD9QK56Mzq7xNSaSUoeGx0/TDM-Calculator?node-id=16061-4518&t=8f3dn1oKCVqu00uc-4
+    "&[disabled]": {
+      color: theme.colorGray,
+      border: "1px solid " + theme.colorSecondaryDisabled,
+      boxShadow: "none"
+    },
     "&[disabled]:hover": {
-      boxShadow: "3px 4px 4px 0px " + theme.colorDropShadowDisabled
+      boxShadow: "none",
+      cursor: "default"
     },
     "&:hover": {
       boxShadow: "3px 3px 4px 0px" + theme.colorDropShadowHover
@@ -56,8 +68,14 @@ const useStyles = createUseStyles(theme => ({
     "&:hover": {
       boxShadow: "3px 3px 4px 0px" + theme.colorDropShadowHover
     },
+    "&[disabled]": {
+      color: theme.colorGray,
+      border: "none",
+      boxShadow: "none"
+    },
     "&[disabled]:hover": {
-      boxShadow: "3px 4px 4px 0px " + theme.colorDropShadowDisabled
+      boxShadow: "none",
+      cursor: "default"
     }
   },
   warning: {
@@ -66,8 +84,13 @@ const useStyles = createUseStyles(theme => ({
     border: "none",
     // Following Colors are from https://www.figma.com/design/nD9QK56Mzq7xNSaSUoeGx0/TDM-Calculator?node-id=16061-4518&t=8f3dn1oKCVqu00uc-4
     boxShadow: "0px 4px 4px 0px " + theme.colorDropShadow,
+    "&[disabled]": {
+      backgroundColor: theme.colorCriticalDisabled,
+      boxShadow: "none"
+    },
     "&[disabled]:hover": {
-      boxShadow: "3px 4px 4px 0px " + theme.colorDropShadowDisabled
+      boxShadow: "none",
+      cursor: "default"
     },
     "&:hover": {
       boxShadow: "3px 3px 4px 0px" + theme.colorDropShadowHover

--- a/client/src/components/Button/Button.jsx
+++ b/client/src/components/Button/Button.jsx
@@ -66,6 +66,7 @@ const useStyles = createUseStyles(theme => ({
     color: theme.colors.primary.black,
     // Following Colors are from https://www.figma.com/design/nD9QK56Mzq7xNSaSUoeGx0/TDM-Calculator?node-id=16061-4518&t=8f3dn1oKCVqu00uc-4
     boxShadow: "0px 4px 4px 0px" + theme.colorDropShadow,
+    border: "none",
     "&:hover": {
       boxShadow: "3px 3px 4px 0px" + theme.colorDropShadowHover
     },

--- a/client/src/components/Button/Button.jsx
+++ b/client/src/components/Button/Button.jsx
@@ -9,6 +9,7 @@ const useStyles = createUseStyles(theme => ({
     fontFamily: "Calibri",
     fontWeight: 700,
     height: "min-content",
+    minHeight: "44px",
     margin: "0.5em",
     padding: "0.5em 1em",
     textAlign: "center",

--- a/client/src/components/Button/Button.jsx
+++ b/client/src/components/Button/Button.jsx
@@ -51,7 +51,7 @@ const useStyles = createUseStyles(theme => ({
     // Following Colors are from https://www.figma.com/design/nD9QK56Mzq7xNSaSUoeGx0/TDM-Calculator?node-id=16061-4518&t=8f3dn1oKCVqu00uc-4
     "&[disabled]": {
       color: theme.colorGray,
-      border: "1px solid " + theme.colorSecondaryDisabled,
+      border: "1px solid " + theme.colors.secondary.mediumGray,
       boxShadow: "none"
     },
     "&[disabled]:hover": {

--- a/client/src/components/Button/NavButton.jsx
+++ b/client/src/components/Button/NavButton.jsx
@@ -14,12 +14,16 @@ const useStyles = createUseStyles(theme => ({
     boxShadow: "rgba(0, 46, 109, 0.3) 0px 3px 5px",
     "&:focus": {
       borderRadius: "none"
+    },
+    "&[disabled]:hover": {
+      boxShadow: "none"
     }
   },
   wizardNavButtonDisabled: {
     cursor: "default",
     backgroundColor: theme.colorPrimaryDisabled,
-    color: theme.colorGray
+    color: theme.colorGray,
+    boxShadow: "none"
   },
   hidden: {
     visibility: "hidden"

--- a/client/src/components/Button/NavButton.jsx
+++ b/client/src/components/Button/NavButton.jsx
@@ -5,7 +5,7 @@ import { MdChevronLeft, MdChevronRight } from "react-icons/md";
 import clsx from "clsx";
 import Button from "./Button";
 
-const useStyles = createUseStyles({
+const useStyles = createUseStyles(theme => ({
   navButton: {
     cursor: "pointer",
     padding: "0.35em 0.7em",
@@ -17,7 +17,8 @@ const useStyles = createUseStyles({
     }
   },
   wizardNavButtonDisabled: {
-    cursor: "default"
+    cursor: "default",
+    backgroundColor: theme.colorPrimaryDisabled
   },
   hidden: {
     visibility: "hidden"
@@ -27,7 +28,7 @@ const useStyles = createUseStyles({
       display: "none"
     }
   }
-});
+}));
 
 const NavButton = ({
   id,

--- a/client/src/components/Button/NavButton.jsx
+++ b/client/src/components/Button/NavButton.jsx
@@ -18,7 +18,8 @@ const useStyles = createUseStyles(theme => ({
   },
   wizardNavButtonDisabled: {
     cursor: "default",
-    backgroundColor: theme.colorPrimaryDisabled
+    backgroundColor: theme.colorPrimaryDisabled,
+    color: theme.colorGray
   },
   hidden: {
     visibility: "hidden"

--- a/client/src/styles/theme.js
+++ b/client/src/styles/theme.js
@@ -1,6 +1,8 @@
 export const jssTheme = {
   colorDefault: "#fff", //white
   colorPrimary: "#a7c539", //lime green
+  colorPrimaryDisabled: "#D3E29C", //green tint
+  colorSecondaryDisabled: "#dbdbdb",
   colorText: "#0F2940", //dark blue
   colorLADOT: "#002E6D",
   colorGray: "#808080",
@@ -12,6 +14,7 @@ export const jssTheme = {
   colorBlack: "#000000",
   colorError: "#E46247", //e.g. red
   colorCritical: "#C3391D",
+  colorCriticalDisabled: "#D57461",
   colorDeselect: "#EEF1F4", //e.g. red
   colorHighlight: "#F0E300", //yellow
   colorTooltipBackground: "#FFEDEA",

--- a/client/src/styles/theme.js
+++ b/client/src/styles/theme.js
@@ -2,7 +2,6 @@ export const jssTheme = {
   colorDefault: "#fff", //white
   colorPrimary: "#a7c539", //lime green
   colorPrimaryDisabled: "#D3E29C", //green tint
-  colorSecondaryDisabled: "#dbdbdb",
   colorText: "#0F2940", //dark blue
   colorLADOT: "#002E6D",
   colorGray: "#808080",


### PR DESCRIPTION
- Fixes #2524

### What changes did you make?

Changed hover states for the following Button component variants:
- **Primary**
    - Background color is now lighter green (added to theme.js as `colorPrimaryDisabled`)
    - Text is now Gray color from theme
- **Secondary**
    - Border color is now lighter than active state
    - Text is now Gray color from theme
- **Tertiary**
    - Text is now Gray color from theme
    - Note: the Figma designs do not have a black border on this variant, so I removed that as well
- **Warning**
    - Now uses lighter red background color (added to theme.js as `colorCriticalDisabled` )

For NavButton component:
- Background color is now lighter green (same `colorPrimaryDisabled` color as Button component)
- Arrows are now Gray color from theme
- Note: I didn’t see the secondary variant being used anywhere

For all of the above:
- Removed drop-shadow for disabled/disabled+hover states
    - Removing the drop-shadow decreased the button heights to 40px, so I added min-height of 44px per this note from the [Full Design System](https://www.figma.com/design/nD9QK56Mzq7xNSaSUoeGx0/TDM-Calculator?node-id=3337-11981&p=f)
       ![Screen Shot 2025-05-22 at 12 58 52 AM](https://github.com/user-attachments/assets/959723cc-72f3-4fa2-a191-c3acafbc7499)
- This wasn’t noted in the design but I thought it made sense to change the cursor to the default arrow when hovering over a disabled button, to further signal the inactive state

### Why did you make the changes (we will use this info to test)?

- The colors for text and button background need to be updated for the disabled state only.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Figma designs</summary>

![Screen Shot 2025-05-22 at 1 09 29 AM](https://github.com/user-attachments/assets/e53bdb38-2815-4f54-9239-9d8a5832a467)

</details>

<details>
<summary>Visuals before changes are applied</summary>

![Screen Shot 2025-05-22 at 1 12 12 AM](https://github.com/user-attachments/assets/9b78f796-2f88-4cad-9059-11f594bb759d)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screen Shot 2025-05-22 at 1 09 59 AM](https://github.com/user-attachments/assets/7f7552f8-2c88-4eb5-a711-9c4a3b937e46)

</details>
