### PR TITLE
2600 Update snapshot share modal

### DIFF
--- a/client/src/components/Modals/ActionSnapshotShare.jsx
+++ b/client/src/components/Modals/ActionSnapshotShare.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { createUseStyles, useTheme } from "react-jss";
 import Button from "../Button/Button";
@@ -154,6 +154,7 @@ const emailSchema = Yup.string()
 export default function ShareSnapshotModal({ mounted, onClose, project }) {
   const theme = useTheme();
   const classes = useStyles({ theme });
+  const modalContentRef = useRef(null);
   const toast = useToast();
   const [error, setError] = useState("");
   const [page, setPage] = useState(1);
@@ -237,7 +238,10 @@ If you don't already have a [TDM Calculator](${tdmLink}) account, please set one
     if (!valid) return;
 
     await shareProject(inputValue, project);
-    toast.add("Email added.", { variant: "modal", topOffset: "8.3em" });
+    toast.add("Email added.", {
+      variant: "modal",
+      contentContainerRef: modalContentRef
+    });
     setEmailInput("");
     setIsEmailValid(false);
     setError("");
@@ -390,7 +394,8 @@ If you don't already have a [TDM Calculator](${tdmLink}) account, please set one
                       navigator.clipboard.writeText(copyMessage);
                       setIsCopied(true);
                       toast.add("Link copied to clipboard.", {
-                        variant: "modal"
+                        variant: "modal",
+                        contentContainerRef: modalContentRef
                       });
                     }}
                   >
@@ -425,7 +430,8 @@ If you don't already have a [TDM Calculator](${tdmLink}) account, please set one
                       navigator.clipboard.writeText(copyLink);
                       setIsCopied(true);
                       toast.add("Link copied to clipboard.", {
-                        variant: "modal"
+                        variant: "modal",
+                        contentContainerRef: modalContentRef
                       });
                     }}
                   >
