### PR TITLE
update tooltip text for deleting projects to updated wording

### DIFF
--- a/client/src/components/Projects/MultiProjectToolbarMenu.jsx
+++ b/client/src/components/Projects/MultiProjectToolbarMenu.jsx
@@ -130,9 +130,9 @@ const MultiProjectToolbarMenu = ({
       delete: () => {
         // first priority check is ownership, if both are selected prioritize ownership msg
         if (!isProjectOwner)
-          return "You have selected a project that does not belong to you";
+          return "TDM Plans shared with you cannot be deleted. Use hide function.";
         if (checkedProjectsSubmittedStatus !== null)
-          return "One or more selected projects have already been submitted";
+          return "Submitted TDM Plans cannot be deleted. Use hide function.";
         return null;
       },
       visibility: () => {


### PR DESCRIPTION
- Fixes #3204

### What changes did you make?

- update tooltip text to updated text from #3204 

### Why did you make the changes (we will use this info to test)?

- update tooltip text for deleting projects to updated text that is clearer for the user

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

1. When one or more projects that the user has selected have been submitted, the trash can icon is grayed out with this message:
<img width="1878" height="750" alt="3204-before-2" src="https://github.com/user-attachments/assets/c202c9d8-53c5-4991-bbe8-ccd22382cdf5" />

<br>

2. When one or more projects that the user has selected have been are owned by someone else (i.e., they are shared snapshots), the trash can icon is grayed out with this message:
<img width="1484" height="832" alt="3204-before-1" src="https://github.com/user-attachments/assets/ab57b1a1-988b-47fa-94e7-0b4001f28af3" />



</details>

<details>
<summary>Visuals after changes are applied</summary>

1. When one or more projects that the user has selected have been submitted, the trash can icon is grayed out with this message:
<img width="1908" height="515" alt="3204-submitted-after" src="https://github.com/user-attachments/assets/3612b5f2-4544-4893-be1b-a9a398bc265f" />

<br>
2. When one or more projects that the user has selected have been are owned by someone else (i.e., they are shared snapshots), the trash can icon is grayed out with this message:

<img width="1470" height="411" alt="3204-owner-after" src="https://github.com/user-attachments/assets/02f513f8-c762-49a0-a223-c48e8c4af3d1" />
</details>
