### PR TITLE
Fix footer on p5 and pdf to properly indicate shared snapshots

### DIFF
--- a/client/src/components/PdfPrint/PdfFooter.jsx
+++ b/client/src/components/PdfPrint/PdfFooter.jsx
@@ -16,8 +16,7 @@ const useStyles = createUseStyles({
     margin: "24px 0 0",
     width: "100%",
     position: "fixed",
-    bottom: "0",
-    height: "100px",
+    bottom: "8px",
     display: "flex",
     flexDirection: "column",
     justifyContent: "flex-end"
@@ -32,12 +31,12 @@ const PdfFooter = ({ project }) => {
     loginId,
     firstName,
     lastName,
-    email
+    email,
+    shareCount
   } = project;
   const classes = useStyles();
   const userContext = useContext(UserContext);
   const calculations = useContext(CalculationsContext);
-  const loggedInUserId = userContext.account?.id;
   const formattedDateModified = formatDatetime(dateModified);
   const formattedDateSnapshotted = formatDatetime(dateSnapshotted);
   const formattedDateSubmitted = formatDatetime(dateSubmitted);
@@ -85,9 +84,9 @@ const PdfFooter = ({ project }) => {
             Status:{" "}
             {!formattedDateSnapshotted
               ? "Draft"
-              : loginId === loggedInUserId
-                ? "Snapshot"
-                : "Shared Snapshot"}
+              : shareCount
+                ? "Shared Snapshot"
+                : "Snapshot"}
           </div>
           {formattedDateSubmitted && (
             <div className={classes.pdfTimeText}>

--- a/client/src/components/PdfPrint/PdfPrint.jsx
+++ b/client/src/components/PdfPrint/PdfPrint.jsx
@@ -124,7 +124,7 @@ const useStyles = createUseStyles({
     border: "1px solid #E7EBF0"
   },
   footerSpace: {
-    height: "115px"
+    height: "150px"
   },
   "@media (max-width: 768px)": {
     logoContainer: {

--- a/client/src/components/ProjectWizard/WizardFooter.jsx
+++ b/client/src/components/ProjectWizard/WizardFooter.jsx
@@ -222,9 +222,9 @@ const WizardFooter = ({
             <strong>Status: </strong>
             {!formattedDateSnapshotted
               ? "Draft"
-              : project.loginId === loggedInUserId
-                ? "Snapshot"
-                : "Shared Snapshot"}
+              : project.shareCount
+                ? "Shared Snapshot"
+                : "Snapshot"}
           </div>
           {formattedDateSubmitted ? (
             <div>


### PR DESCRIPTION
- Fixes #3006
### What changes did you make?

- Fixed the footer on Page 5 of the wizard and the PDF printout to correctly indicate when a plan is a Shared Snapshot
- NOTE: There is a back-end part of this issue that required modifications to the web api endpoint that retrieves projects from the database to include a new column 'shareCount' that indicates if a project is shared. This was done as part of PR #3188

### Why did you make the changes (we will use this info to test)?

- Previously, the footer was incorrectly coded to Print "Shared Snapshot" vs "Snapshot" if the logged on user was not the author of the plan.  This is incorrect.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

Screenshot of the two snapshots used for illustrating the issue - note that v2 is not shared and the other one is.

<img width="2120" height="990" alt="image" src="https://github.com/user-attachments/assets/7a524034-554f-49f6-bf31-6afab08deaa2" />

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

V2 incorrectly shown as shared:
<img width="2120" height="1110" alt="image" src="https://github.com/user-attachments/assets/66790eac-cf19-4402-a447-37b71275059e" />

The other snapshot also showed as shared:
<img width="2123" height="1110" alt="image" src="https://github.com/user-attachments/assets/16a54520-cb12-4748-99e4-5836c57138f2" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
V2 correctly showing "Snapshot" instead of "Shared Snapshot"
<img width="2126" height="1113" alt="image" src="https://github.com/user-attachments/assets/7da029d9-c566-4bbf-96db-d42e8e83e1f6" />

Other project properly showing "Shared Snapshot":
<img width="2125" height="1107" alt="image" src="https://github.com/user-attachments/assets/4dace410-6930-4cc5-8cd9-9edf468e2a23" />

</details>
