### PR TITLE
Re-factor Page 2, so theme is referenced in the same way for h1, h2

### DIFF
--- a/client/src/components/ProjectWizard/WizardPages/ProjectSpecifications.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/ProjectSpecifications.jsx
@@ -2,11 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import RuleInputPanels from "../RuleInput/RuleInputPanels";
 import ResetButtons from "./ResetButtons";
-import { createUseStyles } from "react-jss";
+import { createUseStyles, useTheme } from "react-jss";
 const useStyles = createUseStyles(theme => ({
-  header: {
-    ...theme.typography.heading1
-  },
   resetContainer: {
     display: "grid",
     gridTemplateColumns: "[h-start] auto [h-end] 35%",
@@ -17,21 +14,17 @@ const useStyles = createUseStyles(theme => ({
   alignRight: {
     gridColumn: "h-end",
     justifyContent: "flex-end"
-  },
-  subtitle: {
-    ...theme.typography.subHeading,
-    marginTop: "0.5em",
-    marginBottom: "1em"
   }
 }));
 
 function ProjectSpecifications(props) {
+  const theme = useTheme();
   const classes = useStyles();
   const { rules, onInputChange, uncheckAll, resetProject, page } = props;
   return (
     <div>
-      <h1 className={classes.header}>Determine Project Level</h1>
-      <h2 className={classes.subtitle}>
+      <h1 style={theme.typography.heading1}>Determine Project Level</h1>
+      <h2 style={theme.typography.subHeading}>
         Project Level (left panel) and Citywide Parking Baseline (next page) are
         determined by the use specifications entered below.
       </h2>


### PR DESCRIPTION
- Fixes #2857
- Adjusts PR #3236 
- Fixes #3254

### What changes did you make?

- Re-factored jsx for page 2 to reference the theme styles for h1 and h2 in exactly the same way as other wizard pages.
- Also removed page-specific top and bottom margins from subtitle element.

### Why did you make the changes (we will use this info to test)?

- To make it more obvious that exactly the same theme elements are applied to the h2 on all wizard pages, and remove page-specific margin mentioned above.

### Issue-Specific User Account

n/a

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

Before:

<img width="1105" height="176" alt="image" src="https://github.com/user-attachments/assets/ebce05c0-f4ad-48a3-8de9-72a3c5096b3f" />

After:

<img width="1104" height="183" alt="image" src="https://github.com/user-attachments/assets/e98afad8-e3d8-4b66-9495-ff278a38e116" />

(Note small difference in vertical spacing between page heading and subtitle).


