### PR TITLE
Fixed crash when de-selecting to one row on My  Projects Page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -37,6 +37,7 @@ import ResetPassword from "./components/Authorization/ResetPassword";
 import ForgotPassword from "./components/Authorization/ForgotPassword";
 import Feedback from "./components/Feedback/FeedbackPage";
 import ErrorPage from "./components/ErrorPage";
+import RouteErrorBoundary from "./components/ErrorBoundary";
 import Offline from "./components/Offline";
 import Logout from "./components/Authorization/Logout";
 import SubmissionsPage from "./components/Submissions/SubmissionsPage";
@@ -60,6 +61,7 @@ const App = () => {
             <ClientAreaLayout appContainerRef={appContainerRef} />
           </div>
         }
+        errorElement={<RouteErrorBoundary />}
         // loader={async () => {
         //   const configs = await getConfigs();
         //   const calculations = await getCalculations(true);

--- a/client/src/components/ErrorBoundary.jsx
+++ b/client/src/components/ErrorBoundary.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useRouteError, isRouteErrorResponse } from "react-router-dom";
+import ContentContainer from "./Layout/ContentContainer";
+import { createUseStyles, useTheme } from "react-jss";
+
+const useStyles = createUseStyles(theme => ({
+  heading1: theme.typography.heading1
+}));
+
+const RouteErrorBoundary = () => {
+  const error = useRouteError();
+  const theme = useTheme();
+  const classes = useStyles(theme);
+
+  let message;
+  if (isRouteErrorResponse(error)) {
+    message = `${error.status} ${error.statusText}`;
+  } else if (error instanceof Error) {
+    message = error.message;
+  } else {
+    message = "An unexpected error occurred.";
+  }
+
+  return (
+    <ContentContainer>
+      <h1 className={classes.heading1}>Something went wrong</h1>
+      <p>{message}</p>
+    </ContentContainer>
+  );
+};
+
+export default RouteErrorBoundary;

--- a/client/src/components/PdfPrint/PdfFooter.jsx
+++ b/client/src/components/PdfPrint/PdfFooter.jsx
@@ -71,7 +71,10 @@ const PdfFooter = ({ project }) => {
           </div>
           <div className={classes.pdfTimeText}>
             Guidelines Version:
-            {formatCalculation(calculations[project.calculationId])}
+            {calculations &&
+              project.calculationId &&
+              calculations[project.calculationId] &&
+              formatCalculation(calculations[project.calculationId])}
           </div>
           {isAdmin && (
             <div className={classes.pdfTimeText}>

--- a/client/src/helpers/Calculations.js
+++ b/client/src/helpers/Calculations.js
@@ -30,6 +30,7 @@ export const getCalculations = async () => {
   Format: Version {version number} {date range (if applicable)}
 */
 export const formatCalculation = calculation => {
+  if (!calculation) return "Reference to non-existent calculation";
   const dateStart = calculation.dateStart
     ? formatDate(calculation.dateStart)
     : "";


### PR DESCRIPTION
- Fixes #3079

### What changes did you make?

- Under the circumstances described in the issue, the <PdfFooter> component received  project object that apparently did not have  calculationId property, causing the method that calculates the Program Guidelnes version to throw an error. It's not clear why the calculationId property is missing in this case, but I modified the helper method formatCalculation to fail gracefully if it is not given a calculation object parameter.
- I also added an ErrorBoundary to the React Router, to help with debugging errors thrown during rendering.

### Why did you make the changes (we will use this info to test)?

- See Issue 

### Issue-Specific User Account

Seemed to only happen for non-admin users?

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1148" height="445" alt="image" src="https://github.com/user-attachments/assets/7154ff40-afd0-4ab1-8fd4-29475a7d86c2" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1295" height="804" alt="image" src="https://github.com/user-attachments/assets/1ed9dc13-a0e5-459b-ad4b-ec390ae8c4d0" />

I.e, normal rendering of the grid when a single row is checked, after previously selecting mulitple rows.

</details>
