### PR TITLE
Fix bug in configuring smtp servce for no auth

### DIFF
--- a/server/app/services/smtp.service.js
+++ b/server/app/services/smtp.service.js
@@ -7,18 +7,21 @@ const smtpAuthUser = process.env.SMTP_AUTH_USER;
 const smtpAuthPass = process.env.SMTP_AUTH_PASS;
 
 let transporter = nodemailer.createTransport({
+  // service: "Gmail"
   host: smtpHost,
   port: smtpPort,
   secure: smtpSecure // true
 });
 
 // If Google Workspace SMTP Relay is configured to accept requests
-// from a specific IP address, you don't want to incluide the auth
-// user/pass, otherwise, then you need these credentials.
-transporter.auth = {
-  user: smtpAuthUser,
-  pass: smtpAuthPass
-};
+// from a specific IP address, you don't want to include the auth
+// user/pass. However, if you are using auth, then you need these credentials.
+if (smtpAuthPass) {
+  transporter.auth = {
+    user: smtpAuthUser,
+    pass: smtpAuthPass
+  };
+}
 
 /* 
     msg object should have to, subject, text, html fields


### PR DESCRIPTION
- Fixes #2845

### What changes did you make?

- Fix bug in logic that omits the auth parameter from the SMTP transporter setup if SMTP_AUTH_PASS is blank.

### Why did you make the changes (we will use this info to test)?

-

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
