### PR TITLE
add after click blur to unfocus navLink

### DIFF
--- a/client/src/components/Layout/NavBar.jsx
+++ b/client/src/components/Layout/NavBar.jsx
@@ -106,8 +106,9 @@ const NavBar = ({ navbarOpen, setNavbarOpen }) => {
   const userContext = useContext(UserContext);
   const account = userContext.account;
 
-  const handleHamburgerMenuClick = () => {
+  const handleHamburgerMenuClick = e => {
     setNavbarOpen(window.innerWidth < 900 ? !navbarOpen : false);
+    e.target.blur();
   };
 
   return (


### PR DESCRIPTION
- Fixes #3171 

### What changes did you make?

- Just added a blur event when users click the navlink

### Why did you make the changes (we will use this info to test)?

- The nav link was not being unfocused so it was maintaining the wrong style. The only link that was working correctly was the create project link because navigating to that url automatically focuses the first input of the form. 


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>
<img width="1410" height="153" alt="Screenshot 2026-05-18 at 4 58 10 PM" src="https://github.com/user-attachments/assets/456bf7b6-c149-405b-8793-aa3de70fcf2c" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1410" height="153" alt="Screenshot 2026-05-18 at 4 58 16 PM" src="https://github.com/user-attachments/assets/57278db9-684e-458d-9419-7806d8378847" />


</details>
