### PR TITLE
fix: universal select style matches input

### DIFF
--- a/client/src/components/UI/UniversalSelect.jsx
+++ b/client/src/components/UI/UniversalSelect.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Select from "react-select";
 import PropTypes from "prop-types";
 import classNames from "classnames";
+import { jssTheme } from "styles/theme";
 
 UniversalSelect.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
@@ -46,6 +47,18 @@ export default function UniversalSelect({
     });
   };
 
+  const setFocusStyle = state => {
+    return state.isFocused || state.menuIsOpen
+      ? {
+          border: `none`,
+          outline: `2px solid ${jssTheme.colors.secondary.linkBlue}`
+        }
+      : {
+          border: `1px solid gray`,
+          outline: "none"
+        };
+  };
+
   return (
     <Select
       className={classNames(className)}
@@ -64,13 +77,9 @@ export default function UniversalSelect({
       styles={{
         container: (provided, state) => ({
           ...provided,
-          border:
-            state.isFocused || state.menuIsOpen
-              ? "1px solid black"
-              : "1px solid gray",
+          ...setFocusStyle(state),
           boxShadow:
             state.isFocused || state.menuIsOpen ? "none" : provided.boxShadow,
-          outline: "none",
           borderRadius: "3px",
           padding: 0
         }),


### PR DESCRIPTION
- Fixes #2621

### What changes did you make?

- Changed universal select's focus styles to match inputs

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

<img width="1777" height="445" alt="Screenshot 2025-09-17 at 3 52 27 PM" src="https://github.com/user-attachments/assets/5ee755d2-46e2-43de-a4bf-29b13c3c5f6c" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1847" height="585" alt="Screenshot 2025-09-17 at 3 52 12 PM" src="https://github.com/user-attachments/assets/847b4ac1-1e3d-4481-98e4-d581c2417f03" />

</details>
