### PR TITLE
2719 archived accounts fix missing form label

### DIFF
--- a/client/src/components/ArchiveDelete/RolesArchive.jsx
+++ b/client/src/components/ArchiveDelete/RolesArchive.jsx
@@ -218,7 +218,7 @@ const RolesArchive = ({ contentContainerRef }) => {
           </Link>
         </div>
         <div className={classes.searchBarWrapper}>
-          <label htmlFor="searchString" className={`${classes.textInputLabel}`}>
+          <label htmlFor="searchString" className={classes.textInputLabel}>
             Search for user:
           </label>
           <input


### PR DESCRIPTION
- Fixes #2719 Missing form label

### What changes did you make?

- Fixed a WAVE accessibility error for a missing form label on the search input. Added a id="searchString" on the input to associate the label. Initially, I used the sr-only class on the label, which hid the 'search by user' text visually. Then I removed the sr-only so the label is visible while maintaining accessibility, Since the <label> with htmlFor is already accessible to screen readers.

### Why did you make the changes (we will use this info to test)?

- To be WCAG 2.2 compliance

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of

[[image](https://github.com/hackforla/tdm-calculator/compare/link)](link)

to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="1706" height="505" alt="Screenshot 2025-11-17 at 7 14 49 PM" src="https://github.com/user-attachments/assets/6fce3cfd-8457-4247-ba72-851f378778c5" />

</details>

<details>
<summary>Visuals after changes are applied</summary>

<img width="3008" height="866" alt="Screenshot 2025-11-18 at 11 17 02 AM" src="https://github.com/user-attachments/assets/ab78d64a-2797-49b5-b905-5adc3d26cdaf" />

</details>