### PR TITLE
Add project id calc summary

### DIFF
--- a/client/src/components/PdfPrint/PdfPrint.jsx
+++ b/client/src/components/PdfPrint/PdfPrint.jsx
@@ -15,6 +15,7 @@ import ProjectInfoList from "../ProjectWizard/WizardPages/ProjectSummary/Project
 import PdfResult from "./PdfResult";
 import PdfFooter from "./PdfFooter";
 import logo from "../../images/ladot.png";
+import { formatId } from "helpers/util";
 
 const useStyles = createUseStyles({
   Pdf: {
@@ -87,7 +88,7 @@ const useStyles = createUseStyles({
     paddingTop: "20px",
     paddingLeft: "12px",
     display: "grid",
-    gridTemplateColumns: "2.5fr 1fr",
+    gridTemplateColumns: "2fr 1fr",
     gap: "1.1em",
     maxWidth: "100%",
     minHeight: "55px"
@@ -129,6 +130,10 @@ const useStyles = createUseStyles({
     logoContainer: {
       justifySelf: "start"
     }
+  },
+  projectIdRight: {
+    gridColumn: "2",
+    whiteSpace: "nowrap"
   }
 });
 
@@ -154,6 +159,7 @@ export const PdfPrint = forwardRef((props, ref) => {
   const caseNumberPlanning = getRule(rules, "CASE_NO_PLANNING");
   const parcelNumbers = getRule(rules, "APN");
   const versionNumber = getRule(rules, "VERSION_NO");
+  const formattedId = project?.id ? formatId(project.id) : null;
 
   const measureRules =
     rules &&
@@ -245,6 +251,14 @@ export const PdfPrint = forwardRef((props, ref) => {
                       rule={caseNumberLADOT}
                     />
                   )}
+                  <div className={classes.projectIdRight}>
+                    {formattedId && (
+                      <ProjectInfo
+                        name={"Project Id #"}
+                        rule={{ value: formattedId }}
+                      />
+                    )}
+                  </div>
                 </div>
               </section>
               <section className={classes.categoryContainer}>

--- a/client/src/components/ProjectWizard/Common/RuleLabel.jsx
+++ b/client/src/components/ProjectWizard/Common/RuleLabel.jsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import { MdLink } from "react-icons/md";
 import { createUseStyles, useTheme } from "react-jss";
 import clsx from "clsx";
 import { MdInfo, MdAddCircle } from "react-icons/md";
+import UserContext from "contexts/UserContext";
 
 const useStyles = createUseStyles(theme => ({
   labelWrapper: {
@@ -94,6 +95,8 @@ const RuleLabel = ({
   const classes = useStyles(theme);
   const requiredStyle = required && classes.requiredInputLabel;
   const disabledStyle = !display;
+  const userContext = useContext(UserContext);
+  const isAdmin = !!userContext?.account?.isAdmin;
 
   const descriptionHandler = e => {
     e.preventDefault();
@@ -212,7 +215,7 @@ const RuleLabel = ({
           style={showDescription ? { visibility: "visible" } : {}}
           onClick={addDescriptionHandler}
         >
-          <MdAddCircle className={classes.infoIcon} />
+          {isAdmin ? <MdAddCircle className={classes.infoIcon} /> : null }
         </span>
       )}
     </div>

--- a/client/src/components/ProjectWizard/Common/RuleLabel.jsx
+++ b/client/src/components/ProjectWizard/Common/RuleLabel.jsx
@@ -215,7 +215,7 @@ const RuleLabel = ({
           style={showDescription ? { visibility: "visible" } : {}}
           onClick={addDescriptionHandler}
         >
-          {isAdmin ? <MdAddCircle className={classes.infoIcon} /> : null }
+          {isAdmin ? <MdAddCircle className={classes.infoIcon} /> : null}
         </span>
       )}
     </div>

--- a/client/src/components/ProjectWizard/Common/RuleLabel.jsx
+++ b/client/src/components/ProjectWizard/Common/RuleLabel.jsx
@@ -25,9 +25,7 @@ const useStyles = createUseStyles(theme => ({
     "&:hover $iconContainer": {
       visibility: "visible"
     },
-    "&:hover": {
-      cursor: "pointer"
-    }
+    cursor: props => (props.isAdmin ? "pointer" : "default")
   },
   tooltipLabel: {
     flexGrow: "1",
@@ -210,13 +208,14 @@ const RuleLabel = ({
           <MdInfo className={classes.infoIcon} />
         </span>
       ) : (
-        <span
-          className={clsx("fa-layers fa-fw", classes.iconContainer)}
-          style={showDescription ? { visibility: "visible" } : {}}
-          onClick={addDescriptionHandler}
-        >
-          {isAdmin ? <MdAddCircle className={classes.infoIcon} /> : null}
-        </span>
+        isAdmin && (
+          <span
+            className={clsx("fa-layers fa-fw", classes.iconContainer)}
+            onClick={addDescriptionHandler}
+          >
+            <MdAddCircle className={classes.infoIcon} />
+          </span>
+        )
       )}
     </div>
   );

--- a/client/src/components/ProjectWizard/Common/RuleLabel.jsx
+++ b/client/src/components/ProjectWizard/Common/RuleLabel.jsx
@@ -14,9 +14,11 @@ const useStyles = createUseStyles(theme => ({
     "&:hover $iconContainer": {
       visibility: "visible"
     },
-    "&:hover": {
-      cursor: "pointer"
-    }
+    cursor: props =>
+      props.isAdmin || props.description ? "pointer" : "default"
+    // "&:hover": {
+    //   cursor: "pointer"
+    // }
   },
   labelWrapperWithoutDesc: {
     flexGrow: "1",
@@ -25,7 +27,8 @@ const useStyles = createUseStyles(theme => ({
     "&:hover $iconContainer": {
       visibility: "visible"
     },
-    cursor: props => (props.isAdmin ? "pointer" : "default")
+    cursor: props =>
+      props.isAdmin || props.description ? "pointer" : "default"
   },
   tooltipLabel: {
     flexGrow: "1",
@@ -90,11 +93,11 @@ const RuleLabel = ({
   setIsEditing
 }) => {
   const theme = useTheme();
-  const classes = useStyles(theme);
-  const requiredStyle = required && classes.requiredInputLabel;
-  const disabledStyle = !display;
   const userContext = useContext(UserContext);
   const isAdmin = !!userContext?.account?.isAdmin;
+  const classes = useStyles({ theme, description, isAdmin });
+  const requiredStyle = required && classes.requiredInputLabel;
+  const disabledStyle = !display;
 
   const descriptionHandler = e => {
     e.preventDefault();

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoContainer.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoContainer.jsx
@@ -4,6 +4,8 @@ import { createUseStyles } from "react-jss";
 import ProjectInfo from "./ProjectInfo";
 import { getRule } from "../../helpers";
 import ProjectInfoList from "./ProjectInfoList";
+import { useParams } from "react-router-dom";
+import { formatId } from "helpers/util";
 
 const useStyles = createUseStyles({
   projectInfoContainer: {
@@ -28,9 +30,9 @@ const useStyles = createUseStyles({
   projectInfoDetailsContainer: {
     paddingTop: "6px",
     paddingLeft: "12px",
-    display: "flex",
-    flexDirection: "row",
-    flexWrap: "wrap",
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr",
+    columnGap: "2rem",
     maxWidth: "100%",
     minHeight: "55px",
     rowGap: "1.1rem"
@@ -39,6 +41,9 @@ const useStyles = createUseStyles({
     margin: ".7em 0",
     border: "0",
     borderTop: "1px solid #E7EBF0"
+  },
+  projectIdRight: {
+    gridColumn: "2"
   }
 });
 
@@ -53,6 +58,9 @@ const ProjectInfoContainer = props => {
   const caseNumberPlanning = getRule(rules, "CASE_NO_PLANNING");
   const parcelNumbers = getRule(rules, "APN");
   const versionNumber = getRule(rules, "VERSION_NO");
+
+  const params = useParams();
+  const projectID = formatId(Number(params.projectId));
 
   return (
     <div className={classes.projectInfoContainer}>
@@ -77,6 +85,11 @@ const ProjectInfoContainer = props => {
         {caseNumberLADOT && (
           <ProjectInfo name={caseNumberLADOT.name} rule={caseNumberLADOT} />
         )}
+        <div className={classes.projectIdRight}>
+          {projectID && (
+            <ProjectInfo name="Project ID #" rule={{ value: projectID }} />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoContainer.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoContainer.jsx
@@ -60,7 +60,9 @@ const ProjectInfoContainer = props => {
   const versionNumber = getRule(rules, "VERSION_NO");
 
   const params = useParams();
-  const projectID = formatId(Number(params.projectId));
+  const projectID = params?.projectId
+    ? formatId(Number(params.projectId))
+    : null;
 
   return (
     <div className={classes.projectInfoContainer}>

--- a/client/src/components/ToolTip/AccordionToolTip.jsx
+++ b/client/src/components/ToolTip/AccordionToolTip.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import { createUseStyles, useTheme } from "react-jss";
 import clsx from "clsx";
@@ -11,6 +11,7 @@ import "react-quill/dist/quill.snow.css";
 import "../../styles/AdminQuill.scss";
 import WarningAdminNotesUnsavedChanges from "../Modals/WarningAdminNotesUnsavedChanges";
 import useTooltipEditor from "../../hooks/useTooltipEditor";
+import UserContext from "contexts/UserContext";
 
 const useStyles = createUseStyles(theme => ({
   accordionTooltipLabel: {
@@ -109,6 +110,8 @@ const AccordionToolTip = ({
 }) => {
   const theme = useTheme();
   const classes = useStyles(theme);
+  const userContext = useContext(UserContext);
+  const isAdmin = !!userContext?.account?.isAdmin;
 
   const {
     isEditing,
@@ -153,7 +156,7 @@ const AccordionToolTip = ({
             content={newDescription}
           />
           <div className={clsx(classes.editButton)} onClick={startEditing}>
-            <MdEdit />
+            {isAdmin ? <MdEdit />: null}
           </div>
         </div>
       ) : (
@@ -171,7 +174,7 @@ const AccordionToolTip = ({
             content={newDescription}
           />
           <div className={clsx(classes.editButton)} onClick={startEditing}>
-            <MdEdit />
+            {isAdmin ? <MdEdit />: null}
           </div>
         </div>
       )}

--- a/client/src/components/ToolTip/AccordionToolTip.jsx
+++ b/client/src/components/ToolTip/AccordionToolTip.jsx
@@ -156,7 +156,7 @@ const AccordionToolTip = ({
             content={newDescription}
           />
           <div className={clsx(classes.editButton)} onClick={startEditing}>
-            {isAdmin ? <MdEdit />: null}
+            {isAdmin ? <MdEdit /> : null}
           </div>
         </div>
       ) : (
@@ -174,7 +174,7 @@ const AccordionToolTip = ({
             content={newDescription}
           />
           <div className={clsx(classes.editButton)} onClick={startEditing}>
-            {isAdmin ? <MdEdit />: null}
+            {isAdmin ? <MdEdit /> : null}
           </div>
         </div>
       )}

--- a/client/src/hooks/useTooltipEditor.js
+++ b/client/src/hooks/useTooltipEditor.js
@@ -52,7 +52,11 @@ const useTooltipEditor = (
     setNewDescription(description);
     setIsEditing(false);
     setHasUnsavedChanges(false);
-  }, [description]);
+
+    if (onEditDescription) {
+      onEditDescription(description);
+    }
+  }, [description, onEditDescription]);
 
   const handleModalClose = useCallback(() => {
     if (hasUnsavedChanges) {


### PR DESCRIPTION
- Fixes #2654 

### What changes did you make?

- Add a Project ID field to Page 5 (Calculation Summary Page)  and the Print Summary PDF It appears last in sequence, directly after the “LADOT Case #” in the section above Project Details (00000-00000) Project IDs are 10 digits

### Why did you make the changes (we will use this info to test)?

- So that users can know the difference between versions of a project, even if they don't have a alt number.

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="1193" height="582" alt="Screenshot 2025-09-30 at 4 11 56 PM" src="https://github.com/user-attachments/assets/af0cbb4b-6257-4c3d-8224-84606326d746" />
<img width="1053" height="893" alt="Screenshot 2025-09-30 at 4 12 08 PM" src="https://github.com/user-attachments/assets/8dca980d-d10e-4ba3-80e4-1cdb96d4269e" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
<img width="2104" height="551" alt="Screenshot 2025-09-30 at 4 14 22 PM" src="https://github.com/user-attachments/assets/c0c5d30a-2f4c-423c-b1b6-a1d746cd96b7" />

<img width="548" height="205" alt="Screenshot 2025-09-30 at 4 15 42 PM" src="https://github.com/user-attachments/assets/aa6bd4e3-6c82-4cb9-84ec-289a6b30bff0" />

</details>
