### PR TITLE
2868 Display Last Login On Security Admin Page

### DIFF
--- a/client/src/components/Roles/Roles.jsx
+++ b/client/src/components/Roles/Roles.jsx
@@ -245,11 +245,11 @@ const Roles = ({ contentContainerRef }) => {
             <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
               Dev. Review Office
             </th>
-            <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
-              Email Confirmed
-            </th>
             <th className={`${classes.td} ${classes.theadLabel}`}>
               Registration Date
+            </th>
+            <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
+              Email Confirmed
             </th>
             <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
               Options

--- a/client/src/components/Roles/Roles.jsx
+++ b/client/src/components/Roles/Roles.jsx
@@ -245,13 +245,13 @@ const Roles = ({ contentContainerRef }) => {
             <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
               Dev. Review Office
             </th>
-            <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
+            <th className={`${classes.td} ${classes.theadLabel}`}>
               Registration Date
             </th>
             <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
               Email Confirmed
             </th>
-            <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
+            <th className={`${classes.td} ${classes.theadLabel}`}>
               Last Active Date
             </th>
             <th className={`${classes.tdCenter} ${classes.theadLabel}`}>

--- a/client/src/components/Roles/Roles.jsx
+++ b/client/src/components/Roles/Roles.jsx
@@ -245,11 +245,14 @@ const Roles = ({ contentContainerRef }) => {
             <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
               Dev. Review Office
             </th>
-            <th className={`${classes.td} ${classes.theadLabel}`}>
+            <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
               Registration Date
             </th>
             <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
               Email Confirmed
+            </th>
+            <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
+              Last Active Date
             </th>
             <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
               Options

--- a/client/src/components/Roles/Roles.jsx
+++ b/client/src/components/Roles/Roles.jsx
@@ -30,9 +30,15 @@ const useStyles = createUseStyles(theme => ({
     textAlign: "center",
     fontSize: "16px"
   },
+  tableContainer: {
+    overflow: "auto", // changed to allow Universal Select to show above the page container when expanded
+    width: "calc(90vw - 20px)",
+    margin: "20px 0px",
+    height: "calc(90vh - 300px)"
+  },
   table: {
-    minWidth: "80%",
-    margin: "20px"
+    minWidth: "100%",
+    tableLayout: "fixed"
   },
   tr: {
     margin: "0.5em"
@@ -228,53 +234,89 @@ const Roles = ({ contentContainerRef }) => {
         </Link>
       </div>
 
-      <table className={classes.table}>
-        <thead className={classes.thead}>
-          <tr className={classes.tr}>
-            <th className={`${classes.td} ${classes.theadLabel}`}>Email</th>
-            <th className={`${classes.td} ${classes.theadLabel}`}>Name</th>
-            <th className={`${classes.td} ${classes.theadLabel}`}>
-              # of Projects
-            </th>
-            <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
-              Admin
-            </th>
-            <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
-              Security Admin
-            </th>
-            <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
-              Dev. Review Office
-            </th>
-            <th className={`${classes.td} ${classes.theadLabel}`}>
-              Registration Date
-            </th>
-            <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
-              Email Confirmed
-            </th>
-            <th className={`${classes.td} ${classes.theadLabel}`}>
-              Last Active Date
-            </th>
-            <th className={`${classes.tdCenter} ${classes.theadLabel}`}>
-              Options
-            </th>
-          </tr>
-        </thead>
-        <tbody className={classes.tbody}>
-          {filteredAccounts &&
-            filteredAccounts.map(account => (
-              <RolesTableRow
-                key={JSON.stringify(account)}
-                account={account}
-                classes={classes}
-                loggedInUserId={loggedInUserId}
-                onInputChange={onInputChange}
-                handleArchiveUser={handleArchiveUser}
-                isHovered={hoveredRow === account.id}
-                setHoveredRow={setHoveredRow}
-              />
-            ))}
-        </tbody>
-      </table>
+      <div className={classes.tableContainer}>
+        <table className={classes.table}>
+          <thead className={classes.thead}>
+            <tr className={classes.tr}>
+              <th
+                className={`${classes.td} ${classes.theadLabel}`}
+                style={{ width: "auto" }}
+              >
+                Email
+              </th>
+              <th
+                className={`${classes.td} ${classes.theadLabel}`}
+                style={{ width: "auto" }}
+              >
+                Name
+              </th>
+              <th
+                className={`${classes.td} ${classes.theadLabel}`}
+                style={{ width: "4em" }}
+              >
+                # of Projects
+              </th>
+              <th
+                className={`${classes.tdCenter} ${classes.theadLabel}`}
+                style={{ width: "4em" }}
+              >
+                Admin
+              </th>
+              <th
+                className={`${classes.tdCenter} ${classes.theadLabel}`}
+                style={{ width: "4em" }}
+              >
+                Security Admin
+              </th>
+              <th
+                className={`${classes.tdCenter} ${classes.theadLabel}`}
+                style={{ width: "4em" }}
+              >
+                Dev. Review Office
+              </th>
+              <th
+                className={`${classes.td} ${classes.theadLabel}`}
+                style={{ width: "7em" }}
+              >
+                Registered
+              </th>
+              <th
+                className={`${classes.tdCenter} ${classes.theadLabel}`}
+                style={{ width: "4em" }}
+              >
+                Email Confirmed
+              </th>
+              <th
+                className={`${classes.td} ${classes.theadLabel}`}
+                style={{ width: "7em" }}
+              >
+                Last Active
+              </th>
+              <th
+                className={`${classes.tdCenter} ${classes.theadLabel}`}
+                style={{ width: "4em" }}
+              >
+                Options
+              </th>
+            </tr>
+          </thead>
+          <tbody className={classes.tbody}>
+            {filteredAccounts &&
+              filteredAccounts.map(account => (
+                <RolesTableRow
+                  key={JSON.stringify(account)}
+                  account={account}
+                  classes={classes}
+                  loggedInUserId={loggedInUserId}
+                  onInputChange={onInputChange}
+                  handleArchiveUser={handleArchiveUser}
+                  isHovered={hoveredRow === account.id}
+                  setHoveredRow={setHoveredRow}
+                />
+              ))}
+          </tbody>
+        </table>
+      </div>
     </ContentContainerWithTables>
   );
 };

--- a/client/src/components/Roles/RolesTableRow.jsx
+++ b/client/src/components/Roles/RolesTableRow.jsx
@@ -82,6 +82,7 @@ const RolesTableRow = ({
       <td className={classes.tdCenter}>
         {account.emailConfirmed ? <MdCheck alt="Email confirmed" /> : ""}
       </td>
+      <td className={classes.td}>{formatDate(account.lastLoginDate)}</td>
       <td className={classes.tdCenter}>
         <Popup
           trigger={

--- a/client/src/components/Roles/RolesTableRow.jsx
+++ b/client/src/components/Roles/RolesTableRow.jsx
@@ -78,10 +78,10 @@ const RolesTableRow = ({
           }`}
         />
       </td>
+      <td className={classes.td}>{formatDate(account.dateCreated)}</td>
       <td className={classes.tdCenter}>
         {account.emailConfirmed ? <MdCheck alt="Email confirmed" /> : ""}
       </td>
-      <td className={classes.td}>{formatDate(account.dateCreated)}</td>
       <td className={classes.tdCenter}>
         <Popup
           trigger={

--- a/client/src/components/TermsAndConditions/TermsAndConditionsContent.jsx
+++ b/client/src/components/TermsAndConditions/TermsAndConditionsContent.jsx
@@ -136,8 +136,8 @@ const TermsAndConditionsContent = () => {
       <p className={classes.para}>
         Before making decisions using the information provided in this
         application, contact City LADOT staff at{" "}
-        <a href="mailto:ladot.tdm@lacity.org">ladot.tdm@lacity.org</a> to confirm
-        the validity of the data provided.
+        <a href="mailto:ladot.tdm@lacity.org">ladot.tdm@lacity.org</a> to
+        confirm the validity of the data provided.
       </p>
     </div>
   );


### PR DESCRIPTION
- Fixes #2868 

### What changes did you make?

- Fixes Terms and Conditions content which was causing the linter test to fail (spacing issue)
- Adds the last login date to the Security Roles table, and changes column order to:

Registration Date | Email Confirmed | Last Active Date

### Why did you make the changes (we will use this info to test)?


- We need to display the last login on the Security page (/roles) so that it will be easy to see if the account is still active.


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/506a49aa-acc4-4e67-b012-9ac12d3e7c86)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="2027" height="960" alt="image" src="https://github.com/user-attachments/assets/d5344eb3-b6a8-48a4-843c-00dc14d80f8e" />


</details>
