### PR TITLE
Add label with sr-only class to search input to ensure screen reader accessibility (Submission Page)

### DIFF
--- a/client/src/components/Submissions/SubmissionsPage.jsx
+++ b/client/src/components/Submissions/SubmissionsPage.jsx
@@ -475,6 +475,9 @@ const SubmissionsPage = ({ contentContainerRef }) => {
               }}
             >
               <div className={classes.searchBarWrapper}>
+                <label htmlFor="filterText" className="sr-only">
+                  Search Project By Name, Address, Description, Alt#
+                </label>
                 <input
                   className={classes.searchBar}
                   type="search"


### PR DESCRIPTION
- Partial completion of #2714

### What changes did you make?

Add label with sr-only class to search input in submissions page. This addresses WCAG 2.2 accessibility requirements for form inputs.

### Why did you make the changes (we will use this info to test)?

-Addresses WCAG 2.2 accessibility requirements for missing form input label. 


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="2634" height="389" alt="Screenshot 2025-11-09 at 6 16 37 PM" src="https://github.com/user-attachments/assets/1acaaca2-9c36-4bd4-8be3-5e2996553fb6" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="2535" height="378" alt="Screenshot 2025-11-09 at 6 17 23 PM" src="https://github.com/user-attachments/assets/13f91098-5024-4826-9038-bbd95a58d480" />

</details>
