### PR TITLE
FAQ expanded container border color update

### DIFF
--- a/client/src/components/Faq/Faq.jsx
+++ b/client/src/components/Faq/Faq.jsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useState } from "react";
 import PropTypes from "prop-types";
-import { createUseStyles } from "react-jss";
+import { createUseStyles, useTheme } from "react-jss";
 
 import { Question } from "./Question";
 import { FaqButtonContainer } from "./FaqButtonContainer";
 import { Answer } from "./Answer";
 
-const useStyles = createUseStyles({
+const useStyles = createUseStyles(theme => ({
   faqContainer: {
     display: "flex",
     flexDirection: "column"
@@ -24,7 +24,7 @@ const useStyles = createUseStyles({
     alignItems: "top",
     minHeight: "2em",
     padding: 4,
-    border: "2px solid #a6c439"
+    border: `2px solid ${theme.colors.secondary.linkBlue}`
   },
   faqPlusMinusIcons: {
     display: "flex",
@@ -40,7 +40,7 @@ const useStyles = createUseStyles({
     marginRight: "0.5em",
     flex: "0 0 auto"
   }
-});
+}));
 
 const Faq = props => {
   const {
@@ -52,7 +52,8 @@ const Faq = props => {
     handleEditFAQ,
     handleDeleteFAQ
   } = props;
-  const classes = useStyles();
+  const theme = useTheme();
+  const classes = useStyles(theme);
   const [answer, setAnswer] = useState(faq.answer);
   const [question, setQuestion] = useState(faq.question);
   const [isEditAnswer, setIsEditAnswer] = useState(false);


### PR DESCRIPTION
- Fixes #2622 

### What changes did you make?

- Update `expandFlexContainer` border style to use hyperlink blue 

### Why did you make the changes (we will use this info to test)?

- Having focus color consistency across the site.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1467" height="818" alt="expanded faq with green border" src="https://github.com/user-attachments/assets/d67d0556-ee38-4519-ba68-41f9d5554d22" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1452" height="780" alt="expanded faq with link blue color" src="https://github.com/user-attachments/assets/0580cc56-3150-4326-95de-9c5fefc8cd10" />

</details>
