### PR TITLE
3264 Improve HTTP header security

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -63,7 +63,7 @@
   </head>
   <body id="body">
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <script src="//navbar.lacity.org/global_nav.js"></script>
+    <script src="https://navbar.lacity.org/global_nav.js"></script>
     <div id="root"></div>
     <script type="module" src="/src/index.jsx"></script>
     <!--

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -65,6 +65,21 @@ const App = () => {
           const configs = await getConfigs();
           return { configs };
         }}
+        HydrateFallback={() => {
+          return (
+            <div
+              style={{
+                width: "100%",
+                height: "80vh",
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center"
+              }}
+            >
+              <Loader loaded={false} className="spinner" left="auto" />
+            </div>
+          );
+        }}
         errorElement={<RouteErrorBoundary />}
       >
         {/* These routes depend on ConfigContext and CalculationContext */}

--- a/client/src/helpers/Environment.js
+++ b/client/src/helpers/Environment.js
@@ -2,6 +2,6 @@ export const Environment =
   import.meta.env.NODE_ENV === "development" ||
   window.location.hostname.toLowerCase().includes("tdm-dev")
     ? import.meta.env.ENV || "DEV"
-    : window.location.hostname.toLowerCase().includes("tdm-uat")
+    : window.location.hostname.toLowerCase().includes("tdmusertest")
       ? "UAT"
       : "PROD";

--- a/server/app/routes/dro.routes.js
+++ b/server/app/routes/dro.routes.js
@@ -5,8 +5,8 @@ const { writeLimiter } = require("../../middleware/rateLimiter");
 
 module.exports = router;
 
