### PR TITLE
2965 add Submitted date to Manage Submissions page

### DIFF
--- a/client/src/components/Submissions/ManageSubmissionsPage.jsx
+++ b/client/src/components/Submissions/ManageSubmissionsPage.jsx
@@ -379,6 +379,14 @@ const ManageSubmissions = ({ contentContainerRef }) => {
     },
     { id: "droName", label: "DRO", popupType: "stringList", colWidth: "10rem" },
     {
+      id: "dateSubmitted",
+      label: "Submitted",
+      popupType: "datetime",
+      startDatePropertyName: "startDateSubmitted",
+      endDatePropertyName: "endDateSubmitted",
+      colWidth: "10rem"
+    },
+    {
       id: "assignee",
       label: "Assignee",
       popupType: "string",

--- a/client/src/components/Submissions/SubmissionTableRow.jsx
+++ b/client/src/components/Submissions/SubmissionTableRow.jsx
@@ -140,6 +140,7 @@ const SubmissionTableRow = ({
       <Td>{project.author}</Td>
       <Td align="center">{project.projectLevel}</Td>
       <Td>{project.droName}</Td>
+      <Td>{formatDate(project.dateSubmitted)}</Td>
       <TdExpandable>{project.assignee}</TdExpandable>
       <Td>{formatDate(project.dateAssigned)}</Td>
       <Td>{project.invoiceStatusName}</Td>


### PR DESCRIPTION
- Fixes #2965 

### What changes did you make?

- Add Submitted Date column to the tables on Manage Submission page

### Why did you make the changes (we will use this info to test)?

- Allow users to sort and filter by Submitted Date

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

<img width="1433" height="705" alt="Screenshot 2026-04-01 at 3 49 07 PM" src="https://github.com/user-attachments/assets/54f3d8a1-1974-4260-a3a8-dc6bcbda4aa9" />

</details>

<details>
<summary>Visuals after changes are applied</summary>

Sorted newest->oldest
<img width="1436" height="707" alt="Screenshot 2026-04-01 at 3 46 50 PM" src="https://github.com/user-attachments/assets/045890bc-2fca-4e18-b52f-8a59bf293e31" />

Sorted oldest->newest
<img width="1433" height="709" alt="Screenshot 2026-04-01 at 3 47 22 PM" src="https://github.com/user-attachments/assets/d4920fa7-51d3-4271-912d-94295b9841d7" />

Filtered
<img width="316" height="300" alt="Screenshot 2026-04-01 at 3 47 44 PM" src="https://github.com/user-attachments/assets/ee35d7c3-93f8-4881-b6c0-88d93dbf23b0" />
<img width="1436" height="705" alt="Screenshot 2026-04-01 at 3 47 56 PM" src="https://github.com/user-attachments/assets/4831925f-61bf-4187-ade0-b26a793d7ce8" />

</details>
