### PR TITLE
3006 fix shared snapshot when not shared bug

### DIFF
--- a/client/src/components/Modals/ActionSnapshotShare.jsx
+++ b/client/src/components/Modals/ActionSnapshotShare.jsx
@@ -575,5 +575,5 @@ ShareSnapshotModal.propTypes = {
   mounted: PropTypes.bool,
   onClose: PropTypes.func,
   project: PropTypes.any,
-  onSharedEmailsChange: PropTypes.func,
+  onSharedEmailsChange: PropTypes.func
 };

--- a/client/src/components/Modals/ActionSnapshotShare.jsx
+++ b/client/src/components/Modals/ActionSnapshotShare.jsx
@@ -575,5 +575,5 @@ ShareSnapshotModal.propTypes = {
   mounted: PropTypes.bool,
   onClose: PropTypes.func,
   project: PropTypes.any,
-  sharedEmails: PropTypes.array,
+  onSharedEmailsChange: PropTypes.func,
 };

--- a/client/src/components/Modals/ActionSnapshotShare.jsx
+++ b/client/src/components/Modals/ActionSnapshotShare.jsx
@@ -151,7 +151,7 @@ const emailSchema = Yup.string()
   .required("Email is required")
   .matches(/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/, "Invalid email address");
 
-export default function ShareSnapshotModal({ mounted, onClose, project }) {
+export default function ShareSnapshotModal({ mounted, onClose, project, onSharedEmailsChange }) {
   const theme = useTheme();
   const classes = useStyles({ theme });
   const modalContentRef = useRef(null);
@@ -174,6 +174,7 @@ If you don't already have a [TDM Calculator](${tdmLink}) account, please set one
     if (project.id) {
       const response = await projectShareService.getByProjectId(project.id);
       setSharedEmails(response.data);
+      onSharedEmailsChange?.(response.data);
     }
   };
 

--- a/client/src/components/Modals/ActionSnapshotShare.jsx
+++ b/client/src/components/Modals/ActionSnapshotShare.jsx
@@ -151,7 +151,12 @@ const emailSchema = Yup.string()
   .required("Email is required")
   .matches(/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/, "Invalid email address");
 
-export default function ShareSnapshotModal({ mounted, onClose, project, onSharedEmailsChange }) {
+export default function ShareSnapshotModal({
+  mounted,
+  onClose,
+  project,
+  onSharedEmailsChange
+}) {
   const theme = useTheme();
   const classes = useStyles({ theme });
   const modalContentRef = useRef(null);
@@ -569,5 +574,6 @@ If you don't already have a [TDM Calculator](${tdmLink}) account, please set one
 ShareSnapshotModal.propTypes = {
   mounted: PropTypes.bool,
   onClose: PropTypes.func,
-  project: PropTypes.any
+  project: PropTypes.any,
+  sharedEmails: PropTypes.array,
 };

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
@@ -105,6 +105,7 @@ const TdmCalculationWizard = props => {
   const [selectedDro, setSelectedDro] = useState(null); // Stores the DRO the user selects from the selection modal
   const [committedDro, setCommittedDro] = useState(null); // Stores the DRO the user confirms from the selection modal
   const isSubmittingSnapshot = useRef(false);
+  const [sharedEmails, setSharedEmails] = useState([]);
 
   useEffect(() => {
     fetchDroOptions(setDroOptions);
@@ -298,6 +299,10 @@ const TdmCalculationWizard = props => {
     }
     setDeleteModalOpen(false);
   };
+
+  const updateSharedEmails = (emails) => {
+    setSharedEmails(emails);
+  }
 
   /*
     shouldBlock determines if user should be blocked from navigating away
@@ -580,6 +585,7 @@ const TdmCalculationWizard = props => {
           onSave={onSave}
           project={project}
           shareView={shareView}
+          sharedEmails={sharedEmails}
         />
       </ContentContainerWithTables>
       <CopyAndEditSnapshotModal
@@ -639,6 +645,7 @@ const TdmCalculationWizard = props => {
         mounted={shareSnapshotModalOpen}
         onClose={handleShareSnapshotModalClose}
         project={project}
+        onSharedEmailsChange={updateSharedEmails}
       />
       <DROSelectionModal
         mounted={droSelectionModalOpen}

--- a/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
+++ b/client/src/components/ProjectWizard/TdmCalculationWizard.jsx
@@ -300,9 +300,9 @@ const TdmCalculationWizard = props => {
     setDeleteModalOpen(false);
   };
 
-  const updateSharedEmails = (emails) => {
+  const updateSharedEmails = emails => {
     setSharedEmails(emails);
-  }
+  };
 
   /*
     shouldBlock determines if user should be blocked from navigating away

--- a/client/src/components/ProjectWizard/WizardFooter.jsx
+++ b/client/src/components/ProjectWizard/WizardFooter.jsx
@@ -67,7 +67,8 @@ const WizardFooter = ({
   isDroCommitted,
   isSubmittingSnapshot,
   project,
-  shareView
+  shareView,
+  sharedEmails,
 }) => {
   const classes = useStyles();
   const projectNameRule = rules && rules.find(r => r.code === "PROJECT_NAME");
@@ -100,6 +101,13 @@ const WizardFooter = ({
     bodyClass: "printContainer",
     pageStyle: ".printContainer {overflow: hidden;}"
   });
+
+  /**
+   * Determine if the snapshot has been shared, if there are any emails it has been shared with
+   */
+  const isSharedSnapshot = () => {
+    return sharedEmails && sharedEmails.length > 0;
+  }
 
   return (
     <>
@@ -222,9 +230,9 @@ const WizardFooter = ({
             <strong>Status: </strong>
             {!formattedDateSnapshotted
               ? "Draft"
-              : project.loginId === loggedInUserId
-                ? "Snapshot"
-                : "Shared Snapshot"}
+              : isSharedSnapshot()
+                ? "Shared Snapshot"
+                : "Snapshot"}
           </div>
           {formattedDateSubmitted ? (
             <div>

--- a/client/src/components/ProjectWizard/WizardFooter.jsx
+++ b/client/src/components/ProjectWizard/WizardFooter.jsx
@@ -68,7 +68,7 @@ const WizardFooter = ({
   isSubmittingSnapshot,
   project,
   shareView,
-  sharedEmails,
+  sharedEmails
 }) => {
   const classes = useStyles();
   const projectNameRule = rules && rules.find(r => r.code === "PROJECT_NAME");
@@ -289,7 +289,7 @@ WizardFooter.propTypes = {
   project: PropTypes.any,
   selectProject: PropTypes.any,
   shareView: PropTypes.bool,
-  sharedEmails: PropTypes.array,
+  sharedEmails: PropTypes.array
 };
 
 export default WizardFooter;

--- a/client/src/components/ProjectWizard/WizardFooter.jsx
+++ b/client/src/components/ProjectWizard/WizardFooter.jsx
@@ -107,7 +107,7 @@ const WizardFooter = ({
    */
   const isSharedSnapshot = () => {
     return sharedEmails && sharedEmails.length > 0;
-  }
+  };
 
   return (
     <>
@@ -288,7 +288,8 @@ WizardFooter.propTypes = {
   onDownload: PropTypes.any,
   project: PropTypes.any,
   selectProject: PropTypes.any,
-  shareView: PropTypes.bool
+  shareView: PropTypes.bool,
+  sharedEmails: PropTypes.array,
 };
 
 export default WizardFooter;


### PR DESCRIPTION
- Fixes #3006

### What changes did you make?
- update logic in WizardFooter for determining shared snapshot by checking if there are any results in sharedEmails
- pass callback from TdmCalculationWizard to ShareSnapshotModal to get sharedEmails and then pass to WizardFooter show 'Shared Snapshot' text if there are any shared emails
 
### Why did you make the changes (we will use this info to test)?

- fix bug where the logic to show "Shared Snapshot" is wrong, it was checking if the current logged-in user is the same as the one who created the snapshot, when it should be checking if it was shared to anyone

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

Using project ID 00000-0084, replicated before (bug) behavior

**Snapshot state: NOT SHARED**

Logged in as User: shows "Snapshot" matching the bug report
- Calculator Page 5
<img width="1360" height="535" alt="image" src="https://github.com/user-attachments/assets/a17b72cf-92fe-4bc1-8eab-3d146e7e8829" />

- PDF footer
<img width="695" height="490" alt="image" src="https://github.com/user-attachments/assets/ab7830e1-077f-4c78-80ce-2d5fc655903a" />

<br>
<br>
Logged in as Admin: shows "Shared Snapshot" matching the bug report

- Calculator Page 5
<img width="1281" height="482" alt="image" src="https://github.com/user-attachments/assets/17ca10e5-c8e4-4928-bfec-50fff00f04a1" />

- PDF footer
<img width="660" height="389" alt="image" src="https://github.com/user-attachments/assets/2c829554-472d-49e9-ba55-ccc8312de32b" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
Using project ID 00000-0084, replicated the same behavior but fixed:

**Snapshot state: NOT SHARED**

User:
- Calculator Page 5
<img width="434" height="164" alt="image" src="https://github.com/user-attachments/assets/90b5ec0e-3918-4686-bcba-f21d2ebad27b" />




Admin:
- Calculator Page 5
<img width="485" height="198" alt="image" src="https://github.com/user-attachments/assets/e5f141bf-0a26-4ebe-962b-7cccf5a45f67" />



<br>
<br>

**Snapshot state: _User_ SHARED SNAPSHOT TO _Security Admin_**

User:
- Calculator Page 5
<img width="493" height="164" alt="image" src="https://github.com/user-attachments/assets/e1981e09-d5d8-46fc-9431-54b8c0a7ff65" />


Admin:
- Calculator Page 5
<img width="435" height="188" alt="image" src="https://github.com/user-attachments/assets/2761b582-66e3-4957-aca6-3aad8213c1e8" />


Security Admin:
- Calculator Page 5
<img width="467" height="174" alt="image" src="https://github.com/user-attachments/assets/b60b5066-606e-49c7-aa34-9360cec61eaf" />



</details>
