### PR TITLE
2636:  Add API rate limitting middleware

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -5,7 +5,7 @@ const dotenv = require("dotenv");
 const cookieParser = require("cookie-parser");
 const errorHandler = require("error-handler");
 const routes = require("./app/routes");
-// const helmet = require("helmet");
+const helmet = require("helmet");
 // const pino = require("express-pino-logger")();
 
 dotenv.config();
@@ -31,7 +31,11 @@ const app = express();
 //   }
 // };
 
-// app.use(helmet(helmetConfig));
+app.use(
+  helmet({
+    contentSecurityPolicy: false,
+  }),
+);
 // app.use(pino);
 
 if (process.env.NODE_ENV === "production") {

--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ const cookieParser = require("cookie-parser");
 const errorHandler = require("error-handler");
 const routes = require("./app/routes");
 const helmet = require("helmet");
+const rateLimit = require("express-rate-limit");
 // const pino = require("express-pino-logger")();
 
 dotenv.config();
@@ -71,16 +72,21 @@ app.use(express.static(".well-known"));
 app.use(express.static(path.join(__dirname, "client/build")));
 app.use(express.static("public"));
 
-// TODO: Is following line needed for something. Already added above with
-// {extended: true} option.
-app.use(express.urlencoded({ extended: false }));
+// General limiter for /api
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
 
-// Web API routes
-app.use("/api", routes);
+// Stricter limiter for /api/accounts
+const accountsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // limit each IP to 10 requests per windowMs
+});
 
-// Serve static files from the React app
-app.use(express.static(path.join(__dirname, "client/build")));
-app.use(express.static("public"));
+// Apply API rate limiting
+app.use("/api/accounts", accountsLimiter);
+app.use("/api", apiLimiter, routes);
 
 // The "catchall" handler: for any request that doesn't
 // match one above, send back React's index.html file.


### PR DESCRIPTION
- Fixes #2636

### What changes did you make?
The changes in this pull request enable the `express-rate-limit` middleware for our Express.js backend. Including this rate-limiting functionality addresses the concerns of API resource exhaustion and abuse by limiting the number of requests a client can make to our API within a specific time frame.

#### Enabled `express-rate-limit` middleware
- Create `rateLimit()` middleware that apply for all endpoints defined within the "/api/" and  "/api/accounts/" API routes
- Given routes configured with listed rate limits
  - "/api"          : limit each IP to 100 requests per 15 min window
  - "/api/accounts" : limit each IP to  10 requests per 15 min window

#### Enabled `helmet` middleware
While applying the rate limiting change in server.js I noticed that helmet is installed but commented out and its benefits not leveraged while a CSP configuration is phased in.

The following change enables the installed helmet middleware, but leaves CSP off.

```diff
+app.use(
+  helmet({
+    contentSecurityPolicy: false,
+  }),
+);
```

### Why did you make the changes (we will use this info to test)?
#### Enforce a baseline security posture
Without rate limiting, attackers can perform brute force login requests to the login API until they obtain correct credentials. We will also be less vulnerable to DDoS attacks this way.

With `helmet` (even without CSP): We get important HTTP headers that eliminate several low-effort attack vectors
