### PR TITLE
Roles Page - allow caps in search string, add placeholder text

### DIFF
--- a/client/src/components/Roles/Roles.jsx
+++ b/client/src/components/Roles/Roles.jsx
@@ -25,6 +25,9 @@ const useStyles = createUseStyles(theme => ({
     fontWeight: "normal",
     fontStyle: "normal"
   },
+  input: {
+    width: "20rem"
+  },
   archiveTitle: {
     marginTop: "0.5em",
     textAlign: "center",
@@ -118,7 +121,14 @@ const Roles = ({ contentContainerRef }) => {
       try {
         const response = await accountService.search();
         if (response.status === 200) {
-          setAccounts(response.data);
+          setAccounts(
+            response.data.map(account => {
+              return {
+                ...account,
+                name: `${account.lastName}, ${account.firstName}`
+              };
+            })
+          );
           setFilteredAccounts(response.data);
         } else if (response.status === 401) {
           setRedirectPath("/login");
@@ -135,13 +145,14 @@ const Roles = ({ contentContainerRef }) => {
   }, []);
 
   const filt = (allAccounts, searchString) => {
-    const str = searchString;
+    const str = searchString.toLowerCase();
     const filteredAccounts = allAccounts.filter(
       account =>
         str === "" ||
         account.email.toLowerCase().includes(str) ||
         account.firstName.toLowerCase().includes(str) ||
-        account.lastName.toLowerCase().includes(str)
+        account.lastName.toLowerCase().includes(str) ||
+        account.name.toLowerCase().includes(str)
     );
     if (filteredAccounts) {
       setFilteredAccounts(filteredAccounts);
@@ -220,6 +231,7 @@ const Roles = ({ contentContainerRef }) => {
           className={classes.input}
           name="searchString"
           type="text"
+          placeholder="Search by Email, First or Last Name"
           value={searchString || ""}
           onChange={e => {
             setSearchString(e.target.value);


### PR DESCRIPTION
- Fixes #2947
### What changes did you make?

Modified Security Roles Page to:
- Allow capital letters in the search string - previously they would not match any results.
- Search by matching any substring of the email address, substring of the first name, substring of the last name or substring of the full name in the format last name, first name. Previously, it would not match the full name.
- Added the requested placeholder "Search by Email or Name" to the search field.

### Why did you make the changes (we will use this info to test)?

- To comply with issue request and fix bugs in search

### Issue-Specific User Account

Security Admin

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

No placeholder, couldn't find accounts matching "Dar", due to capital letter in search string:

<img width="2217" height="1191" alt="image" src="https://github.com/user-attachments/assets/d0fc52d0-4a1d-4a70-82a3-431a52e5e945" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
Shows Placeholder:

<img width="2226" height="1172" alt="image" src="https://github.com/user-attachments/assets/2944c598-53f3-4df5-9cd9-8bb4afe99abb" />

Correctly uses capital letters in search, finding matching accounts:
<img width="2226" height="1178" alt="image" src="https://github.com/user-attachments/assets/99e0ab1b-da84-409a-8610-71f8563017f5" />


</details>
