### PR TITLE
2777 registration page field validation

### DIFF
--- a/client/src/components/Authorization/Register.jsx
+++ b/client/src/components/Authorization/Register.jsx
@@ -326,9 +326,6 @@ const Register = props => {
       {!submitted ? (
         <>
           <h1 className={classes.heading1}>Create a New Account</h1>
-          <h3>Save your project information.</h3>
-          <br />
-
           <div className="auth-form">
             <Formik
               initialValues={initialValues}
@@ -349,6 +346,7 @@ const Register = props => {
                         innerRef={focusRef}
                         name="firstName"
                         placeholder="First Name"
+                        aria-label="First Name"
                         className="form-control"
                       />
                       <ValidationIcon
@@ -367,6 +365,7 @@ const Register = props => {
                         type="text"
                         name="lastName"
                         placeholder="Last Name"
+                        aria-label="Last Name"
                         className="form-control"
                       />
                       <ValidationIcon
@@ -385,6 +384,7 @@ const Register = props => {
                         type="email"
                         name="email"
                         placeholder="Email"
+                        aria-label="Email"
                         className="form-control"
                       />
                       <ValidationIcon
@@ -410,6 +410,7 @@ const Register = props => {
                         name="password"
                         placeholder="Password"
                         autoComplete="new-password"
+                        aria-label="Password"
                         className={`form-control ${
                           touched.password && values.password && errors.password
                             ? classes.inputInvalid
@@ -439,6 +440,7 @@ const Register = props => {
                         name="passwordConfirm"
                         placeholder="Retype Password"
                         autoComplete="new-password"
+                        aria-label="Confirm Password"
                         className={`form-control ${
                           touched.passwordConfirm &&
                           values.passwordConfirm &&


### PR DESCRIPTION
- Fixes #2777 

### What changes did you make?

- add validation icons to First Name and Last Name fields
- add multi-line validation messages for Email and Password inputs
- add icon to validation message for Confirm Password inputs
- add red outline to Password and Confirm Password inputs when invalid

### Why did you make the changes (we will use this info to test)?

The Registration Page needs to communicate input requirements clearly. Currently, if a field fails validation, the user only sees a general error message after attempting to submit.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="686" height="661" alt="Screenshot 2026-03-26 at 4 13 21 PM" src="https://github.com/user-attachments/assets/efbb8e11-e68d-43df-82c6-1faa4f32607a" />

First name not entered
<img width="650" height="613" alt="Screenshot 2026-03-26 at 4 13 48 PM" src="https://github.com/user-attachments/assets/976a44dd-5173-40b4-9fc3-5ebfd35f336a" />

First name invalid
<img width="735" height="640" alt="Screenshot 2026-03-26 at 4 14 07 PM" src="https://github.com/user-attachments/assets/b4ba05c0-0c7f-4d64-85b2-e4107e91660b" />

Last name not entered
<img width="685" height="636" alt="Screenshot 2026-03-26 at 4 14 37 PM" src="https://github.com/user-attachments/assets/c5f77232-5ab2-4044-85c9-0e7e00df6072" />

Last name invalid
<img width="679" height="637" alt="Screenshot 2026-03-26 at 4 14 48 PM" src="https://github.com/user-attachments/assets/d6bd3be8-0e47-4fbd-a539-4391f60c9ea2" />

Email not entered
<img width="677" height="640" alt="Screenshot 2026-03-26 at 4 15 01 PM" src="https://github.com/user-attachments/assets/52abd8a5-46aa-48c2-a7d9-fa08e651b25f" />

Email invalid
<img width="695" height="630" alt="Screenshot 2026-03-26 at 4 15 12 PM" src="https://github.com/user-attachments/assets/07009e9c-80c8-4d91-8b57-36e026f225fb" />

Password not entered
<img width="681" height="630" alt="Screenshot 2026-03-26 at 4 15 34 PM" src="https://github.com/user-attachments/assets/ab444415-8690-4035-a86d-1448af20cf18" />

Password invalid
<img width="693" height="636" alt="Screenshot 2026-03-26 at 4 15 44 PM" src="https://github.com/user-attachments/assets/88d84df9-405b-41f5-a892-3603f036402f" />

Passwords don't match
<img width="664" height="620" alt="Screenshot 2026-03-26 at 4 16 04 PM" src="https://github.com/user-attachments/assets/4c042ffe-316b-421e-8228-1a2b98518da6" />

All inputs valid
<img width="644" height="601" alt="Screenshot 2026-03-26 at 4 16 37 PM" src="https://github.com/user-attachments/assets/a87149bf-a13b-4682-a872-6d318a31e7e1" />

</details>

<details>
<summary>Visuals after changes are applied</summary>

First name not entered
<img width="602" height="653" alt="Screenshot 2026-03-26 at 4 25 22 PM" src="https://github.com/user-attachments/assets/d9cd2b74-c8d6-4b0f-9cc1-522b043fd9ce" />

First name invalid
<img width="647" height="657" alt="Screenshot 2026-03-26 at 4 25 39 PM" src="https://github.com/user-attachments/assets/f66eaeb0-5ce2-4838-ad16-66dae4b13dce" />

First name valid
<img width="655" height="639" alt="Screenshot 2026-03-26 at 4 25 52 PM" src="https://github.com/user-attachments/assets/a3c720bc-b3f6-4a8c-bc0c-0e0ae541b24b" />

Last name not entered
<img width="609" height="650" alt="Screenshot 2026-03-26 at 4 26 02 PM" src="https://github.com/user-attachments/assets/5155db5e-ae18-41e4-ba6c-781012c126a5" />

Last name invalid
<img width="614" height="655" alt="Screenshot 2026-03-26 at 4 26 11 PM" src="https://github.com/user-attachments/assets/b7b19534-6892-4024-916d-b262ffb4a478" />

Last name valid
<img width="623" height="639" alt="Screenshot 2026-03-26 at 4 26 27 PM" src="https://github.com/user-attachments/assets/8ece997a-e57c-48ca-a9ae-a18ed3161860" />

Email not entered
<img width="569" height="708" alt="Screenshot 2026-03-26 at 4 26 36 PM" src="https://github.com/user-attachments/assets/bff8c71a-68ca-479b-b47e-4119fb28f7dc" />

Email satisfies some requirements but not all
<img width="655" height="730" alt="Screenshot 2026-03-26 at 4 27 46 PM" src="https://github.com/user-attachments/assets/1a8fc65a-9e99-47e7-a485-ad3fab4c16d6" />

Email satisfies all requirements
<img width="617" height="731" alt="Screenshot 2026-03-26 at 4 27 55 PM" src="https://github.com/user-attachments/assets/b54978d1-4863-4f92-ba11-79b900e3502c" />

Password not entered
<img width="617" height="772" alt="Screenshot 2026-03-26 at 4 28 04 PM" src="https://github.com/user-attachments/assets/0e889490-c6de-446e-a86a-4f68e9355e15" />

Password satisfies some requirements but not all
<img width="602" height="778" alt="Screenshot 2026-03-26 at 4 28 40 PM" src="https://github.com/user-attachments/assets/61584526-6df0-4ab3-84c2-b5534ef4c52b" />

Password satisfies all requirements
<img width="616" height="767" alt="Screenshot 2026-03-26 at 4 28 52 PM" src="https://github.com/user-attachments/assets/d6842146-576a-497d-9505-8ba9d3afb159" />

Confirm password not entered
<img width="602" height="751" alt="Screenshot 2026-03-26 at 4 29 00 PM" src="https://github.com/user-attachments/assets/92e5d031-1fe6-4460-aceb-17a635b50e1c" />

Passwords don't match
<img width="609" height="749" alt="Screenshot 2026-03-26 at 4 29 17 PM" src="https://github.com/user-attachments/assets/c7694f6a-f473-4ac4-8a8c-2a6be5635be2" />

Passwords match
<img width="618" height="748" alt="Screenshot 2026-03-26 at 4 29 33 PM" src="https://github.com/user-attachments/assets/a5e03afa-2507-4223-bf69-a61196b3172c" />


</details>
