### PR TITLE
Prevent shrinkage of filter icon on Column Headers

### DIFF
--- a/client/src/components/Projects/ColumnHeaderPopups/ProjectTableColumnHeader.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/ProjectTableColumnHeader.jsx
@@ -21,6 +21,7 @@ import { useTheme } from "react-jss";
 const useStyles = createUseStyles(theme => ({
   iconFilter: {
     color: theme.colorWhite,
+    flexShrink: 0,
     fontSize: "1.2rem",
     marginLeft: "1rem",
     "&.active": {
@@ -35,7 +36,8 @@ const useStyles = createUseStyles(theme => ({
   },
   sortIcon: {
     fontSize: "1.2rem",
-    transform: "rotate(90deg)"
+    transform: "rotate(90deg)",
+    flexShrink: 0
   },
   reactTinyPopoverContainer: {
     color: "orange"

--- a/client/src/components/Submissions/ManageSubmissionsPage.jsx
+++ b/client/src/components/Submissions/ManageSubmissionsPage.jsx
@@ -400,7 +400,7 @@ const ManageSubmissions = ({ contentContainerRef }) => {
       id: "invoiceStatusName",
       label: "Invoice Status",
       popupType: "stringList",
-      colWidth: "7rem"
+      colWidth: "10rem"
     },
     {
       id: "dateInvoicePaid",
@@ -408,7 +408,7 @@ const ManageSubmissions = ({ contentContainerRef }) => {
       popupType: "datetime",
       startDatePropertyName: "startDateInvoicePaid",
       endDatePropertyName: "endDateInvoicePaid",
-      colWidth: "10rem"
+      colWidth: "7rem"
     },
     { id: "onHold", label: "On Hold", popupType: "boolean", colWidth: "8rem" },
     {


### PR DESCRIPTION
- Fixes #2880

### What changes did you make?

- set flex-shrink on filter icon to 0 to prevent it from shrinking, regardless of the neighboring column header title text.

### Why did you make the changes (we will use this info to test)?

- To keep it from shrinking on the all the grids in the app with column header fitlering.

### Issue-Specific User Account

n/a

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

See Issue

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1459" height="267" alt="image" src="https://github.com/user-attachments/assets/29d6b515-017a-4e18-a52b-b0cd0d715b3f" />

</details>
