### PR TITLE
add aria label to buttons

### DIFF
--- a/client/src/components/About/AdminView.jsx
+++ b/client/src/components/About/AdminView.jsx
@@ -301,6 +301,7 @@ const AdminView = ({ aboutList, setAboutList }) => {
                           onClick={() => toggleEditing(about.id, "title")}
                           id={`edit-about-title-${about.id}`}
                           data-testid={`edit-about-title-${about.id}`}
+                          ariaLabel={`edit title of about item ${about.id}`}
                           title={
                             editingItems[`${about.id}-title`]
                               ? "Finish editing title"
@@ -328,6 +329,7 @@ const AdminView = ({ aboutList, setAboutList }) => {
                           onClick={() => toggleEditing(about.id, "content")}
                           id={`edit-about-content-${about.id}`}
                           data-testid={`edit-about-content-${about.id}`}
+                          ariaLabel={`edit content of about item ${about.id}`}
                           title={
                             editingItems[`${about.id}-content`]
                               ? "Finish editing content"
@@ -355,6 +357,7 @@ const AdminView = ({ aboutList, setAboutList }) => {
                           onClick={() => setShowDeleteAboutItemModal(true)}
                           id={`delete-about-${about.id}`}
                           data-testid={`delete-about-${about.id}`}
+                          ariaLabel={`delete about item ${about.id}`}
                           title="Delete item"
                           className={classes.controlButton}
                         >


### PR DESCRIPTION
- Fixes #3040 

### What changes did you make?

- added aria label to editing and delete buttons

### Why did you make the changes (we will use this info to test)?

- Helps accessibility by giving labels to admin level buttons

### Issue-Specific User Account

- Requires admin account so you can edit the about page

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1089" height="564" alt="Screenshot 2026-05-20 at 12 37 33 PM" src="https://github.com/user-attachments/assets/e2cbe2b3-92d6-4d7c-afa4-070cd7f6bbd6" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1089" height="564" alt="Screenshot 2026-05-20 at 12 38 00 PM" src="https://github.com/user-attachments/assets/9be3726f-9ed4-488d-9a3b-2e40d1127670" />


</details>
