### PR TITLE
fix: change styles to match new address desing on page 5

### DIFF
--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfo.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfo.jsx
@@ -5,8 +5,8 @@ import { createUseStyles } from "react-jss";
 const useStyles = createUseStyles({
   projectInfoDetailsSubContainer: {
     display: "flex",
+    flexDirection: "column",
     alignItems: "baseline",
-    maxHeight: "20px",
     width: "50%"
   },
   projectInfoCategory: {

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoContainer.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoContainer.jsx
@@ -71,9 +71,12 @@ const ProjectInfoContainer = props => {
         {projectAddress && (
           <ProjectInfo name={projectAddress.name} rule={projectAddress} />
         )}
-        <ProjectInfoList name={"PARCEL # (AIN)"} rule={parcelNumbers} />
         {buildingPermit && (
           <ProjectInfo name={buildingPermit.name} rule={buildingPermit} />
+        )}
+        <ProjectInfoList name={"PARCEL # (AIN)"} rule={parcelNumbers} />
+        {caseNumberLADOT && (
+          <ProjectInfo name={caseNumberLADOT.name} rule={caseNumberLADOT} />
         )}
         {versionNumber && (
           <ProjectInfo name={versionNumber.name} rule={versionNumber} />
@@ -84,10 +87,6 @@ const ProjectInfoContainer = props => {
             rule={caseNumberPlanning}
           />
         )}
-        {caseNumberLADOT && (
-          <ProjectInfo name={caseNumberLADOT.name} rule={caseNumberLADOT} />
-        )}
-
         {projectID && (
           <div className={classes.projectIdRight}>
             <ProjectInfo name="Project ID #" rule={{ value: projectID }} />

--- a/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoList.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSummary/ProjectInfoList.jsx
@@ -5,8 +5,8 @@ import { createUseStyles } from "react-jss";
 const useStyles = createUseStyles({
   projectInfoDetailsSubContainer: {
     display: "flex",
-    alignItems: "baseline",
-    maxHeight: "20px"
+    flexDirection: "column",
+    alignItems: "baseline"
   },
   projectInfoCategory: {
     fontWeight: "600",
@@ -23,7 +23,8 @@ const useStyles = createUseStyles({
     display: "flex",
     flexWrap: "wrap",
     flexDirection: "row",
-    gap: ".3em"
+    gap: ".3em",
+    fontWeight: 400
   },
   AINValues: {
     minWidth: "100px",


### PR DESCRIPTION
- Fixes #2691 

### What changes did you make?

- updated to match design

### Why did you make the changes (we will use this info to test)?

-

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)
<details>
<summary>Visuals before changes are applied</summary>

<img width="1657" height="1390" alt="Screenshot 2026-02-25 at 7 04 42 PM" src="https://github.com/user-attachments/assets/89e97dac-8584-46b8-85f9-ec3b1ece3799" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="2120" height="1393" alt="Screenshot 2026-02-25 at 7 04 04 PM" src="https://github.com/user-attachments/assets/dad6a048-186d-49e9-a2dd-81f2eb35a49f" />


</details>
