### PR TITLE
2748 change share snapshot icon button behavior

### DIFF
--- a/client/src/components/Modals/ActionSnapshotShare.jsx
+++ b/client/src/components/Modals/ActionSnapshotShare.jsx
@@ -311,11 +311,11 @@ If you don't already have a [TDM Calculator](${tdmLink}) account, please set one
                 name="emailAddresses"
                 value={emailInput}
                 onChange={e => {
-                  setEmailInput(e.target.value);
-                  // debouncedValidate(e.target.value);
-                }}
-                onBlur={() => {
-                  validateEmail(emailInput);
+                  const value = e.target.value;
+                  setEmailInput(value);
+
+                  const isValid = emailSchema.isValidSync(value.trim());
+                  if (isValid) setError("");
                 }}
               />
               <MdAdd


### PR DESCRIPTION
- Fixes #2748 

### What changes did you make?
- Enabled the green '+' button to be 'active' when users type in the input field
- Removed email validation when the input field loses focuses so that email validation only occurs when users click the green '+' button
- Cleared the existing error message if the new email becomes valid while the user types

### Why did you make the changes (we will use this info to test)?
- To make typing in the input field intuitive.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="425" height="335" alt="before-ss-1" src="https://github.com/user-attachments/assets/13b18ea5-5c90-4dfa-a2f4-74e3ab8702f7" />
<img width="425" height="335" alt="before-ss-2" src="https://github.com/user-attachments/assets/fd8f4f02-c6b1-4ede-b5c7-8d89800271b9" />
<img width="425" height="335" alt="before-ss-3" src="https://github.com/user-attachments/assets/1da5a780-e510-4e4e-9a91-d3c341412123" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="425" height="335" alt="after-ss-1" src="https://github.com/user-attachments/assets/ae9d692c-23a4-4283-aa38-61a6f60294ad" />
<img width="425" height="335" alt="after-ss-2" src="https://github.com/user-attachments/assets/339836d3-afef-4a17-924e-ef56cc19999f" />
<img width="425" height="435" alt="after-ss-3" src="https://github.com/user-attachments/assets/9fb91272-9ec0-4f20-a3fe-5d94f84e98b0" />


</details>