-router.get("/", jwtSession.validateUser, droController.getAll);
-router.get("/:id", jwtSession.validateUser, droController.getById);
+router.get("/", droController.getAll);
+router.get("/:id", droController.getById);
 router.post(
   "/",
   writeLimiter,

--- a/server/server.js
+++ b/server/server.js
@@ -20,12 +20,13 @@ const helmetConfig = {
     useDefaults: false,
     directives: {
       defaultSrc: ["'self'"],
-      scriptSrc: ["'self'", "'unsafe-eval'", "https://navbar.lacity.org"],
-      styleSrc: [
+      scriptSrc: [
         "'self'",
+        "'unsafe-eval'",
         "'unsafe-inline'",
-        "https://fonts.googleapis.com/* "
+        "https://navbar.lacity.org"
       ],
+      styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       imgSrc: ["'self'", "data:"],
       fontSrc: ["'self'", "https://fonts.googleapis.com/* "],
       upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null

--- a/server/server.js
+++ b/server/server.js
@@ -5,7 +5,7 @@ const dotenv = require("dotenv");
 const cookieParser = require("cookie-parser");
 const errorHandler = require("error-handler");
 const routes = require("./app/routes");
-// const helmet = require("helmet");
+const helmet = require("helmet");
 // const pino = require("express-pino-logger")();
 
 dotenv.config();
@@ -31,7 +31,12 @@ const app = express();
 //   }
 // };
 
-// app.use(helmet(helmetConfig));
+const helmetConfig = {
+  useDefaults: true,
+  contentSecurityPolicy: false
+};
+
+app.use(helmet(helmetConfig));
 // app.use(pino);
 
 if (process.env.NODE_ENV === "production") {

--- a/server/server.js
+++ b/server/server.js
@@ -13,28 +13,28 @@ const port = process.env.PORT || 5000;
 
 const app = express();
 
-const helmetConfig = {
-  useDefaults: true,
-  contentSecurityPolicy: {
-    useDefaults: true,
-    directives: {
-      defaultSrc: ["'self'"],
-      scriptSrc: null,
-      objectSrc: ["'none'"],
-      styleSrc: null,
-      fontSrc: ["'self'", "https://fonts.googleapis.com"],
-      imgSrc: ["'self'", "data:", "https://tdm.ladot.lacity.org"],
-      connectSrc: ["'self'"], // Add other domains as needed
-      upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null
-    },
-    reportOnly: false
-  }
-};
-
 // const helmetConfig = {
 //   useDefaults: true,
-//   contentSecurityPolicy: false
+//   contentSecurityPolicy: {
+//     useDefaults: true,
+//     directives: {
+//       defaultSrc: ["'self'"],
+//       scriptSrc: null,
+//       objectSrc: ["'none'"],
+//       styleSrc: null,
+//       fontSrc: ["'self'", "https://fonts.googleapis.com"],
+//       imgSrc: ["'self'", "data:", "https://tdm.ladot.lacity.org"],
+//       connectSrc: ["'self'"], // Add other domains as needed
+//       upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null
+//     },
+//     reportOnly: false
+//   }
 // };
+
+const helmetConfig = {
+  useDefaults: true,
+  contentSecurityPolicy: false
+};
 
 app.use(helmet(helmetConfig));
 // app.use(pino);

--- a/server/server.js
+++ b/server/server.js
@@ -24,7 +24,8 @@ const helmetConfig = {
         "'self'",
         "'unsafe-eval'",
         "'unsafe-inline'",
-        "https://navbar.lacity.org"
+        "https://navbar.lacity.org",
+        "https://www.googletagmanager.com"
       ],
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       imgSrc: ["'self'", "data:"],

--- a/server/server.js
+++ b/server/server.js
@@ -21,7 +21,12 @@ const helmetConfig = {
     directives: {
       defaultSrc: ["'self'"],
       scriptSrc: ["'self'", "'unsafe-eval'", "https://navbar.lacity.org"],
-      styleSrc: ["'self'", "'unsafe-inline'"],
+      styleSrc: [
+        "'self'",
+        "'unsafe-inline'",
+        "https://fonts.googleapis.com/* "
+      ],
+      imgSrc: ["'self'", "data:"],
       fontSrc: ["'self'", "https://fonts.googleapis.com/* "],
       upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null
     },

--- a/server/server.js
+++ b/server/server.js
@@ -27,6 +27,7 @@ const helmetConfig = {
         "https://navbar.lacity.org",
         "https://www.googletagmanager.com"
       ],
+      objectSrc: ["'none'"],
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       imgSrc: ["'self'", "data:"],
       fontSrc: [

--- a/server/server.js
+++ b/server/server.js
@@ -29,7 +29,7 @@ const helmetConfig = {
       ],
       objectSrc: ["'none'"],
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
-      imgSrc: ["'self'", "data:"],
+      imgSrc: ["'self'", "data:", "https://www.googletagmanager.com"],
       fontSrc: [
         "'self'",
         "https://fonts.googleapis.com",

--- a/server/server.js
+++ b/server/server.js
@@ -19,6 +19,7 @@ const helmetConfig = {
   contentSecurityPolicy: {
     useDefaults: false,
     directives: {
+      defaultSrc: ["'self'"],
       scriptSrc: ["'self'", "'unsafe-eval'"],
       upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null
     },

--- a/server/server.js
+++ b/server/server.js
@@ -35,7 +35,11 @@ const helmetConfig = {
         "https://fonts.googleapis.com",
         "https://fonts.gstatic.com"
       ],
-      connectSrc: ["'self'", "https://www.google-analytics.com"],
+      connectSrc: [
+        "'self'",
+        "https://www.google-analytics.com",
+        "https://google.com"
+      ],
       upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null
     },
     reportOnly: false

--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ const cookieParser = require("cookie-parser");
 const errorHandler = require("error-handler");
 const routes = require("./app/routes");
 const helmet = require("helmet");
+const { truncate } = require("fs");
 // const pino = require("express-pino-logger")();
 
 dotenv.config();
@@ -13,28 +14,28 @@ const port = process.env.PORT || 5000;
 
 const app = express();
 
+const helmetConfig = {
+  useDefaults: truncate,
+  contentSecurityPolicy: {
+    useDefaults: false,
+    directives: {
+      defaultSrc: helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc,
+      scriptSrc: ["'self'", "unsafe-eval"], // Add other domains as needed
+      objectSrc: ["'none'"],
+      styleSrc: null,
+      fontSrc: null,
+      imgSrc: null,
+      connectSrc: ["'self'"], // Add other domains as needed
+      upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null
+    },
+    reportOnly: false
+  }
+};
+
 // const helmetConfig = {
 //   useDefaults: true,
-//   contentSecurityPolicy: {
-//     useDefaults: true,
-//     directives: {
-//       defaultSrc: ["'self'"],
-//       scriptSrc: null,
-//       objectSrc: ["'none'"],
-//       styleSrc: null,
-//       fontSrc: ["'self'", "https://fonts.googleapis.com"],
-//       imgSrc: ["'self'", "data:", "https://tdm.ladot.lacity.org"],
-//       connectSrc: ["'self'"], // Add other domains as needed
-//       upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null
-//     },
-//     reportOnly: false
-//   }
+//   contentSecurityPolicy: false
 // };
-
-const helmetConfig = {
-  useDefaults: true,
-  contentSecurityPolicy: false
-};
 
 app.use(helmet(helmetConfig));
 // app.use(pino);

--- a/server/server.js
+++ b/server/server.js
@@ -19,13 +19,7 @@ const helmetConfig = {
   contentSecurityPolicy: {
     useDefaults: false,
     directives: {
-      defaultSrc: helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc,
-      scriptSrc: ["'self'", "unsafe-eval"], // Add other domains as needed
-      objectSrc: ["'none'"],
-      styleSrc: null,
-      fontSrc: null,
-      imgSrc: null,
-      connectSrc: ["'self'"], // Add other domains as needed
+      scriptSrc: ["'self'", "'unsafe-eval'"],
       upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null
     },
     reportOnly: false

--- a/server/server.js
+++ b/server/server.js
@@ -20,7 +20,9 @@ const helmetConfig = {
     useDefaults: false,
     directives: {
       defaultSrc: ["'self'"],
-      scriptSrc: ["'self'", "'unsafe-eval'"],
+      scriptSrc: ["'self'", "'unsafe-eval'", "https://navbar.lacity.org"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      fontSrc: ["'self'", "https://fonts.googleapis.com/* "],
       upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null
     },
     reportOnly: false

--- a/server/server.js
+++ b/server/server.js
@@ -13,28 +13,28 @@ const port = process.env.PORT || 5000;
 
 const app = express();
 
-// const helmetConfig = {
-//   useDefaults: true,
-//   contentSecurityPolicy: {
-//     useDefaults: true,
-//     directives: {
-//       defaultSrc: ["'self'"],
-//       scriptSrc: ["'self'", "'https://navbar.lacity.org'"],
-//       objectSrc: ["'none'"],
-//       styleSrc: ["'self'", "'unsafe-inline'"],
-//       fontSrc: ["'self'", "https://fonts.googleapis.com"],
-//       imgSrc: ["'self'", "data:", "https://tdm.ladot.lacity.org"],
-//       connectSrc: ["'self'"], // Add other domains as needed
-//       upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null
-//     },
-//     reportOnly: false
-//   }
-// };
-
 const helmetConfig = {
   useDefaults: true,
-  contentSecurityPolicy: false
+  contentSecurityPolicy: {
+    useDefaults: true,
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'", "'https://navbar.lacity.org'"],
+      objectSrc: ["'none'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      fontSrc: ["'self'", "https://fonts.googleapis.com"],
+      imgSrc: ["'self'", "data:", "https://tdm.ladot.lacity.org"],
+      connectSrc: ["'self'"], // Add other domains as needed
+      upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null
+    },
+    reportOnly: false
+  }
 };
+
+// const helmetConfig = {
+//   useDefaults: true,
+//   contentSecurityPolicy: false
+// };
 
 app.use(helmet(helmetConfig));
 // app.use(pino);

--- a/server/server.js
+++ b/server/server.js
@@ -19,9 +19,9 @@ const helmetConfig = {
     useDefaults: true,
     directives: {
       defaultSrc: ["'self'"],
-      scriptSrc: ["'self'", "'https://navbar.lacity.org'"],
+      scriptSrc: null,
       objectSrc: ["'none'"],
-      styleSrc: ["'self'", "'unsafe-inline'"],
+      styleSrc: null,
       fontSrc: ["'self'", "https://fonts.googleapis.com"],
       imgSrc: ["'self'", "data:", "https://tdm.ladot.lacity.org"],
       connectSrc: ["'self'"], // Add other domains as needed

--- a/server/server.js
+++ b/server/server.js
@@ -35,6 +35,7 @@ const helmetConfig = {
         "https://fonts.googleapis.com",
         "https://fonts.gstatic.com"
       ],
+      connectSrc: ["'self'", "https://www.google-analytics.com"],
       upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null
     },
     reportOnly: false

--- a/server/server.js
+++ b/server/server.js
@@ -28,7 +28,11 @@ const helmetConfig = {
       ],
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       imgSrc: ["'self'", "data:"],
-      fontSrc: ["'self'", "https://fonts.googleapis.com/* "],
+      fontSrc: [
+        "'self'",
+        "https://fonts.googleapis.com",
+        "https://fonts.gstatic.com"
+      ],
       upgradeInsecureRequests: process.env.NODE_ENV === "production" ? [] : null
     },
     reportOnly: false


### PR DESCRIPTION
- Fixes #3264 
- Fixes #2846 
- Fixes #2688 

### What changes did you make?

#### Get UAT working
- Modified logic for determining whether a badge is displayed in the header indicating a non-production (DEV or UAT) environment, so it is driven by the ENVIRONMENT configuration row of the Config table in the database, since this is more definitive that the previous method fo deducting the environment from node environment variables and/or the host name.
- Added a GitHub Action (on a separate [commit 821aa05](https://github.com/hackforla/tdm-calculator/commit/821aa05cd8cd82a69b57652dabc4693693f4d4cb)) to merge to UAT environment any code merged into the UAT branch)

#### Header Security and Content Security Policy
- Included and configured the npm package "Helmet' to implement HTTP headers to  reduce vulnerabiltiy of the application to various attacks. (See Issue for explanation).

### Why did you make the changes (we will use this info to test)?
- See Issues

### Issue-Specific User Account

(any)

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1165" height="588" alt="image" src="https://github.com/user-attachments/assets/6ff756ab-d57f-463e-87ff-7c097aeeba3c" />

</details>

<details>
<summary>Visuals after changes are applied</summary>

The only visible change is the badge in the header ("UAT" in the UAT environment - this should not show in the prod environment)
  
<img width="1532" height="912" alt="image" src="https://github.com/user-attachments/assets/81d0ed74-9d61-499e-9b9c-49f244c271f9" />

</details>