@@ -512,6 +518,7 @@ If you don't already have a [TDM Calculator](${tdmLink}) account, please set one
   return (
     <div>
       <ModalDialog
+        ref={modalContentRef}
         mounted={mounted}
         onClose={() => {
           closeProject();

--- a/client/src/components/UI/Modal.jsx
+++ b/client/src/components/UI/Modal.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
 import Modal from "react-modal";
@@ -48,46 +48,52 @@ const modalStyleDefaultOverrides = {
   }
 };
 
-export default function ModalDialog({
-  mounted,
-  children,
-  onClose,
-  // initialFocus,
-  omitCloseBox = false,
-  underlayClickExits = false,
-  escapeExits = true,
-  title = "Title Text"
-}) {
-  const classes = useStyles();
+const ModalDialog = forwardRef(
+  (
+    {
+      mounted,
+      children,
+      onClose,
+      omitCloseBox = false,
+      underlayClickExits = false,
+      escapeExits = true,
+      title = "Title Text"
+    },
+    ref
+  ) => {
+    const classes = useStyles();
 
-  return (
-    <Modal
-      isOpen={mounted}
-      onRequestClose={() => onClose()}
-      shouldCloseOnOverlayClick={underlayClickExits}
-      shouldCloseOnEscape={escapeExits}
-      contentLabel={title}
-      style={modalStyleDefaultOverrides}
-      appElement={document.getElementById("root") || undefined}
-      // initialFocus={initialFocus || null}
-    >
-      <div>
-        {omitCloseBox ? null : (
-          <div className={classes.buttonFlexBox}>
-            <button
-              onClick={onClose}
-              className={classes.closeButton}
-              aria-label={`Close ${title} modal`}
-            >
-              <MdClose />
-            </button>
-          </div>
-        )}
-        {children}
-      </div>
-    </Modal>
-  );
-}
+    return (
+      <Modal
+        isOpen={mounted}
+        onRequestClose={() => onClose()}
+        shouldCloseOnOverlayClick={underlayClickExits}
+        shouldCloseOnEscape={escapeExits}
+        contentLabel={title}
+        style={modalStyleDefaultOverrides}
+        appElement={document.getElementById("root") || undefined}
+        // initialFocus={initialFocus || null}
+      >
+        <div ref={ref} style={{ position: "relative" }}>
+          {omitCloseBox ? null : (
+            <div className={classes.buttonFlexBox}>
+              <button
+                onClick={onClose}
+                className={classes.closeButton}
+                aria-label={`Close ${title} modal`}
+              >
+                <MdClose />
+              </button>
+            </div>
+          )}
+          {children}
+        </div>
+      </Modal>
+    );
+  }
+);
+
+ModalDialog.displayName = "ModalDialog";
 
 ModalDialog.propTypes = {
   mounted: PropTypes.bool,
@@ -99,3 +105,5 @@ ModalDialog.propTypes = {
   escapeExits: PropTypes.bool,
   title: PropTypes.string
 };
+
+export default ModalDialog;

--- a/client/src/contexts/Toast/Toast.jsx
+++ b/client/src/contexts/Toast/Toast.jsx
@@ -36,7 +36,7 @@ const useStyles = createUseStyles({
   }
 });
 
-const Toast = ({ children, remove, variant, topOffset }) => {
+const Toast = ({ children, remove, variant }) => {
   const classes = useStyles();
   const removeRef = useRef();
   removeRef.current = remove;
@@ -47,14 +47,17 @@ const Toast = ({ children, remove, variant, topOffset }) => {
     return () => clearTimeout(id);
   }, []);
 
+  const isModal = variant === "modal";
+
   return (
     <div
       className={classes.toast}
       style={
-        variant === "modal"
+        isModal
           ? {
-              top: topOffset || "2.5em",
-              left: "54%",
+              position: "absolute",
+              top: "-2em",
+              left: "50%",
               right: "auto",
               bottom: "auto",
               transform: "translateX(-50%)",
@@ -76,7 +79,6 @@ Toast.propTypes = {
   children: PropTypes.string,
   remove: PropTypes.func.isRequired,
   variant: PropTypes.oneOf(["default", "modal"]),
-  topOffset: PropTypes.string,
   sidebarWidth: PropTypes.number
 };
 

--- a/client/src/contexts/Toast/withToastProvider.jsx
+++ b/client/src/contexts/Toast/withToastProvider.jsx
@@ -41,25 +41,25 @@ const withToastProvider = Component => {
     return (
       <ToastContext.Provider value={{ add, remove }}>
         <Component {...props} />
-        {createPortal(
-          <div className={classes.toast}>
-            {toasts.map(t => (
+        {toasts.map(t => {
+          const portalTarget =
+            t.contentContainerRef?.current ||
+            contentContainer ||
+            appContainer ||
+            document.body;
+
+          return createPortal(
+            <div className={classes.toast} key={t.id}>
               <Toast
-                key={t.id}
                 remove={() => remove(t.id)}
                 variant={t.variant || "default"}
-                topOffset={t.topOffset}
               >
                 {t.content}
               </Toast>
-            ))}
-          </div>,
-          contentContainer
-            ? contentContainer
-            : appContainer
-              ? appContainer
-              : document.body
-        )}
+            </div>,
+            portalTarget
+          );
+        })}
       </ToastContext.Provider>
     );
   };


### PR DESCRIPTION
- Fixes #2600 

### What changes did you make?

First modal page
- Changed camera icon to ios share icon
- Only show “People with viewing permission” header if emails added
- Simplified message to Enter at least one email to give access to this snapshot
- Added + button to add email (still allow hitting enter to add)
- Added Cancel button
- Added error message if email is invalid
- Added toast to confirm when email is added to list to share

Second modal page
- Changed camera icon to ! info icon
- Added message that users must send email to actually share the link
- Added toast to confirm when link is copied to clipboard

### Why did you make the changes (we will use this info to test)?

- We need to implement changes in Share Snapshot modal to add a Cancel button, clearer email entry instructions, proper input indicators, and notes explaining that no automatic notification is sent, so that the process will be more intutitive.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

<img width="702" height="640" alt="Screen Shot 2025-09-17 at 4 51 29 PM" src="https://github.com/user-attachments/assets/50358cc8-6f6c-401e-94b9-58d689b42f6a" />

<img width="701" height="591" alt="Screen Shot 2025-09-17 at 4 51 44 PM" src="https://github.com/user-attachments/assets/0985e2f1-e99d-40f0-8ead-65062c1f89d2" />

<img width="697" height="660" alt="Screen Shot 2025-09-17 at 4 52 03 PM" src="https://github.com/user-attachments/assets/5c383989-f5ce-4017-999d-4c7239be99fa" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="698" height="602" alt="Screenshot 2025-10-28 at 2 31 27 PM" src="https://github.com/user-attachments/assets/68a0aa0e-82aa-481a-8d1b-8a264344a663" />

<img width="698" height="587" alt="Screenshot 2025-10-28 at 2 31 45 PM" src="https://github.com/user-attachments/assets/340fd193-acf5-4064-846c-8be565fe56c8" />

<img width="709" height="590" alt="Screenshot 2025-10-28 at 2 32 02 PM" src="https://github.com/user-attachments/assets/a6c88a56-8a5c-4cec-9d5e-2bf1659f889f" />

<img width="703" height="770" alt="Screenshot 2025-10-28 at 2 32 34 PM" src="https://github.com/user-attachments/assets/faaec570-ac79-4620-ab40-520f47d6c266" />

</details>
