### PR TITLE
fix: remove aria-describedby attr when popup is not on screen

### DIFF
--- a/client/src/components/Layout/NavBarLogin.jsx
+++ b/client/src/components/Layout/NavBarLogin.jsx
@@ -15,7 +15,11 @@ const NavBarLogin = ({ classes, handleHamburgerMenuClick }) => {
 
   const [isCalculation, setIsCalculation] = useState(false);
   const [tooltipOpen, setTooltipOpen] = useState(true);
-  const closeModal = () => setTooltipOpen(false);
+  const closeModal = () => {
+    const loginLink = document.getElementById("login-link");
+    loginLink.removeAttribute("aria-describedby");
+    setTooltipOpen(false);
+  };
 
   const location = useLocation();
   const pathname = location.pathname;
@@ -102,7 +106,11 @@ const NavBarLogin = ({ classes, handleHamburgerMenuClick }) => {
           open={tooltipOpen}
           onClose={closeModal}
           closeOnDocumentClick={false}
-          trigger={<span style={{ cursor: "pointer" }}>{loginLink}</span>}
+          trigger={
+            <span id="login-link" style={{ cursor: "pointer" }}>
+              {loginLink}
+            </span>
+          }
           position="bottom right"
           arrow={true}
           arrowStyle={{


### PR DESCRIPTION
- Fixes #2531

### What changes did you make?

- Remove the aria described by attribute when tooltip is not rendered

### Why did you make the changes (we will use this info to test)?

- This is an accessibility change that will help screen readers


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="936" alt="Screenshot 2025-06-04 at 2 21 26 PM" src="https://github.com/user-attachments/assets/fb531d36-9139-402e-a057-9c86ea5bcd61" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1241" alt="Screenshot 2025-06-04 at 2 20 33 PM" src="https://github.com/user-attachments/assets/a9e8fc47-85f5-44d5-bd2d-35ba8953a7a8" />

<img width="1048" alt="Screenshot 2025-06-04 at 2 20 38 PM" src="https://github.com/user-attachments/assets/a362a3bd-ab99-460f-b237-523c901ea686" />


</details>
