### PR TITLE
Fix background of column headings on Security pages

### DIFF
--- a/client/src/components/ArchiveDelete/ProjectsArchive.jsx
+++ b/client/src/components/ArchiveDelete/ProjectsArchive.jsx
@@ -31,23 +31,22 @@ const useStyles = createUseStyles(theme => ({
     margin: "0.5em"
   },
   td: {
-    padding: "0.2em",
     textAlign: "left"
   },
   thead: {
     fontWeight: "bold",
-    backgroundColor: theme.colors.primary.darkNavy,
+    backgroundColor: theme.colors.secondary.darkNavy,
     color: theme.colors.primary.white,
-    "& td": {
+    "& tr th": {
       padding: ".4em"
     }
   },
   tbody: {
     "& tr td": {
-      padding: ".4em 0"
+      padding: ".4em"
     },
     "& tr:hover": {
-      background: "#f0e300"
+      background: theme.colorRowHighlight
     }
   },
   link: {
@@ -88,19 +87,19 @@ const ProjectsArchive = () => {
         </div>
         <div className={classes.pageSubtitle}>
           <Link to="/archivedaccounts" className={classes.link}>
-            See Archived Users
+            Return to Archived Accounts
           </Link>
         </div>
 
         <table className={classes.table}>
           <thead className={classes.thead}>
             <tr className={classes.tr}>
-              <td className={classes.td}>Name</td>
-              <td className={classes.td}>Address</td>
-              <td className={classes.td}>Created By</td>
-              <td className={classes.td}>Created On</td>
-              <td className={classes.td}>Last Saved</td>
-              <td className={classes.td}>Archive Date</td>
+              <th className={classes.td}>Name</th>
+              <th className={classes.td}>Address</th>
+              <th className={classes.td}>Created By</th>
+              <th className={classes.td}>Created On</th>
+              <th className={classes.td}>Last Saved</th>
+              <th className={classes.td}>Archive Date</th>
             </tr>
           </thead>
           <tbody className={classes.tbody}>

--- a/client/src/components/ArchiveDelete/RolesArchive.jsx
+++ b/client/src/components/ArchiveDelete/RolesArchive.jsx
@@ -36,22 +36,20 @@ const useStyles = createUseStyles(theme => ({
     margin: "20px"
   },
   tr: {
-    margin: "0.5em"
+    margin: "0"
   },
   td: {
-    padding: "0.2em 2em",
     textAlign: "left"
   },
   tdCenter: {
-    padding: "0.2em",
     textAlign: "center"
   },
   thead: {
     fontWeight: "bold",
-    backgroundColor: theme.colors.primary.darkNavy,
+    backgroundColor: theme.colors.secondary.darkNavy,
     color: theme.colors.primary.white,
-    "& td": {
-      padding: "12px"
+    "& th": {
+      padding: "0.4em"
     }
   },
   tbody: {
@@ -60,11 +58,11 @@ const useStyles = createUseStyles(theme => ({
       borderBottom: "1px solid #E7EBF0"
     },
     "& tr td": {
-      padding: "12px",
+      padding: "0.4em",
       verticalAlign: "top"
     },
     "& tr:hover": {
-      background: theme.colors.secondary.mediumGray
+      background: theme.colorRowHighlight
     }
   },
   link: {
@@ -255,17 +253,17 @@ const RolesArchive = ({ contentContainerRef }) => {
         </div>
         <table className={classes.table}>
           <thead className={classes.thead}>
-            <tr className={classes.tr}>
-              <td className={classes.td}>Email</td>
-              <td className={classes.td}>Name</td>
-              <td className={`${classes.td} ${classes.tdheadLabel}`}>
+            <tr className={classes.td}>
+              <th className={classes.td}>Email</th>
+              <th className={classes.td}>Name</th>
+              <th className={`${classes.td} ${classes.thheadLabel}`}>
                 # of Projects
-              </td>
-              <td className={`${classes.td} ${classes.tdheadLabel}`}>
+              </th>
+              <th className={`${classes.td} ${classes.thheadLabel}`}>
                 # of Submissions
-              </td>
-              <td className={classes.td}>Date Archived</td>
-              <td className={classes.tdCenter}></td>
+              </th>
+              <th className={classes.td}>Date Archived</th>
+              <th className={classes.tdCenter}></th>
             </tr>
           </thead>
           <tbody className={classes.tbody}>

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -198,7 +198,7 @@ const useStyles = createUseStyles(theme => ({
       verticalAlign: "top"
     },
     "& tr:hover": {
-      background: "#B2C0D3"
+      background: theme.colorRowHighlight
     }
   },
   tdNoSavedProjects: {

--- a/client/src/components/Roles/Roles.jsx
+++ b/client/src/components/Roles/Roles.jsx
@@ -47,12 +47,12 @@ const useStyles = createUseStyles(theme => ({
   },
   thead: {
     fontWeight: "bold",
-    backgroundColor: theme.colors.primary.darkNavy,
+    backgroundColor: theme.colors.secondary.darkNavy,
     color: theme.colors.primary.white,
     position: "sticky",
     top: "0",
-    "& td": {
-      padding: ".4em"
+    "& th": {
+      padding: "0.4em"
     }
   },
   theadLabel: {
@@ -60,10 +60,10 @@ const useStyles = createUseStyles(theme => ({
   },
   tbody: {
     "& tr td": {
-      padding: ".4em 0"
+      padding: ".4em"
     },
     "& tr:hover": {
-      background: "#f0e300"
+      background: theme.colorRowHighlight
     }
   },
   link: {

--- a/client/src/components/Submissions/ManageSubmissionsPage.jsx
+++ b/client/src/components/Submissions/ManageSubmissionsPage.jsx
@@ -140,7 +140,7 @@ const useStyles = createUseStyles(theme => ({
       verticalAlign: "top"
     },
     "& tr:hover": {
-      background: "#B2C0D3"
+      background: theme.colorRowHighlight
     }
   },
   tdNoSavedProjects: {

--- a/client/src/components/Submissions/SubmissionsPage.jsx
+++ b/client/src/components/Submissions/SubmissionsPage.jsx
@@ -139,7 +139,7 @@ const useStyles = createUseStyles(theme => ({
       verticalAlign: "top"
     },
     "& tr:hover": {
-      background: "#B2C0D3"
+      background: theme.colorRowHighlight
     }
   },
   tdNoSavedProjects: {

--- a/client/src/styles/theme.js
+++ b/client/src/styles/theme.js
@@ -16,6 +16,7 @@ export const jssTheme = {
   colorCriticalDisabled: "#D57461",
   colorDeselect: "#EEF1F4", //e.g. red
   colorHighlight: "#F0E300", //yellow
+  colorRowHighlight: "#B2C0D3", //light blue - for Highlighting selected row in a grid
   colorTooltipBackground: "#FFEDEA",
   // Drop Shadow Colors are from https://www.figma.com/design/nD9QK56Mzq7xNSaSUoeGx0/TDM-Calculator?node-id=16061-4518&t=8f3dn1oKCVqu00uc-4
   colorDropShadow: "#00000040",


### PR DESCRIPTION
- Fixes #2837 

### What changes did you make?

- On Roles, Archived Accounts and Archived Projects, a non-existent style was applied to the column headings, causing the column headings to be white text on a white background. Applied the correct color.

### Why did you make the changes (we will use this info to test)?

- To make column headings visible.

### Issue-Specific User Account

Security Admin

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

(See comments by Rabia on Issue)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1115" height="562" alt="image" src="https://github.com/user-attachments/assets/8d9bd786-1139-4aa5-b82d-70b9e81082ae" />

<img width="1116" height="565" alt="image" src="https://github.com/user-attachments/assets/65845479-ee03-4203-88a5-13e6f4318b19" />

<img width="1116" height="566" alt="image" src="https://github.com/user-attachments/assets/88d87221-c7d7-4fe9-826d-e4cc9964c6e1" />

<img width="1503" height="489" alt="image" src="https://github.com/user-attachments/assets/c3f9e45f-70dc-4bdf-b28d-bf719bdb87d1" />

<img width="1498" height="528" alt="image" src="https://github.com/user-attachments/assets/19eb8803-b929-4e29-bdd1-4039eb595ba2" />

</details>
