### PR TITLE
fix: do not clear checked projects on page change

### DIFF
--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -407,9 +407,6 @@ const ProjectsPage = ({ contentContainerRef }) => {
     } else if (pageNumber === "right" && currentPage < newHighestPage) {
       setCurrentPage(currentPage + 1);
     }
-    // uncheck Projects on page change
-    setCheckedProjectIds([]);
-    setSelectAllChecked(false);
   };
 
   const handleCopyModalOpen = project => {


### PR DESCRIPTION
- Fixes #2590 

### What changes did you make?

- Revert the code that clears checked projects on page change

### Why did you make the changes (we will use this info to test)?

- When a user searched a string and checked all projects matching that string then cleared the search -- the checked projects should still be checked.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)


<details>
<summary>Visuals before changes are applied</summary>

<img width="1473" height="581" alt="1" src="https://github.com/user-attachments/assets/1cfb36f5-f1e1-4d56-9cb4-3d8d343dacc0" />
<img width="1376" height="527" alt="2" src="https://github.com/user-attachments/assets/d85e2e8b-1e10-4590-8eda-ee48ff9c051a" />
<img width="1424" height="866" alt="3" src="https://github.com/user-attachments/assets/0c26af65-eee9-4783-a91a-7d699a0e1c57" />
<img width="1433" height="907" alt="4" src="https://github.com/user-attachments/assets/7bc4cc17-ec23-4f39-920c-e43c3a641ca6" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1338" height="525" alt="1" src="https://github.com/user-attachments/assets/7d2dcfd0-cea4-4775-8042-ea5708e8f21f" />
<img width="1384" height="847" alt="2" src="https://github.com/user-attachments/assets/6667e401-524c-4acc-8646-ae33a2bd8cf9" />
<img width="1196" height="869" alt="3" src="https://github.com/user-attachments/assets/78dc045d-e801-4312-90d1-cf2e859141d8" />

</details>


### Notes:
- unsure if this is the final iteration of this, can be discussed during the meeting. But this first change does fix the bug detailed in the issue above. So as long as the code is approved, I say we merge this while we decide the next steps on this feature (e.g. a better way to clear selected projects)
