### PR TITLE
3087 Update password requirement wording on Create Account page

### DIFF
--- a/client/src/components/Authorization/Register.jsx
+++ b/client/src/components/Authorization/Register.jsx
@@ -150,7 +150,7 @@ const PasswordRules = ({ value, touched, classes }) => {
     },
     {
       label:
-        "Password must contain one special character from the following list: !@#$%&*?",
+        "Password must contain at least one special character from the following list: !@#$%&*?",
       valid: /[!@#$%&*?]/.test(value)
     },
     {


### PR DESCRIPTION
- Fixes #3087 

### What changes did you make?

- Updated wording per stakeholder request:
Current Text: `Password must contain one special character from the following list: !@#$%&*?`
Requested Text: `Password must contain at least one special character from the following list: !@#$%&*?`

### Why did you make the changes (we will use this info to test)?

- We need to update the wording of the fourth password requirement so that the changes requested by the stakeholders can be implemented.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

<img width="539" height="237" alt="Screenshot 2026-04-01 at 3 30 12 PM" src="https://github.com/user-attachments/assets/8c290347-db1d-45da-93e0-b52b00853a6f" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="539" height="239" alt="Screenshot 2026-04-01 at 3 29 43 PM" src="https://github.com/user-attachments/assets/6b6e098b-616e-4756-bab2-ffe4d9c77143" />

</details>
