### PR TITLE
3202 fix status filter active icon

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tdm-calculator-client",
-  "version": "0.2.74",
+  "version": "0.2.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tdm-calculator-client",
-  "version": "0.2.74",
+  "version": "0.2.75",
   "private": true,
   "proxy": "http://localhost:5001",
   "type": "module",

--- a/client/src/components/Projects/ColumnHeaderPopups/ProjectTableColumnHeader.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/ProjectTableColumnHeader.jsx
@@ -156,7 +156,7 @@ const ProjectTableColumnHeader = ({
       return criteria.visibility !== "visible";
     }
     if (header.id === "dateSnapshotted") {
-      return criteria.type !== "all" || criteria.status !== "active";
+      return criteria.type !== "all";
     }
     if (header.id === "dro") {
       return criteria.droList?.length > 0; // Use optional chaining

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.2.73",
+  "version": "0.2.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.2.74",
+  "version": "0.2.75",
   "private": true,
   "scripts": {
     "lint": "lerna run lint",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tdm-calculator-api",
-  "version": "0.2.74",
+  "version": "0.2.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tdm-calculator-api",
-  "version": "0.2.74",
+  "version": "0.2.75",
   "description": "Transportation Demand Management Calculator",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Fixes #3202
### What changes did you make?

- Filter icon on the Status column should only be underlined if "Drafts and Snapshots" is selected as the filter.

### Why did you make the changes (we will use this info to test)?

- So icon correctly indicates when the default filter for status is applied.

### Issue-Specific User Account
(any)

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

The default filtering is applied to the status column, but filter icon in the column heading is underlined, when it should not be:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/e89ca11f-77c7-41d9-8606-170361cb513d" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
The default filtering is applied to the status column, the filter icon in the column heading is not underlined because default filters are not underlined by design, otherwise every column would have an underline.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/58754d86-8608-40f9-bc57-1597b54808a6" />

</details>
