### PR TITLE
fix: create project page 1 and 2

### DIFF
--- a/client/src/components/ProjectWizard/WizardSidebar/EarnedPointsProgress.jsx
+++ b/client/src/components/ProjectWizard/WizardSidebar/EarnedPointsProgress.jsx
@@ -6,6 +6,7 @@ import clsx from "clsx";
 import Popup from "reactjs-popup";
 import { MdClose } from "react-icons/md";
 import { sanitizeHtml } from "helpers/SanitizeRichText";
+import { useReplaceAriaAttribute } from "hooks/useReplaceAriaAttribute";
 
 /* 
 See https://css-tricks.com/building-progress-ring-quickly/
@@ -132,6 +133,16 @@ const EarnedPointsProgress = ({ rulesConfig }) => {
   // Sanitize DangerouslySetInnerHtml with DomPurify
   const sanitizeTipText = sanitizeHtml(tipText);
 
+  const elementId = `project-earned-points-tooltip-icon-trigger`;
+  const popupContentId = `popup-content-${elementId}`;
+  useReplaceAriaAttribute({
+    elementId,
+    deps: [target, earned],
+    attrToRemove: "aria-describedby",
+    attrToAdd: "aria-controls",
+    value: popupContentId
+  });
+
   return (
     <div
       className={
@@ -157,7 +168,7 @@ const EarnedPointsProgress = ({ rulesConfig }) => {
         <Popup
           lockScroll={false}
           trigger={
-            <span style={{ cursor: "pointer" }}>
+            <span id={elementId} style={{ cursor: "pointer" }}>
               <ToolTipIcon />
             </span>
           }
@@ -167,7 +178,7 @@ const EarnedPointsProgress = ({ rulesConfig }) => {
         >
           {close => {
             return (
-              <div style={{ margin: "1rem" }}>
+              <div id={popupContentId} style={{ margin: "1rem" }}>
                 <button
                   style={{
                     backgroundColor: "transparent",

--- a/client/src/components/ProjectWizard/WizardSidebar/SidebarProjectLevel.jsx
+++ b/client/src/components/ProjectWizard/WizardSidebar/SidebarProjectLevel.jsx
@@ -6,6 +6,7 @@ import clsx from "clsx";
 import Popup from "reactjs-popup";
 import { MdClose } from "react-icons/md";
 import { sanitizeHtml } from "helpers/SanitizeRichText";
+import { useReplaceAriaAttribute } from "hooks/useReplaceAriaAttribute";
 
 const useStyles = createUseStyles({
   projectLevelHeader: {
@@ -40,6 +41,16 @@ const SidebarProjectLevel = ({ level, rules }) => {
   // Sanitize DangerouslySetInnerHtml with DomPurify
   const sanitizeTipText = sanitizeHtml(tipText);
 
+  const elementId = `project-level-tooltip-icon-trigger`;
+  const popupContentId = `popup-content-${elementId}`;
+  useReplaceAriaAttribute({
+    elementId,
+    deps: [level],
+    attrToRemove: "aria-describedby",
+    attrToAdd: "aria-controls",
+    value: popupContentId
+  });
+
   return (
     <div
       className={clsx(
@@ -52,10 +63,14 @@ const SidebarProjectLevel = ({ level, rules }) => {
       </p>
       <h3 className={classes.projectLevelHeader}>
         PROJECT LEVEL
-        {level > 0 && (
+        {level > -1 && (
           <Popup
             trigger={
-              <span style={{ cursor: "pointer" }}>
+              <span
+                id={elementId}
+                className="aosidjoasidj"
+                style={{ cursor: "pointer" }}
+              >
                 <ToolTipIcon />
               </span>
             }
@@ -65,7 +80,7 @@ const SidebarProjectLevel = ({ level, rules }) => {
           >
             {close => {
               return (
-                <div style={{ margin: "1rem" }}>
+                <div id={popupContentId} style={{ margin: "1rem" }}>
                   <button
                     style={{
                       backgroundColor: "transparent",


### PR DESCRIPTION
- Fixes #2710 #2699 

### What changes did you make?

- fixed broken aria reference errors in page 1 (also fixes it for pages 2-5)
- Fixing and adding all alerts for page 1 fixed everything for page 2 as well (no alerts or errors in pg 2)

### Why did you make the changes (we will use this info to test)?

-

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="451" height="527" alt="Screenshot 2025-12-08 at 6 23 34 PM" src="https://github.com/user-attachments/assets/77075973-f67b-4d35-8db1-0bd52f8a8272" />

<img width="1700" height="903" alt="Screenshot 2026-01-28 at 1 16 45 AM" src="https://github.com/user-attachments/assets/4e228dbd-14a1-44db-81c5-213ff8371a98" />



</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="419" height="560" alt="Screenshot 2025-12-08 at 6 23 43 PM" src="https://github.com/user-attachments/assets/5b78e8af-64cd-4b1b-8100-57841fcbd224" />

</details>
