### PR TITLE
Fix Bug where user could use Back Button to Save changes to a Snapshot

### DIFF
--- a/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
@@ -376,7 +376,8 @@ const TdmCalculationWizard = props => {
       (!(account.isAdmin || account.id === loginId) ||
         !!project.dateSnapshotted)
     ) {
-      navigate(`/calculation/5/${projectId}`);
+      // {replace: true} used to prevent user from going back to the page they don't have access to with the back button
+      navigate(`/calculation/5/${projectId}`, { replace: true });
     } // eslint-disable-next-line
   }, [projectId, account, loginId, navigate]);
 
@@ -417,8 +418,10 @@ const TdmCalculationWizard = props => {
     const loggedIn = !!account && !!account.id;
     const notASavedProject = !projectId;
     const projectBelongsToUser = account && account.id === loginId;
+    const isDraft = !project.dateSnapshotted;
     const setDisabled = !(
       loggedIn &&
+      isDraft &&
       (notASavedProject || projectBelongsToUser) &&
       formIsDirty &&
       projectIsValid()

--- a/server/app/controllers/project.controller.js
+++ b/server/app/controllers/project.controller.js
@@ -70,7 +70,11 @@ const put = async (req, res) => {
       return;
     }
 
-    await projectService.put(req.body);
+    const result = await projectService.put(req.body);
+    if (result === 1) {
+      // Stored Proc rejected the update because project is a snapshot
+      res.sendStatus(403);
+    }
     res.sendStatus(204);
   } catch (err) {
     res.status(500).send(err);

--- a/server/app/services/project.service.js
+++ b/server/app/services/project.service.js
@@ -85,7 +85,8 @@ const put = async item => {
     request.input("loginId", mssql.Int, item.loginId);
     request.input("calculationId", mssql.Int, item.calculationId);
     request.input("id", mssql.Int, item.id);
-    await request.execute("Project_Update");
+    const response = await request.execute("Project_Update");
+    return response.returnValue;
   } catch (err) {
     return Promise.reject(err);
   }

--- a/server/db/migration/V20260312.1041__reject-attempt_to_put_snapshot-changes_2865.sql
+++ b/server/db/migration/V20260312.1041__reject-attempt_to_put_snapshot-changes_2865.sql
@@ -1,0 +1,39 @@
+CREATE OR ALTER PROC [dbo].[Project_Update]
+	@id int
+	, @name nvarchar(200)
+	, @address nvarchar(200)
+	, @formInputs nvarchar(max)
+	, @targetPoints int
+	, @earnedPoints int
+	, @projectLevel int
+	, @loginId int
+	, @calculationId int
+	, @description nvarchar(max)
+AS
+BEGIN
+
+	DECLARE @rc int
+	SELECT @rc = count(*) FROM Project p WHERE p.id = @id AND p.dateSnapshotted IS NOT NULL
+	IF (@rc = 1)
+	BEGIN
+		RETURN 1 /* Cannot update a snapshot */
+	END
+
+	UPDATE Project SET 
+		name = @name
+		, address = @address
+		, formInputs = @formInputs
+		, targetPoints = @targetPoints
+		, earnedPoints = @earnedPoints
+		, projectLevel = @projectLevel
+		, loginId = @loginId
+		, calculationId = @calculationId
+		, description = @description
+		, DateModified = getutcdate()
+	WHERE 
+		id = @id
+
+END
+GO
+
+


### PR DESCRIPTION
- Fixes #2865

### What changes did you make?

- Modified the Web API PUT request to /api/projects/:id to fail with a 403 (Forbidden) code if the client application attempts to save changes to a snapshot.
- Modified the logic for the Project Save button on the Calculation Wizard to be disabled if the project is not a draft.
- Modified the logic that redirects from any page of the Wizard to Page 5 for projects that do not belong to the user or are not a draft to replace the browser history current page with Page 5 when re-directing, so the back button will go back to the page the user was on before opening the Wizard.

### Why did you make the changes (we will use this info to test)?

- See Issue

### Issue-Specific User Account

Any

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

See Issue

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
(Back button will not take user to Page 1 of the Wizard)

</details>
