### PR TITLE
3088 add tld req to registration email

### DIFF
--- a/client/src/components/Authorization/Register.jsx
+++ b/client/src/components/Authorization/Register.jsx
@@ -95,6 +95,11 @@ const EmailRules = ({ value, touched, classes }) => {
       label:
         "You can use letters, numbers, apostrophe, hyphen, period and a plus sign only",
       valid: /^[a-zA-Z0-9@.'+-]+$/.test(value)
+    },
+    {
+      label:
+        "Your email must end with a valid top-level domain such as .com, .org, .net, etc. (at least 2 letters after the last period)",
+      valid: /^[a-zA-Z0-9@.'+-]*\.[a-zA-Z0-9.'+-]{2,}$/.test(value)
     }
   ];
 

--- a/server/app/schemas/account.register.js
+++ b/server/app/schemas/account.register.js
@@ -14,8 +14,16 @@ module.exports = {
     },
     email: {
       type: "string",
-      minLength: 3,
-      pattern: "\\S+@\\S+"
+      minLength: 6,
+      pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+      /*
+        ^ and $ → Ensure the match is for the entire string.
+        [a-zA-Z0-9._%+-]+ → Local part (before @), allows letters, digits, dots, underscores, percent, plus, and hyphen.
+        @ → Mandatory separator.
+        [a-zA-Z0-9.-]+ → Domain name part, allows letters, digits, dots, and hyphens.
+        \\. → Literal dot before the TLD.
+        [a-zA-Z]{2,} → Top-level domain (at least 2 letters, e.g., .com, .org).
+      */
     },
     password: {
       type: "string",


### PR DESCRIPTION
- Fixes #3088

### What changes did you make
- Added an additional validation check to the email validation on the registration page that requires the email to end with two or more characters after a period - that is, it must end with something that looks like a top-level domain.
- Also upgraded the regex used by server-side validation for the email to be more specific.

### Why did you make the changes (we will use this info to test)?

- So that the user gets prompted to use an email that ends with something that looks like a TLD.

### Issue-Specific User Account
n/a

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="579" height="791" alt="image" src="https://github.com/user-attachments/assets/0cd28fa0-cdb1-4491-a336-91338cca5a3c" />

Note that the email entered does not end with a top-level domain, but the front-end validation checks are all checked and the submit request will do through (just like it would for any email that meets the basic criteria, but does not correspond to a real email account.

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
