### PR TITLE
fix: remove check on active projects

### DIFF
--- a/client/src/components/Projects/MultiProjectToolbarMenu.jsx
+++ b/client/src/components/Projects/MultiProjectToolbarMenu.jsx
@@ -111,9 +111,7 @@ const MultiProjectToolbarMenu = ({
     isBtnDisabled("dateHidden", "visibility");
 
   const isDelBtnDisabled =
-    !isProjectOwner ||
-    isBtnDisabled("dateTrashed", "status") ||
-    !isActiveProjectsTab;
+    !isProjectOwner || isBtnDisabled("dateTrashed", "status");
 
   const tooltipMsg = criteriaProp => {
     if (checkedProjectIds.length === 0) return;


### PR DESCRIPTION
- Fixes #2763 

### What changes did you make?

- I updated the isDelBtnDisabled logic to not check for active projects.

### Why did you make the changes (we will use this info to test)?

- I made this change since we are sharing the logic between the active projects tab and the deleted projects tab so it was blocking the restore functionality.


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

<img width="2859" height="674" alt="Screenshot 2026-03-25 174434" src="https://github.com/user-attachments/assets/c11cc5f9-62ad-45bd-ba71-2130157d915a" />

</details>

<details>
<summary>Visuals after changes are applied</summary>

  
<img width="2862" height="837" alt="Screenshot 2026-03-25 174354" src="https://github.com/user-attachments/assets/3ad10121-84f5-4d4a-bfcd-b3205b4fa0fa" />

</details>
