### PR TITLE
Add shared icon next to status col if plan is shared

### DIFF
--- a/client/src/components/Projects/ProjectTableRow.jsx
+++ b/client/src/components/Projects/ProjectTableRow.jsx
@@ -11,7 +11,8 @@ import {
   MdMoreVert,
   MdAdd,
   MdOutlineStickyNote2,
-  MdLockOutline
+  MdLockOutline,
+  MdOutlinePeopleAlt
 } from "react-icons/md";
 import { formatDate, formatId } from "../../helpers/util";
 import { useReactToPrint } from "react-to-print";
@@ -344,16 +345,23 @@ const ProjectTableRow = ({
         )}
       </Td>
       <Td>
-        {project.dateSnapshotted ? "Snapshot" : "Draft"}{" "}
-        {project.dateTrashed ? (
-          <span
-            style={{
-              color: daysUntilPermanentDeletion(project) <= 7 ? "red" : "gray"
-            }}
-          >
-            ({daysUntilPermanentDeletion(project)})
-          </span>
-        ) : null}
+        <span style={{ display: "flex" }}>
+          {project.dateSnapshotted ? "Snapshot" : "Draft"}{" "}
+          {project.dateTrashed ? (
+            <span
+              style={{
+                color: daysUntilPermanentDeletion(project) <= 7 ? "red" : "gray"
+              }}
+            >
+              ({daysUntilPermanentDeletion(project)})
+            </span>
+          ) : null}
+          {project.shareCount > 0 && (
+            <span title={`shared`}>
+              <MdOutlinePeopleAlt style={{ width: "1em", marginLeft: "4px" }} />
+            </span>
+          )}
+        </span>
       </Td>
       <Td className={classes.td}>{formatId(project.id)}</Td>
       <TdExpandable>

--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -943,7 +943,7 @@ const ProjectsPage = ({ contentContainerRef }) => {
       id: "dateSnapshotted",
       label: "Status",
       popupType: "status",
-      colWidth: `${isActiveProjectsTab ? "7rem" : "12rem"}`
+      colWidth: `${isActiveProjectsTab ? "9rem" : "14rem"}`
     },
     {
       id: "idFormatted",


### PR DESCRIPTION
- Fixes #2725

### What changes did you make?

- Added shared (people) icon to contents of the status column on the My Project page if the plan is shared.

### Why did you make the changes (we will use this info to test)?

- As requested in issue.

### Issue-Specific User Account

any

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="2117" height="1157" alt="image" src="https://github.com/user-attachments/assets/7105ea06-ba6e-4051-af31-f06f0c94e200" />

<img width="2116" height="1162" alt="image" src="https://github.com/user-attachments/assets/fc2d8c74-cb10-41e9-b5c9-a685fdb8fc92" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="2122" height="1166" alt="image" src="https://github.com/user-attachments/assets/76d713fa-0e2b-4ab9-960f-f80a9e86b2cc" />

<img width="2116" height="1171" alt="image" src="https://github.com/user-attachments/assets/414c80cb-0f59-4c3f-902c-a5ed367e7105" />


</details>
