### PR TITLE
Change Level Column filtering to use stringList popup for filtering

### DIFF
--- a/client/src/components/Submissions/ManageSubmissionsPage.jsx
+++ b/client/src/components/Submissions/ManageSubmissionsPage.jsx
@@ -378,7 +378,7 @@ const ManageSubmissions = ({ contentContainerRef }) => {
     {
       id: "projectLevel",
       label: "Level",
-      popupType: "number",
+      popupType: "stringList",
       colWidth: "8rem"
     },
     { id: "droName", label: "DRO", popupType: "stringList", colWidth: "10rem" },

--- a/client/src/components/Submissions/SubmissionsPage.jsx
+++ b/client/src/components/Submissions/SubmissionsPage.jsx
@@ -358,7 +358,7 @@ const SubmissionsPage = ({ contentContainerRef }) => {
     {
       id: "projectLevel",
       label: "Level",
-      popupType: "number",
+      popupType: "stringList",
       colWidth: "96px"
     },
     { id: "droName", label: "DRO", popupType: "stringList", colWidth: "160px" },


### PR DESCRIPTION
- Fixes #2727
### What changes did you make?

- Changed Level colum on the Submissions and Manage Submissions Pages to use the popup filter "stringList", so it does not include the search box

### Why did you make the changes (we will use this info to test)?

- See issue

### Issue-Specific User Account

Submissions Page is only visible to non-admins
Manage Submissions Page is only visible to admins


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="306" height="397" alt="image" src="https://github.com/user-attachments/assets/a1c02197-9219-412e-ac26-9cb8e7ac62f6" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="265" height="297" alt="image" src="https://github.com/user-attachments/assets/8a2e6851-f647-49ec-9a44-b21fc563c94c" />

</details>
