### PR TITLE
Surface email service errors to client

### DIFF
--- a/client/src/components/Authorization/ConfirmEmail.jsx
+++ b/client/src/components/Authorization/ConfirmEmail.jsx
@@ -31,7 +31,7 @@ const ConfirmEmail = () => {
     const confirmEmail = async token => {
       const result = await accountService.confirmRegister(token);
       setConfirmResult(result);
-      if (result.success) {
+      if (result.isSuccess) {
         toast.add("Your email has been confirmed. Please log in.");
         navigate(`/login/${encodeURIComponent(result.email)}`);
       }
@@ -41,7 +41,7 @@ const ConfirmEmail = () => {
     }
   }, [token, toast, navigate]);
 
-  return confirmResult.success ? (
+  return confirmResult.isSuccess ? (
     <Navigate to={`/login/${confirmResult.email}`} />
   ) : (
     <ContentContainer>

--- a/client/src/components/Authorization/ForgotPassword.jsx
+++ b/client/src/components/Authorization/ForgotPassword.jsx
@@ -17,6 +17,8 @@ const ForgotPassword = () => {
         "email",
         "That email address is not associated with any accounts"
       );
+    } else {
+      setFieldError("email", submitResponse.data.message);
     }
   };
 

--- a/client/src/components/Feedback/FeedbackPage.jsx
+++ b/client/src/components/Feedback/FeedbackPage.jsx
@@ -178,7 +178,7 @@ const FeedbackPage = ({ contentContainerRef }) => {
               <div className={classes.formContainer}>
                 <div className={classes.row}>
                   <label htmlFor="name" className={classes.formLabel}>
-                    Project Name <span className={classes.asterisk}>*</span>
+                    Your Name <span className={classes.asterisk}>*</span>
                   </label>
 
                   <Field

--- a/server/__tests__/account.test.js
+++ b/server/__tests__/account.test.js
@@ -117,7 +117,7 @@ describe("Account API endpoints for end user accounts", () => {
       .post("/api/accounts/confirmRegister")
       .send({ token: capturedToken });
     expect(res.statusCode).toEqual(200);
-    expect(res.body).toHaveProperty("success", true);
+    expect(res.body).toHaveProperty("isSuccess", true);
   });
 
   // POST "/login" attempt to login with an incorrect password

--- a/server/app/services/account.service.js
+++ b/server/app/services/account.service.js
@@ -122,7 +122,7 @@ const resendConfirmationEmail = async email => {
     const selectByEmailResponse = await request.execute("Login_SelectByEmail");
 
     result = {
-      success: true,
+      isSuccess: true,
       code: "REG_SUCCESS",
       newId: selectByEmailResponse.recordset[0].id,
       message: "Account found."
@@ -133,7 +133,7 @@ const resendConfirmationEmail = async email => {
     // Assume any error is an email that does not correspond to
     // an account.
     return {
-      success: false,
+      isSuccess: false,
       code: "REG_ACCOUNT_NOT_FOUND",
       message: `Resending confirmation email to ${email} failed due to: ${err.message}`
     };
@@ -151,7 +151,7 @@ const requestRegistrationConfirmation = async (email, result) => {
     request.input("email", mssql.NVarChar, email);
     await request.execute("SecurityToken_Insert");
 
-    await sendRegistrationConfirmation(email, token);
+    result = await sendRegistrationConfirmation(email, token);
 
     return {
       ...result,
@@ -159,7 +159,7 @@ const requestRegistrationConfirmation = async (email, result) => {
     };
   } catch (err) {
     return {
-      success: false,
+      isSuccess: false,
       code: "REG_EMAIL_FAILED",
       message: `Sending registration confirmation email to ${email} failed due to: ${err.message}`
     };
@@ -179,7 +179,7 @@ const confirmRegistration = async token => {
 
     if (resultSet.length !== 1) {
       return {
-        success: false,
+        isSuccess: false,
         code: "REG_CONFIRM_TOKEN_INVALID",
         message:
           "Email confirmation failed. Invalid security token. Re-send confirmation email."
@@ -189,7 +189,7 @@ const confirmRegistration = async token => {
       24
     ) {
       return {
-        success: false,
+        isSuccess: false,
         code: "REG_CONFIRM_TOKEN_EXPIRED",
         message:
           "Email confirmation failed. Security token expired. Re-send confirmation email."
@@ -203,7 +203,7 @@ const confirmRegistration = async token => {
     await updateRequest.execute("Login_ConfirmEmail");
 
     return {
-      success: true,
+      isSuccess: true,
       code: "REG_CONFIRM_SUCCESS",
       message: "Email confirmed.",
       email
@@ -241,7 +241,7 @@ const forgotPassword = async model => {
       result
     );
     if (tokenInsertResult) {
-      return result;
+      return tokenInsertResult;
     } else {
       return {
         isSuccess: false,
@@ -270,9 +270,9 @@ const requestResetPasswordConfirmation = async (email, result) => {
     return result;
   } catch (err) {
     return {
-      success: false,
+      isSuccess: false,
       code: "FORGOT_PASSWORD_EMAIL_FAILED",
-      message: `Sending registration confirmation email to ${email} failed.`
+      message: `Sending registration confirmation email to ${email} failed due to: ${err.message}.`
     };
   }
 };


### PR DESCRIPTION
- Fixes #2845

### What changes did you make?

- Pass error messages about sending emails from forgot password or registration actions to the client, so we can debug problems with the Google Workspace SMTP Relay setup.

### Why did you make the changes (we will use this info to test)?

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
