### PR TITLE
Add back InfoSnapshotSubmitted component to ProjectPage.jsx

### DIFF
--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -1288,6 +1288,11 @@ const ProjectsPage = ({ contentContainerRef }) => {
                 onClose={() => setTargetNotReachedModalOpen(false)}
                 project={selectedProject}
               />
+              <InfoSnapshotSubmit 
+              mounted={successModelOpen}
+              onClose={handleSuccessModalClose}
+              project={selectedProject}
+              />
             </>
           )}
         </div>


### PR DESCRIPTION
### What changes did you make?

- Add back InfoSnapshotSubmit component to ProjectsPage. 

### Why did you make the changes (we will use this info to test)?

- The success modal wouldn't open after the warning snapshot submit without this component on the projectpage. Adding this back to get it working again. 

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

![Screenshot 2025-06-06 at 9 44 21 PM](https://github.com/user-attachments/assets/5ad15e63-393f-4842-b054-48d78c36371e)


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![Screenshot 2025-06-06 at 9 44 26 PM](https://github.com/user-attachments/assets/8ffdeff4-f2a6-49b5-a1cc-9bd7aa4a1b50)


</details>
