### PR TITLE
Hide edit icon non admin

### DIFF
--- a/client/src/components/ProjectWizard/Common/RuleLabel.jsx
+++ b/client/src/components/ProjectWizard/Common/RuleLabel.jsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import { MdLink } from "react-icons/md";
 import { createUseStyles, useTheme } from "react-jss";
 import clsx from "clsx";
 import { MdInfo, MdAddCircle } from "react-icons/md";
+import UserContext from "contexts/UserContext";
 
 const useStyles = createUseStyles(theme => ({
   labelWrapper: {
@@ -94,6 +95,8 @@ const RuleLabel = ({
   const classes = useStyles(theme);
   const requiredStyle = required && classes.requiredInputLabel;
   const disabledStyle = !display;
+  const userContext = useContext(UserContext);
+  const isAdmin = !!userContext?.account?.isAdmin;
 
   const descriptionHandler = e => {
     e.preventDefault();
@@ -212,7 +215,7 @@ const RuleLabel = ({
           style={showDescription ? { visibility: "visible" } : {}}
           onClick={addDescriptionHandler}
         >
-          <MdAddCircle className={classes.infoIcon} />
+          {isAdmin ? <MdAddCircle className={classes.infoIcon} /> : null }
         </span>
       )}
     </div>

--- a/client/src/components/ProjectWizard/Common/RuleLabel.jsx
+++ b/client/src/components/ProjectWizard/Common/RuleLabel.jsx
@@ -215,7 +215,7 @@ const RuleLabel = ({
           style={showDescription ? { visibility: "visible" } : {}}
           onClick={addDescriptionHandler}
         >
-          {isAdmin ? <MdAddCircle className={classes.infoIcon} /> : null }
+          {isAdmin ? <MdAddCircle className={classes.infoIcon} /> : null}
         </span>
       )}
     </div>

--- a/client/src/components/ToolTip/AccordionToolTip.jsx
+++ b/client/src/components/ToolTip/AccordionToolTip.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import { createUseStyles, useTheme } from "react-jss";
 import clsx from "clsx";
@@ -11,6 +11,7 @@ import "react-quill/dist/quill.snow.css";
 import "../../styles/AdminQuill.scss";
 import WarningAdminNotesUnsavedChanges from "../Modals/WarningAdminNotesUnsavedChanges";
 import useTooltipEditor from "../../hooks/useTooltipEditor";
+import UserContext from "contexts/UserContext";
 
 const useStyles = createUseStyles(theme => ({
   accordionTooltipLabel: {
@@ -109,6 +110,8 @@ const AccordionToolTip = ({
 }) => {
   const theme = useTheme();
   const classes = useStyles(theme);
+  const userContext = useContext(UserContext);
+  const isAdmin = !!userContext?.account?.isAdmin;
 
   const {
     isEditing,
@@ -153,7 +156,7 @@ const AccordionToolTip = ({
             content={newDescription}
           />
           <div className={clsx(classes.editButton)} onClick={startEditing}>
-            <MdEdit />
+            {isAdmin ? <MdEdit />: null}
           </div>
         </div>
       ) : (
@@ -171,7 +174,7 @@ const AccordionToolTip = ({
             content={newDescription}
           />
           <div className={clsx(classes.editButton)} onClick={startEditing}>
-            <MdEdit />
+            {isAdmin ? <MdEdit />: null}
           </div>
         </div>
       )}

--- a/client/src/components/ToolTip/AccordionToolTip.jsx
+++ b/client/src/components/ToolTip/AccordionToolTip.jsx
@@ -156,7 +156,7 @@ const AccordionToolTip = ({
             content={newDescription}
           />
           <div className={clsx(classes.editButton)} onClick={startEditing}>
-            {isAdmin ? <MdEdit />: null}
+            {isAdmin ? <MdEdit /> : null}
           </div>
         </div>
       ) : (
@@ -174,7 +174,7 @@ const AccordionToolTip = ({
             content={newDescription}
           />
           <div className={clsx(classes.editButton)} onClick={startEditing}>
-            {isAdmin ? <MdEdit />: null}
+            {isAdmin ? <MdEdit /> : null}
           </div>
         </div>
       )}


### PR DESCRIPTION
- Fixes #2647 

### What changes did you make?

-Modify the code to only show these add icon and edit button if the user has the admin role.

### Why did you make the changes (we will use this info to test)?

- We only want the admin to be able to make changes to the tooltip. Other users shouldn't have access to this. 

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="782" height="213" alt="490297780-58b644f1-61f5-4e81-8e87-a88f0e7a4c51" src="https://github.com/user-attachments/assets/7d459741-b370-47b7-8b87-ddd289a1ce61" />
<img width="1175" height="399" alt="add_button" src="https://github.com/user-attachments/assets/6219ed79-dbbe-40e4-8f00-774388a7324e" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
**Admin Role With Add Button**
<img width="1175" height="399" alt="add_button" src="https://github.com/user-attachments/assets/ca409642-bbc1-4952-9481-126b70bfe342" />

**User Role Without Add Button** 
<img width="2460" height="754" alt="Screenshot 2025-09-22 at 1 52 48 PM" src="https://github.com/user-attachments/assets/ed4dfb49-762c-4b72-99f4-c0d1f5e309dd" />

**User Role Without Edit Button**
<img width="2497" height="900" alt="Screenshot 2025-09-22 at 1 51 03 PM" src="https://github.com/user-attachments/assets/bf2377b5-516b-494c-8b2e-d1cd2749b306" />

**Admin Role With Edit Button**
<img width="1233" height="363" alt="Screenshot 2025-09-22 at 1 53 25 PM" src="https://github.com/user-attachments/assets/713ea087-1c09-42f4-b03e-28a515e4b69f" />

</details>
