### PR TITLE
Update smtp.service.js

### DIFF
--- a/server/app/services/smtp.service.js
+++ b/server/app/services/smtp.service.js
@@ -5,12 +5,15 @@ const smtpPort = Number(process.env.SMTP_PORT);
 const smtpSecure = process.env.SMTP_SECURE === "true";
 const smtpAuthUser = process.env.SMTP_AUTH_USER;
 const smtpAuthPass = process.env.SMTP_AUTH_PASS;
+const smtpAuthDomainName = process.env.SMTP_AUTH_DOMAIN;
 
 const smtpConfig = {
   // service: "Gmail"
   host: smtpHost,
   port: smtpPort,
-  secure: smtpSecure // true
+  secure: smtpSecure, // true
+  name: smtpAuthDomainName, // Used in EHLO/HELO command, defaults to os.hostname(), so we set environment variable.
+  tls: { rejectUnauthorized: false }
 };
 
 // If Google Workspace SMTP Relay is configured to accept requests


### PR DESCRIPTION


- Fixes #2819 

### What changes did you make?

- Added smtpAuthDomainName - Used in EHLO/HELO command, defaults to os.hostname(), so we set environment variable.

### Why did you make the changes (we will use this info to test)?

-Should allow the TDM application to send emails using the Google SMTP relay
-Need to add to Azure Environment Variables "SMTP_AUTH_DOMAIN" with the value lacity.org

