### PR TITLE
2701 WAVE fixes - Forgot Password page

### DIFF
--- a/client/src/components/Authorization/SendEmailForm.jsx
+++ b/client/src/components/Authorization/SendEmailForm.jsx
@@ -76,10 +76,14 @@ const SendEmailForm = ({ label, submitted, handleSubmit }) => {
           return (
             <Form>
               <div className={classes.fieldGroup}>
+                <label htmlFor="email" className="sr-only">
+                  Enter Registered/Updated Email
+                </label>
                 <Field
                   type="email"
                   innerRef={focusRef}
                   value={values.email}
+                  id="email"
                   name="email"
                   placeholder="Registered/Updated Email"
                   className={clsx(


### PR DESCRIPTION
- Fixes #2701 

### What changes did you make?

- added label to input field with `sr-only` class
- change subheading text from h3 element to h2

### Why did you make the changes (we will use this info to test)?

- to fix the WAVE error & alert for this page

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

<img width="227" height="65" alt="Screenshot 2025-11-12 at 7 24 23 PM" src="https://github.com/user-attachments/assets/554728e8-ffa5-499f-92e0-c7dc2c3ccfe2" />
<img width="247" height="61" alt="Screenshot 2025-11-12 at 7 24 37 PM" src="https://github.com/user-attachments/assets/a1cc23b8-d542-43cf-aebd-f02c557b4624" />
<img width="1201" height="548" alt="Screenshot 2025-11-12 at 7 24 48 PM" src="https://github.com/user-attachments/assets/a9549b2e-699e-489c-a632-32f9b91a4cc2" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1379" height="524" alt="Screenshot 2025-11-12 at 7 25 14 PM" src="https://github.com/user-attachments/assets/eb96f8bf-d025-4467-b44b-853d921047fa" />

</details>
