### PR TITLE
3051: Unsaved changes warning triggered after opening FAQ external link.

### DIFF
--- a/client/src/components/Faq/Answer.jsx
+++ b/client/src/components/Faq/Answer.jsx
@@ -71,6 +71,8 @@ export const Answer = ({
   const classes = useStyles(admin);
 
   const handleSetFAQ = event => {
+    if (!isEditAnswer) return;
+
     // TODO: the early returns look like hackery.
     // not sure what it's trying to do, but handleSetFAQ is called on blur,
     // which means it's called when opening links in a new tab.

--- a/client/src/components/Faq/FaqView.jsx
+++ b/client/src/components/Faq/FaqView.jsx
@@ -11,7 +11,7 @@ import { createUseStyles } from "react-jss";
 import DeleteFaqModal from "../Modals/WarningFaqDelete";
 import SaveConfirmationModal from "../Modals/WarningFaqSaveEdits";
 import FaqConfirmDialog from "../Modals/WarnngFaqLeave";
-import { matchPath, useBlocker as useBlocker } from "react-router-dom";
+import { matchPath, useBlocker } from "react-router-dom";
 
 const useStyles = createUseStyles(theme => ({
   headerContainer: {
@@ -73,9 +73,9 @@ const FaqView = () => {
         return currentMatch && nextMatch;
       };
 
-      return formHasSaved && !isSamePage(currentLocation, nextLocation);
+      return admin && formHasSaved && !isSamePage(currentLocation, nextLocation);
     },
-    [formHasSaved]
+    [admin, formHasSaved]
   );
 
   const blocker = useBlocker(shouldBlock);


### PR DESCRIPTION
- Fixes #3051

The root cause that clicking an external link triggers the bug:

The outermost container of the Answer.jsx component has an onBlur handler that is triggered when a focus shift occurs after a user follows an external link. Because the "edit mode" is not considered in `handleSetFAQ` the FAQ "unsaved changes" warning dialog is subsequently shown.


### What changes did you make?

Code Changes:

- Apply a fix to shouldBlock in FaqView.jsx so that it respects admin mode

- Add an explicit safeguard inside the component's handleSetFAQ function so that it early-exits when not in edit mode


### Why did you make the changes (we will use this info to test)?

The changes in the pull request address the following issue:
  “Unsaved changes will be lost” warning appears after interacting with FAQ page

Now, if a visitor clicks on the "external link" and the browser loses window focus, the app ignores the focus shift instead of trying to save an empty edit. The “Unsaved changes will be lost” warning dialog is no longer shown.