### PR TITLE
3088 fix email validation summary checkbox

### DIFF
--- a/client/src/components/Authorization/Register.jsx
+++ b/client/src/components/Authorization/Register.jsx
@@ -292,10 +292,10 @@ const Register = props => {
       // for consistency with the EmailRules component.
       // Ulitimately, the only real way to validate an email it to send to it and
       // see if it is received.
-      .matches(emailRules[0].label, emailRules[0].regex)
-      .matches(emailRules[1].label, emailRules[1].regex)
-      .matches(emailRules[2].label, emailRules[2].regex)
-      .matches(emailRules[3].label, emailRules[3].regex)
+      .matches(emailRules[0].regex, emailRules[0].label)
+      .matches(emailRules[1].regex, emailRules[1].label)
+      .matches(emailRules[2].regex, emailRules[2].label)
+      .matches(emailRules[3].regex, emailRules[3].label)
       .required("Email is required"),
     password: Yup.string()
       .min(12, "Password must be at least 12 characters")

--- a/client/src/components/Authorization/Register.jsx
+++ b/client/src/components/Authorization/Register.jsx
@@ -80,28 +80,35 @@ ValidationIcon.propTypes = {
   }).isRequired
 };
 
+// These are the specific email validation rules that the designers specified.
+// If they prove to be too strict, they may need to be relaxed.
+const emailRules = [
+  {
+    label:
+      "Your email must have at least one character before and after the @ symbol",
+    regex: /^[^@]+@[^@]+$/
+  },
+  {
+    label: "Your email must begin and end with either a letter or a number",
+    regex: /^[a-zA-Z0-9].*[a-zA-Z0-9]$/
+  },
+  {
+    label:
+      "You can use letters, numbers, apostrophe, hyphen, period and a plus sign only",
+    regex: /^[a-zA-Z0-9@.'+-]+$/
+  },
+  {
+    label:
+      "Your email must end with a valid top-level domain such as .com, .org, .net, etc. (at least 2 letters after the last period)",
+    regex: /^[a-zA-Z0-9@.'+-]*\.[a-zA-Z0-9.'+-]{2,}$/
+  }
+];
+
 const EmailRules = ({ value, touched, classes }) => {
-  const rules = [
-    {
-      label:
-        "Your email must have at least one character before and after the @ symbol",
-      valid: /^[^@]+@[^@]+$/.test(value)
-    },
-    {
-      label: "Your email must begin and end with either a letter or a number",
-      valid: /^[a-zA-Z0-9].*[a-zA-Z0-9]$/.test(value)
-    },
-    {
-      label:
-        "You can use letters, numbers, apostrophe, hyphen, period and a plus sign only",
-      valid: /^[a-zA-Z0-9@.'+-]+$/.test(value)
-    },
-    {
-      label:
-        "Your email must end with a valid top-level domain such as .com, .org, .net, etc. (at least 2 letters after the last period)",
-      valid: /^[a-zA-Z0-9@.'+-]*\.[a-zA-Z0-9.'+-]{2,}$/.test(value)
-    }
-  ];
+  const rules = emailRules.map(rule => ({
+    label: rule.label,
+    valid: rule.regex.test(value)
+  }));
 
   return (
     <div>
@@ -279,7 +286,16 @@ const Register = props => {
       )
       .required("Last Name is required"),
     email: Yup.string()
-      .email("Invalid email address")
+      // Since the TDM designers specified the specific validation rules they
+      // wanted, it won't match up with the Yup standard email validation,
+      // so we apply the same specific regex rules as the EmailRules component
+      // for consistency with the EmailRules component.
+      // Ulitimately, the only real way to validate an email it to send to it and
+      // see if it is received.
+      .matches(emailRules[0].label, emailRules[0].regex)
+      .matches(emailRules[1].label, emailRules[1].regex)
+      .matches(emailRules[2].label, emailRules[2].regex)
+      .matches(emailRules[3].label, emailRules[3].regex)
       .required("Email is required"),
     password: Yup.string()
       .min(12, "Password must be at least 12 characters")


### PR DESCRIPTION
- Fixes #3088 

### What changes did you make?
The email validation rules applied for the email validation field on the register form were not equivalent to the composite of the four specific validation rules itemized below the email input field, so I modified the overall validation to be implemented using exactly the same rules as the four itemized rules.

### Why did you make the changes (we will use this info to test)?

- To avoid cases where the overall email validation check is not consistent with the result of applying the four more detailed rules.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="474" height="411" alt="image" src="https://github.com/user-attachments/assets/059e81ef-fe9b-4285-90e8-feb81a2c2a67" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="536" height="469" alt="image" src="https://github.com/user-attachments/assets/27d49e72-03fd-43b4-ae51-8082f2ad8ba0" />

</details>
