### PR TITLE
fix: revise text on page 2 of calc

### DIFF
--- a/server/db/migration/V20250820.1934__update_calculation_rule_names_parkcondo_sftradeschool.sql
+++ b/server/db/migration/V20250820.1934__update_calculation_rule_names_parkcondo_sftradeschool.sql
@@ -1,0 +1,7 @@
+UPDATE [CalculationRule]
+SET name = '..... Required Number of Parking Spaces'
+WHERE id = 238;
+
+UPDATE [CalculationRule]
+SET name = '..... Classroom or Assembly Area'
+WHERE id = 104;

--- a/server/db/migration/V20250820.1934__update_calculation_rule_names_parkcondo_sftradeschool.sql
+++ b/server/db/migration/V20250820.1934__update_calculation_rule_names_parkcondo_sftradeschool.sql
@@ -1,7 +1,7 @@
 UPDATE [CalculationRule]
 SET name = '..... Required Number of Parking Spaces'
-WHERE id = 238;
+WHERE id = 'PARK_CONDO' AND calculationId = 1;
 
 UPDATE [CalculationRule]
 SET name = '..... Classroom or Assembly Area'
-WHERE id = 104;
+WHERE code = 'SF_TRADE_SCHOOL' AND calculationId = 1;


### PR DESCRIPTION
- Fixes #2545 


### What changes did you make?

- Running this migration revises the text on two fields on the 2nd page of the calculator

### Why did you make the changes (we will use this info to test)?

-

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

<img width="1289" height="142" alt="Screenshot 2025-09-03 at 5 52 53 PM" src="https://github.com/user-attachments/assets/6765e689-aa54-4908-8ba2-7e3558192edb" />

<img width="1247" height="212" alt="Screenshot 2025-09-03 at 5 55 39 PM" src="https://github.com/user-attachments/assets/bd4fd1bc-2b46-4315-8569-997121500ff7" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1265" height="167" alt="Screenshot 2025-09-03 at 5 56 17 PM" src="https://github.com/user-attachments/assets/fc90b36f-78d9-459c-8839-f193b7979178" />

<img width="1253" height="216" alt="Screenshot 2025-09-03 at 5 56 30 PM" src="https://github.com/user-attachments/assets/8ed8e1fd-cc31-4f8a-92ea-2f9fcb368d42" />

</details>


### TODO for Devs
Once the PR has been approved, we have to run the migration on shared DB 