### PR TITLE
fix: avoid skipped heading levels

### DIFF
--- a/client/src/components/About/DefaultView.jsx
+++ b/client/src/components/About/DefaultView.jsx
@@ -9,10 +9,14 @@ const useStyles = createUseStyles({
     fontSize: "14px",
     padding: " 0 0.4em",
     color: "#00F"
+  },
+  subHeaders: {
+    fontSize: "20px"
   }
 });
 
 const DefaultView = ({ aboutList }) => {
+  const classes = useStyles();
   if (!aboutList || aboutList?.length === 0) {
     return null;
   }
@@ -20,7 +24,7 @@ const DefaultView = ({ aboutList }) => {
     <>
       {aboutList.map(about => (
         <div key={about.id}>
-          <h2>{about.title}</h2>
+          <h2 className={classes.subHeaders}>{about.title}</h2>
           <Interweave
             transform={TransformExternalLink}
             content={about.content}

--- a/client/src/components/About/DefaultView.jsx
+++ b/client/src/components/About/DefaultView.jsx
@@ -10,7 +10,7 @@ const useStyles = createUseStyles({
     padding: " 0 0.4em",
     color: "#00F"
   },
-  subHeaders: {
+  subheading: {
     fontSize: "20px"
   }
 });
@@ -24,7 +24,7 @@ const DefaultView = ({ aboutList }) => {
     <>
       {aboutList.map(about => (
         <div key={about.id}>
-          <h2 className={classes.subHeaders}>{about.title}</h2>
+          <h2 className={classes.subheading}>{about.title}</h2>
           <Interweave
             transform={TransformExternalLink}
             content={about.content}

--- a/client/src/components/About/DefaultView.jsx
+++ b/client/src/components/About/DefaultView.jsx
@@ -20,7 +20,7 @@ const DefaultView = ({ aboutList }) => {
     <>
       {aboutList.map(about => (
         <div key={about.id}>
-          <h3>{about.title}</h3>
+          <h2>{about.title}</h2>
           <Interweave
             transform={TransformExternalLink}
             content={about.content}

--- a/client/src/components/About/DefaultView.jsx
+++ b/client/src/components/About/DefaultView.jsx
@@ -11,7 +11,8 @@ const useStyles = createUseStyles({
     color: "#00F"
   },
   subheading: {
-    fontSize: "20px"
+    fontSize: "20px",
+    margin: "1em 0"
   }
 });
 


### PR DESCRIPTION
- Fixes #2960 
### What changes did you make?

- Changed h3 to h2 and updated css styling to avoid visual changes.


### Why did you make the changes (we will use this info to test)?

- Updated the heading level to avoid skipping heading levels, which is an accessibility issue. Previously it was h1 to h3; now it's h1 to h2.

### Issue-Specific User Account

N/A

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1557" height="767" alt="Screenshot 2026-03-18 191647" src="https://github.com/user-attachments/assets/de65b188-4f04-4956-9581-53e8dec090d3" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1563" height="761" alt="Screenshot 2026-03-18 191536" src="https://github.com/user-attachments/assets/bbb43c16-71f4-46ec-b82b-3517491b8500" />

</details>
