### PR TITLE
3116 disable delete from toolbar for submitted plans

### DIFF
--- a/client/src/components/Projects/MultiProjectToolbarMenu.jsx
+++ b/client/src/components/Projects/MultiProjectToolbarMenu.jsx
@@ -136,6 +136,7 @@ const MultiProjectToolbarMenu = ({
         return null;
       },
       visibility: () => {
+        // false indicates mixed statuses
         if (checkedProjectsStatusData.dateHidden === false) {
           return "Your selection includes both hidden and visible items";
         }

--- a/client/src/components/Projects/MultiProjectToolbarMenu.jsx
+++ b/client/src/components/Projects/MultiProjectToolbarMenu.jsx
@@ -98,6 +98,9 @@ const MultiProjectToolbarMenu = ({
       account.id === checkedProjectsStatusData.loginId
     : false;
 
+  const checkedProjectsSubmittedStatus =
+    checkedProjectsStatusData.dateSubmitted;
+
   const isBtnDisabled = (projProp, criteriaProp) => {
     const sameDateVals = checkedProjectsStatusData[projProp] !== false;
     const criteriaFilter = criteria[criteriaProp] === "all";
@@ -111,14 +114,36 @@ const MultiProjectToolbarMenu = ({
     isBtnDisabled("dateHidden", "visibility");
 
   const isDelBtnDisabled =
-    !isProjectOwner || isBtnDisabled("dateTrashed", "status");
+    !isProjectOwner ||
+    checkedProjectsSubmittedStatus !== null ||
+    isBtnDisabled("dateTrashed", "status");
 
-  const tooltipMsg = criteriaProp => {
-    if (checkedProjectIds.length === 0) return;
+  const getTooltipMsg = actionType => {
+    const hasNoSelection = checkedProjectIds.length === 0;
 
-    if (!isProjectOwner && criteriaProp !== "visibility") {
-      return "You have selected a project that does not belong to you";
-    }
+    if (actionType === "print" && hasNoSelection)
+      return "Please select one project";
+
+    if (!actionType || hasNoSelection) return null;
+
+    const contentRules = {
+      delete: () => {
+        // first priority check is ownership, if both are selected prioritize ownership msg
+        if (!isProjectOwner)
+          return "You have selected a project that does not belong to you";
+        if (checkedProjectsSubmittedStatus !== null)
+          return "One or more selected projects have already been submitted";
+        return null;
+      },
+      visibility: () => {
+        if (checkedProjectsStatusData.dateHidden === false) {
+          return "Your selection includes both hidden and visible items";
+        }
+        return null;
+      }
+    };
+
+    return contentRules[actionType]?.() ?? null;
   };
 
   // fetching rules for PDF
@@ -207,25 +232,22 @@ const MultiProjectToolbarMenu = ({
               }
             />
           </button>
-          {checkedProjectIds.length !== 1 ? (
-            <Tooltip
-              // Cannot use JSS, because Tooltip default styles would overwrite
-              style={{
-                ...theme.typography.paragraph1,
-                backgroundColor: theme.colors.secondary.lightGray,
-                width: "12rem",
-                borderRadius: "5px",
-                textAlign: "center",
-                boxShadow:
-                  "0px 4px 8px 3px rgba(0,0,0,0.15), 0px 1px 3px 0px rgba(0,0,0,0.3)"
-              }}
-              border="1px solid black"
-              anchorSelect="#print-btn"
-              content="Please select one project"
-            />
-          ) : (
-            ""
-          )}
+
+          <Tooltip
+            // Cannot use JSS, because Tooltip default styles would overwrite
+            style={{
+              ...theme.typography.paragraph1,
+              backgroundColor: theme.colors.secondary.lightGray,
+              width: "12rem",
+              borderRadius: "5px",
+              textAlign: "center",
+              boxShadow:
+                "0px 4px 8px 3px rgba(0,0,0,0.15), 0px 1px 3px 0px rgba(0,0,0,0.3)"
+            }}
+            border="1px solid black"
+            anchorSelect="#print-btn"
+            content={getTooltipMsg("print")}
+          />
           {project && hasPdfData() && (
             <div style={{ display: "none" }}>
               <PdfPrint
@@ -276,11 +298,7 @@ const MultiProjectToolbarMenu = ({
               }}
               border="1px solid black"
               anchorSelect="#hide-btn"
-              content={tooltipMsg(
-                "visibility",
-                "Your selection includes both hidden and visible items",
-                "dateHidden"
-              )}
+              content={getTooltipMsg("visibility")}
             />
           </button>
         </li>
@@ -312,6 +330,22 @@ const MultiProjectToolbarMenu = ({
                 }
               />
             )}
+
+            <Tooltip
+              // Cannot use JSS, because Tooltip default styles would overwrite
+              style={{
+                ...theme.typography.paragraph1,
+                backgroundColor: theme.colors.secondary.lightGray,
+                width: "12rem",
+                borderRadius: "5px",
+                textAlign: "center",
+                boxShadow:
+                  "0px 4px 8px 3px rgba(0,0,0,0.15), 0px 1px 3px 0px rgba(0,0,0,0.3)"
+              }}
+              border="1px solid black"
+              anchorSelect="#delete-btn"
+              content={getTooltipMsg("delete")}
+            />
           </button>
         </li>
       </ul>

--- a/client/src/components/Projects/MultiProjectToolbarMenu.jsx
+++ b/client/src/components/Projects/MultiProjectToolbarMenu.jsx
@@ -121,10 +121,11 @@ const MultiProjectToolbarMenu = ({
   const getTooltipMsg = actionType => {
     const hasNoSelection = checkedProjectIds.length === 0;
 
-    if (!actionType || hasNoSelection) return null;
-
-    if (actionType === "print" && hasNoSelection)
+    if (actionType === "print" && checkedProjectIds.length !== 1) {
       return "Please select one project";
+    }
+
+    if (!actionType || hasNoSelection) return null;
 
     const contentRules = {
       delete: () => {
@@ -141,11 +142,6 @@ const MultiProjectToolbarMenu = ({
           return "Your selection includes both hidden and visible items";
         }
         return null;
-      },
-      print: () => {
-        if (checkedProjectIds.length !== 1) {
-          return "Please select one project";
-        }
       }
     };
 

--- a/client/src/components/Projects/MultiProjectToolbarMenu.jsx
+++ b/client/src/components/Projects/MultiProjectToolbarMenu.jsx
@@ -121,10 +121,10 @@ const MultiProjectToolbarMenu = ({
   const getTooltipMsg = actionType => {
     const hasNoSelection = checkedProjectIds.length === 0;
 
+    if (!actionType || hasNoSelection) return null;
+
     if (actionType === "print" && hasNoSelection)
       return "Please select one project";
-
-    if (!actionType || hasNoSelection) return null;
 
     const contentRules = {
       delete: () => {
@@ -141,6 +141,11 @@ const MultiProjectToolbarMenu = ({
           return "Your selection includes both hidden and visible items";
         }
         return null;
+      },
+      print: () => {
+        if (checkedProjectIds.length !== 1) {
+          return "Please select one project";
+        }
       }
     };
 

--- a/client/src/components/TermsAndConditions/TermsAndConditionsContent.jsx
+++ b/client/src/components/TermsAndConditions/TermsAndConditionsContent.jsx
@@ -136,8 +136,8 @@ const TermsAndConditionsContent = () => {
       <p className={classes.para}>
         Before making decisions using the information provided in this
         application, contact City LADOT staff at{" "}
-        <a href="mailto:ladot.tdm@lacity.org">ladot.tdm@lacity.org</a> to confirm
-        the validity of the data provided.
+        <a href="mailto:ladot.tdm@lacity.org">ladot.tdm@lacity.org</a> to
+        confirm the validity of the data provided.
       </p>
     </div>
   );

--- a/client/src/hooks/useCheckedProjectsStatusData.js
+++ b/client/src/hooks/useCheckedProjectsStatusData.js
@@ -45,7 +45,11 @@ const useCheckedProjectsStatusData = (checkedProjects, projects) => {
     const isSameVal = property => {
       const firstVal = getProjects[0][property];
 
-      if (property === "dateTrashed" || property === "dateHidden") {
+      if (
+        property === "dateTrashed" ||
+        property === "dateHidden" ||
+        property === "dateSubmitted"
+      ) {
         const allNull = getProjects.every(p => p[property] === null);
         const allString = getProjects.every(
           p => typeof p[property] === "string"
@@ -61,6 +65,7 @@ const useCheckedProjectsStatusData = (checkedProjects, projects) => {
       name: getProjects.map(p => p.name),
       dateTrashed: isSameVal("dateTrashed"),
       dateHidden: isSameVal("dateHidden"),
+      dateSubmitted: isSameVal("dateSubmitted"),
       loginId: isSameVal("loginId")
     };
 


### PR DESCRIPTION
- Fixes #3116 

### What changes did you make?

- Disable the Project page tooltip delete button if there is at lease one submitted project that is selected
- Slight refactor on the tooltip message logic to organize by action type 

Note: the issue says to remove the delete button, then later says to disable it. The current behavior of the toolbar buttons is to disable, so did this for consistency. Also since this is a main action toolbar with buttons that display horizontally it makes more sense to disable versus removing the element (as opposed to an ephemeral popup with vertical display).

### Why did you make the changes (we will use this info to test)?

- To provide clear messaging to the user that at least one of their selected projects has been submitted, and therefore cannot delete the current selection of projects.


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](https://github.com/user-attachments/assets/1bf1ba6f-e60d-4aa3-82e5-225162cfbde4)





</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](https://github.com/user-attachments/assets/2848e31e-6c31-4328-810a-12007b9f90a7)

![image](https://github.com/user-attachments/assets/b1334121-f649-4a88-8d28-8d6c64598cbe)


Toolbar / tooltip Delete action:

https://github.com/user-attachments/assets/b1951c4e-2e1d-4f75-aae9-54503255cb62



Tooltip messages - all cases:



https://github.com/user-attachments/assets/f433eb41-a2c5-4b77-a527-263ba1d2b11a


</details>
