### PR TITLE
Kk/3119 indicate self in createdby filter

### DIFF
--- a/client/src/components/Faq/FaqView.jsx
+++ b/client/src/components/Faq/FaqView.jsx
@@ -73,7 +73,9 @@ const FaqView = () => {
         return currentMatch && nextMatch;
       };
 
-      return admin && formHasSaved && !isSamePage(currentLocation, nextLocation);
+      return (
+        admin && formHasSaved && !isSamePage(currentLocation, nextLocation)
+      );
     },
     [admin, formHasSaved]
   );

--- a/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
@@ -81,6 +81,8 @@ const TextPopup = ({
 }) => {
   const userContext = useContext(UserContext);
   const property = header.accessor || header.id;
+  const loggedInUserName = `${userContext?.account?.lastName}, ${userContext?.account?.firstName}`;
+
   const getDisplayValue = value => {
     if (property === "droName" && value === "") {
       return "No DRO Assigned";
@@ -121,14 +123,15 @@ const TextPopup = ({
     selectOptions = droOptions.map(dro => dro.name);
     selectOptions.push("No DRO Assigned");
   } else if (property === "author" && droOptions) {
-    const loggedInUserName = `${userContext?.account?.lastName}, ${userContext?.account?.firstName} (Me)`;
     let hasLoggedInUserInList = false;
 
     selectOptions = [
       ...new Set(
         filteredProjects.map(p => {
           const name = `${p.lastName}, ${p.firstName}`;
-          if (name === loggedInUserName) hasLoggedInUserInList = true;
+          if (p.loginId === userContext?.account?.id) {
+            hasLoggedInUserInList = true;
+          }
           return name;
         })
       )
@@ -281,7 +284,6 @@ const TextPopup = ({
 
         {filteredOptions.map(o => {
           const checked = isChecked(o);
-          const loggedInUserName = `${userContext?.account?.lastName}, ${userContext?.account?.firstName}`;
 
           return (
             <div key={o} className={classes.listItem}>

--- a/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
@@ -281,6 +281,8 @@ const TextPopup = ({
 
         {filteredOptions.map(o => {
           const checked = isChecked(o);
+          const loggedInUserName = `${userContext?.account?.lastName}, ${userContext?.account?.firstName}`;
+
           return (
             <div key={o} className={classes.listItem}>
               <ToggleCheckbox
@@ -295,7 +297,7 @@ const TextPopup = ({
                 }
                 label={o}
               />
-              <span>{o}</span>
+              <span>{o === loggedInUserName ? `${o} (Me)` : o}</span>
             </div>
           );
         })}


### PR DESCRIPTION
- Fixes #3119 

### What changes did you make?

- Within `TextPopup` a check was added to see if the current user is any of the created by users. If so it displays `(Me)` next to the users name. 

### Why did you make the changes (we will use this info to test)?

- To quickly show if the current users is in the created by list. 

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)
<img width="389" height="584" alt="Screenshot 2026-04-29 at 4 17 30 PM" src="https://github.com/user-attachments/assets/473029af-5ee4-4344-b2fd-1680d35d6bfc" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)
<img width="389" height="584" alt="Screenshot 2026-04-29 at 4 27 27 PM" src="https://github.com/user-attachments/assets/10c68262-1be9-480b-a8d4-67524ad81584" />


</details>