### PR TITLE
Fix logic to hide button for different owners of projects

### DIFF
--- a/client/src/components/Projects/MultiProjectToolbarMenu.jsx
+++ b/client/src/components/Projects/MultiProjectToolbarMenu.jsx
@@ -110,8 +110,7 @@ const MultiProjectToolbarMenu = ({
   };
 
   const isHideBtnDisabled =
-    !checkedProjectsStatusData.loginId ||
-    isBtnDisabled("dateHidden", "visibility");
+    !checkedProjectIds.length || isBtnDisabled("dateHidden", "visibility");
 
   const isDelBtnDisabled =
     !isProjectOwner ||


### PR DESCRIPTION
- Fixes #3080 

### What changes did you make?

- Changed logic of hide button on toolbar menu too allow 

### Why did you make the changes (we will use this info to test)?

- It allows users that were shared a project to hide the project for themselves. Hide is on a per user property so it will not hide the project for all users if one users hides a project. 

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/199a5e88-765d-48a0-ad2f-1e8a70e70c0d" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/64bc4c08-1f13-4244-b51f-6235088fff71" />


</details>
