### PR TITLE
Manage Submissions Page should show hidden projects

### DIFF
--- a/server/db/migration/V20260311.1949__show hidden_proejcts_on_manage_submissions_page_2962.sql
+++ b/server/db/migration/V20260311.1949__show hidden_proejcts_on_manage_submissions_page_2962.sql
@@ -1,0 +1,56 @@
+CREATE OR ALTER PROC [dbo].[ProjectSubmission_SelectAdmin]
+   @loginId int = null, -- loginId of Admin user
+   @projectId int = null -- optional, null returns all
+AS
+BEGIN
+/* 
+	This is used to populate the Manage Submissions Admin page, 
+	which allows an admin to view and process submitted snapshots.
+*/
+	
+    SELECT
+        p.id
+		, p.name
+		, p.address
+		, p.projectLevel
+		, p.dateSubmitted
+		, p.dateStatus
+		, p.loginIdStatus
+		, ls.firstName as statuserFirstName
+		, ls.lastName as statuserLastName
+		, p.droId 
+		, d.name as droName
+		, p.loginIdAssigned
+		, la.firstName as assigneeFirstName
+		, la.lastName as assigneeLastName
+		, p.dateAssigned
+		, p.invoiceStatusId
+		, i.name as invoiceStatusName
+		, p.dateInvoicePaid
+		, p.onHold
+		, p.approvalStatusId
+		, a.name as approvalStatusName
+		, p.dateCoO
+		, p.dateTrashed
+		, p.dateSnapshotted
+		, p.adminNotes
+		, p.dateModifiedAdmin
+		, p.loginId
+		, author.firstName as authorFirstName
+		, author.lastName as authorLastName
+		, author.email as authorEmail
+    FROM Project p
+		JOIN Login author ON p.loginId = author.id
+		LEFT JOIN Login ls ON p.loginIdStatus = ls.id
+		LEFT JOIN Login la ON p.loginIdAssigned = la.id
+		LEFT JOIN Dro d on p.droId = d.id
+		LEFT JOIN InvoiceStatus i on p.invoiceStatusId = i.id
+		LEFT JOIN ApprovalStatus a on p.approvalStatusId = a.id
+    WHERE p.dateSubmitted IS NOT NULL -- IS a Submission
+		AND p.dateTrashed IS NULL -- IS NOT deleted
+		AND EXISTS (SELECT 1 FROM Login WHERE id = @loginId AND isAdmin = 1)
+		AND (@projectId IS NULL OR p.id = @projectId)
+END
+GO
+
+


### PR DESCRIPTION
- Fixes #2962
### What changes did you make?

- Modify the stored procedure for the Manage Submissions page to NOT filter out hidden projects

### Why did you make the changes (we will use this info to test)?

- see issue. 
- Note that the Submissions Page used by non-admin users already showed the hidden projects.

### Issue-Specific User Account

Admin

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1730" height="412" alt="image" src="https://github.com/user-attachments/assets/830ad7ad-d4d7-4802-92ac-fc71d8d1efbb" />

(Then project could not be found on the Mange Submissions Page.

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1730" height="412" alt="image" src="https://github.com/user-attachments/assets/830ad7ad-d4d7-4802-92ac-fc71d8d1efbb" />

Project can be found on the Manage Submissions Page

<img width="1788" height="222" alt="image" src="https://github.com/user-attachments/assets/a7742350-91ec-42f4-a2a8-4554d0d8116b" />


</details>
