### PR TITLE
fix(terms): change LADOT email link to mailto: instead of website (#3…

### DIFF
--- a/client/src/components/TermsAndConditions/TermsAndConditionsContent.jsx
+++ b/client/src/components/TermsAndConditions/TermsAndConditionsContent.jsx
@@ -136,7 +136,7 @@ const TermsAndConditionsContent = () => {
       <p className={classes.para}>
         Before making decisions using the information provided in this
         application, contact City LADOT staff at{" "}
-        <a href="https://www.lacity.org/">ladot.tdm@lacity.org</a> to confirm
+        <a href="mailto:ladot.tdm@lacity.org">ladot.tdm@lacity.org</a> to confirm
         the validity of the data provided.
       </p>
     </div>


### PR DESCRIPTION
…082)




- Fixes #3082

### What changes did you make?

The bottom of the Terms and Conditions page rendered the LADOT contact email as a link, but the `href` pointed to `https://www.lacity.org/` instead of a `mailto:` URI. Clicking the link took the user to a generic city website rather than opening their default email client — the very thing the link text promised.

One-line fix: change the href to
`mailto:ladot.tdm@lacity.org`. The visible link text was already correct, so users see no change other than the click behavior matching the visible text.

### Why did you make the changes (we will use this info to test)?

- See Issue

### Issue-Specific User Account
(any)

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

(no change to appearance)
