### PR TITLE
Move Registered col to right of email confirmed col on Roles page

### DIFF
--- a/client/src/components/Roles/Roles.jsx
+++ b/client/src/components/Roles/Roles.jsx
@@ -275,16 +275,16 @@ const Roles = ({ contentContainerRef }) => {
                 Dev. Review Office
               </th>
               <th
-                className={`${classes.td} ${classes.theadLabel}`}
-                style={{ width: "7em" }}
-              >
-                Registered
-              </th>
-              <th
                 className={`${classes.tdCenter} ${classes.theadLabel}`}
                 style={{ width: "4em" }}
               >
                 Email Confirmed
+              </th>
+              <th
+                className={`${classes.td} ${classes.theadLabel}`}
+                style={{ width: "7em" }}
+              >
+                Registered
               </th>
               <th
                 className={`${classes.td} ${classes.theadLabel}`}

--- a/client/src/components/Roles/RolesTableRow.jsx
+++ b/client/src/components/Roles/RolesTableRow.jsx
@@ -78,10 +78,10 @@ const RolesTableRow = ({
           }`}
         />
       </td>
-      <td className={classes.td}>{formatDate(account.dateCreated)}</td>
       <td className={classes.tdCenter}>
         {account.emailConfirmed ? <MdCheck alt="Email confirmed" /> : ""}
       </td>
+      <td className={classes.td}>{formatDate(account.dateCreated)}</td>
       <td className={classes.td}>{formatDate(account.lastLoginDate)}</td>
       <td className={classes.tdCenter}>
         <Popup


### PR DESCRIPTION
- Fixes PR #3165
### What changes did you make?

- Move Registered col to the right of the emal confirmed col on the Security Roles page, like it was before.

### Why did you make the changes (we will use this info to test)?

- To preserve the prior column order.


