### PR TITLE
WAVE  - Manage Submissions - Skipped Heading Level Alert Fix

### DIFF
--- a/client/src/components/Modals/ActionProjectAdminNotes.jsx
+++ b/client/src/components/Modals/ActionProjectAdminNotes.jsx
@@ -110,9 +110,9 @@ const AdminNotesModal = ({
             style={{ borderTop: "1px solid #ccc", margin: "8px 0px 0px 0px" }}
           />
           <div className={classes.textareaWrapper}>
-            <h3 className={classes.subHeader} style={{ fontWeight: "normal" }}>
+            <h2 className={classes.subHeader} style={{ fontWeight: "normal" }}>
               Note
-            </h3>
+            </h2>
             <textarea
               style={{
                 border: "1px solid #0075FF",
@@ -169,9 +169,9 @@ const AdminNotesModal = ({
             style={{ borderTop: "1px solid #ccc", margin: "8px 0px 0px 0px" }}
           />
           <div className={classes.textareaWrapper}>
-            <h3 className={classes.subHeader} style={{ fontWeight: "normal" }}>
+            <h2 className={classes.subHeader} style={{ fontWeight: "normal" }}>
               Note
-            </h3>
+            </h2>
             <textarea
               type="text"
               value={adminNotes}


### PR DESCRIPTION
- Fixes #2705 - address skipped heading level alert

### What changes did you make?

- changed header of Note from h3 to h2

### Why did you make the changes (we will use this info to test)?

- fixes skipped heading level alert found when running the WAVE Tool on manage submissions page

### Issue-Specific User Account

logged in as an admin to view notes of a snapshot in manage submission table 

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)
<img width="679" height="495" alt="Screenshot 2025-11-18 at 12 41 31 PM" src="https://github.com/user-attachments/assets/c09c614e-9b32-4dae-8892-9c97c08e2616" />
<img width="692" height="472" alt="Screenshot 2025-11-18 at 12 37 18 PM" src="https://github.com/user-attachments/assets/cd765b48-988c-482e-9df1-1488994d3dae" />
</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)
<img width="683" height="483" alt="Screenshot 2025-11-18 at 12 41 46 PM" src="https://github.com/user-attachments/assets/7bf12076-3d42-45f8-a1f7-9d449d3033aa" />
<img width="691" height="485" alt="Screenshot 2025-11-18 at 12 37 08 PM" src="https://github.com/user-attachments/assets/3fb006ad-0881-4a03-8643-a87b9421d0db" />


</details>
