### PR TITLE
Feature flag for sidebar style

### DIFF
--- a/client/src/components/ProjectWizard/WizardSidebar/SidebarPointsPanel.jsx
+++ b/client/src/components/ProjectWizard/WizardSidebar/SidebarPointsPanel.jsx
@@ -1,4 +1,4 @@
-import React /*, { useEffect, useState } */ from "react";
+import React, { useContext /*, { useEffect, useState } */ } from "react";
 import PropTypes from "prop-types";
 import SidebarProjectLevel from "./SidebarProjectLevel";
 // import EarnedPointsMetContainer from "./EarnedPointsMetContainer";
@@ -7,6 +7,7 @@ import EarnedPointsProgress from "./EarnedPointsProgress";
 import SidebarCart from "./SidebarCart";
 import ToolTip from "../../ToolTip/ToolTip";
 import { createUseStyles } from "react-jss";
+import ConfigContext from "../../../contexts/ConfigContext";
 
 const useStyles = createUseStyles({
   resultsPanel: {
@@ -43,10 +44,12 @@ const useStyles = createUseStyles({
   }
 });
 
-const USE_PROGRESS_DIAL = false;
+//const USE_PROGRESS_DIAL = false;
 
 const SidebarPointsPanel = props => {
   const classes = useStyles();
+  const configContext = useContext(ConfigContext);
+  const useProgressDial = configContext.SIDEBAR_STYLE !== "LEGACY";
   const { rules, strategyRules, page } = props;
   let targetPointsRule = {};
   let earnedPointsRule = {};
@@ -78,7 +81,7 @@ const SidebarPointsPanel = props => {
         />
       </div>
       <hr className={classes.divider} />
-      {USE_PROGRESS_DIAL ? (
+      {useProgressDial ? (
         <div className={classes.calculationProgress}>
           <EarnedPointsProgress
             key={targetPointsRule.id}

--- a/server/db/migration/V20250717.1731__feature-flag-for-sidebar-style_2594.sql
+++ b/server/db/migration/V20250717.1731__feature-flag-for-sidebar-style_2594.sql
@@ -1,0 +1,2 @@
+INSERT Config(code, value)
+VALUES('SIDEBAR_STYLE', 'LEGACY')


### PR DESCRIPTION
- Fixes #2594

### What changes did you make?

- Implemented a feature flag to switch between two different styles of wizard Sidebar, called "LEGACY" and "DIAL"

### Why did you make the changes (we will use this info to test)?

- So the UX Research team can have different versions of the sidebar to show for user testing, and allow us to easily switch between the two styles without having to re-deploy the application by editing a value in the Config database tablse.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
