### PR TITLE
Fix accessibility error in the Create Project pages navigation buttons

### DIFF
--- a/client/src/components/Button/Button.jsx
+++ b/client/src/components/Button/Button.jsx
@@ -158,6 +158,7 @@ const Button = ({
   color = "colorDefault",
   type = "button",
   disabled = false,
+  ariaLabel = undefined,
   id
 }) => {
   const classes = useStyles({ color });
@@ -169,6 +170,7 @@ const Button = ({
       onClick={onClick}
       type={type}
       disabled={disabled}
+      aria-label={ariaLabel}
       id={id}
     >
       {children}
@@ -186,6 +188,7 @@ Button.propTypes = {
   color: PropTypes.string,
   type: PropTypes.string,
   disabled: PropTypes.bool,
+  ariaLabel: PropTypes.string,
   id: PropTypes.string
 };
 

--- a/client/src/components/Button/NavButton.jsx
+++ b/client/src/components/Button/NavButton.jsx
@@ -56,6 +56,11 @@ const NavButton = ({
       color={color}
       onClick={onClick}
       disabled={isDisabled}
+      ariaLabel={
+        navDirection === "previous"
+          ? "project creation previous page"
+          : "project creation next page"
+      }
     >
       {navDirection === "previous" ? (
         <MdChevronLeft fontSize="2em" />


### PR DESCRIPTION
- Fixes #2571 

### What changes did you make?

- I added an aria-label to the navigation buttons in the Create Project pages

### Why did you make the changes (we will use this info to test)?

- To fix an accessibility error found by the WAVE tool

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

Visually the website looks the same, but now screen readers can pick up the navigation buttons. Below I've added screenshots of what the WAVE accessibility tool picks up.

<details>
<summary>Visuals before changes are applied</summary>

<img width="626" height="285" alt="before-label" src="https://github.com/user-attachments/assets/632a7c89-cda8-4283-8fd8-8a2abb2a9701" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="611" height="256" alt="after-label" src="https://github.com/user-attachments/assets/176da5c1-7b48-47db-983b-4cd74dc98fbd" />


</details>