### PR TITLE
Add accounts/feature: implement cleanup utility for inactive accounts…

### DIFF
--- a/client/src/components/Link/Link.jsx
+++ b/client/src/components/Link/Link.jsx
@@ -1,0 +1,81 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { createUseStyles } from "react-jss";
+import clsx from "clsx";
+
+const useStyles = createUseStyles(theme => ({
+  link: {
+    fontFamily: "Calibri",
+    fontWeight: 400,
+    fontSize: "16px",
+    color: theme.colors.secondary.linkBlue,
+    textDecoration: "underline",
+    cursor: "pointer",
+    margin: "0",
+    padding: "0",
+    "&[aria-disabled='true'], &[disabled]": {
+      color: theme.colorGray,
+      cursor: "default",
+      textDecoration: "none"
+    }
+  },
+  activeLink: {
+    backgroundColor: theme.colorDefault,
+    color: theme.colors.secondary.linkBlue,
+    padding: "0",
+    textDecoration: "none",
+    cursor: "default"
+  }
+}));
+
+const Link = ({
+  children,
+  className,
+  isDisplayed = true,
+  onClick,
+  disabled = false,
+  ariaLabel = undefined,
+  id,
+  href = "#",
+  isActive = false
+}) => {
+  const classes = useStyles();
+
+  if (!isDisplayed) return null;
+
+  return (
+    <a
+      className={clsx(classes.link, isActive && classes.activeLink, className)}
+      onClick={e => {
+        e.preventDefault();
+        if (disabled || isActive) {
+          return;
+        }
+        if (onClick) {
+          onClick(e);
+        }
+      }}
+      href={disabled ? undefined : href}
+      aria-label={ariaLabel}
+      id={id}
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled || undefined}
+    >
+      {children}
+    </a>
+  );
+};
+
+Link.propTypes = {
+  onClick: PropTypes.func,
+  children: PropTypes.any,
+  isDisplayed: PropTypes.bool,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  ariaLabel: PropTypes.string,
+  id: PropTypes.string,
+  href: PropTypes.string,
+  isActive: PropTypes.bool
+};
+
+export default Link;

--- a/client/src/components/Roles/Roles.jsx
+++ b/client/src/components/Roles/Roles.jsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect, useContext } from "react";
 import PropTypes from "prop-types";
-import { Navigate, Link } from "react-router-dom";
+import { Navigate, Link as NavLink } from "react-router-dom";
 import { createUseStyles, useTheme } from "react-jss";
 import * as accountService from "../../services/account.service";
 import { useToast } from "../../contexts/Toast";
 import UserContext from "../../contexts/UserContext";
 import ContentContainerWithTables from "../Layout/ContentContainerWithTables";
 import RolesTableRow from "./RolesTableRow";
+import Link from "../Link/Link";
 
 const useStyles = createUseStyles(theme => ({
   main: {
@@ -115,6 +116,37 @@ const Roles = ({ contentContainerRef }) => {
   const toast = useToast();
   const userContext = useContext(UserContext);
   const loggedInUserId = userContext.account?.id;
+
+  const handleCleanupInactive = async () => {
+    try {
+      const response = await accountService.cleanupInactiveAccounts();
+      if (response.status === 200 && response.data.isSuccess) {
+        const deletedCount = response.data.deletedCount;
+        toast.add(
+          `Cleanup completed! Removed ${deletedCount} inactive accounts.`
+        );
+
+        // Refresh accounts list
+        const searchResponse = await accountService.search();
+        if (searchResponse.status === 200) {
+          setAccounts(
+            searchResponse.data.map(account => {
+              return {
+                ...account,
+                name: `${account.lastName}, ${account.firstName}`
+              };
+            })
+          );
+          setFilteredAccounts(searchResponse.data);
+        }
+      } else {
+        toast.add("Cleanup failed to complete successfully.");
+      }
+    } catch (cleanupErr) {
+      console.error("Cleanup of inactive accounts failed", cleanupErr);
+      toast.add("An error occurred during inactive account cleanup.");
+    }
+  };
 
   useEffect(() => {
     const getAccounts = async () => {
@@ -240,9 +272,25 @@ const Roles = ({ contentContainerRef }) => {
           data-testid="searchString"
         />
       </div>
-      <div className={classes.archiveTitle}>
-        <Link to="/archivedaccounts" className={classes.link}>
+      <div
+        className={classes.archiveTitle}
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "1.5rem"
+        }}
+      >
+        <NavLink to="/archivedaccounts" className={classes.link}>
           View Archived Accounts
+        </NavLink>
+        <span style={{ color: "#808589" }}>|</span>
+        <Link
+          onClick={handleCleanupInactive}
+          ariaLabel="Cleanup inactive accounts"
+        >
+          Cleanup Inactive Accounts
         </Link>
       </div>
 

--- a/client/src/services/account.service.js
+++ b/client/src/services/account.service.js
@@ -110,6 +110,11 @@ export const deleteAccount = async id => {
   return response;
 };
 
+export const cleanupInactiveAccounts = async () => {
+  const response = await axios.delete(`${baseUrl}/cleanup-inactive`);
+  return response;
+};
+
 export const getAuthorization = async ({
   email,
   firstName,

--- a/server/app/controllers/account.controller.js
+++ b/server/app/controllers/account.controller.js
@@ -225,6 +225,15 @@ const deleteById = async (req, res) => {
   }
 };
 
+const cleanupInactive = async (req, res) => {
+  try {
+    const response = await accountService.cleanupInactive();
+    res.send(response);
+  } catch (err) {
+    res.status(500).send(err);
+  }
+};
+
 module.exports = {
   getAll,
   // getById,
@@ -274,5 +283,6 @@ module.exports = {
   unarchiveById,
   getAllArchivedUsers,
   getAllDROUsers,
-  deleteById
+  deleteById,
+  cleanupInactive
 };

--- a/server/app/routes/account.routes.js
+++ b/server/app/routes/account.routes.js
@@ -84,6 +84,13 @@ router.get(
 );
 
 router.delete(
+  "/cleanup-inactive",
+  writeLimiter,
+  jwtSession.validateRoles(["isSecurityAdmin"]),
+  accountController.cleanupInactive
+);
+
+router.delete(
   "/:id/deleteaccount",
   writeLimiter,
   jwtSession.validateRoles(["isSecurityAdmin"]),

--- a/server/app/services/account.service.js
+++ b/server/app/services/account.service.js
@@ -598,6 +598,53 @@ const deleteUser = async id => {
   }
 };
 
+const cleanupInactive = async () => {
+  try {
+    await poolConnect;
+    const request = pool.request();
+    const selectResult = await request.execute(
+      "Login_SelectInactiveForCleanup"
+    );
+    const inactiveAccounts = selectResult.recordset;
+
+    let deletedCount = 0;
+    let failedCount = 0;
+    const errors = [];
+
+    for (const account of inactiveAccounts) {
+      try {
+        const delResult = await deleteUser(account.id);
+        if (delResult.isSuccess) {
+          deletedCount++;
+        } else {
+          failedCount++;
+          errors.push({
+            id: account.id,
+            email: account.email,
+            message: delResult.message
+          });
+        }
+      } catch (err) {
+        failedCount++;
+        errors.push({
+          id: account.id,
+          email: account.email,
+          message: err.message || err.toString()
+        });
+      }
+    }
+
+    return {
+      isSuccess: true,
+      deletedCount,
+      failedCount,
+      errors
+    };
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
 async function hashPassword(user) {
   if (!user.password) throw user.invalidate("password", "password is required");
   if (user.password.length < 8)
@@ -610,6 +657,7 @@ module.exports = {
   addLastLoginDate,
   archiveUser,
   authenticate,
+  cleanupInactive,
   confirmRegistration,
   deleteUser,
   forgotPassword,

--- a/server/db/migration/V20260603.1200__add_select_inactive_users_sproc.sql
+++ b/server/db/migration/V20260603.1200__add_select_inactive_users_sproc.sql
@@ -1,0 +1,37 @@
+/* Flyway Migration
+   Description: Add Login_SelectInactiveForCleanup stored procedure
+*/
+
+CREATE OR ALTER PROCEDURE [dbo].[Login_SelectInactiveForCleanup]
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT
+        id,
+        email,
+        firstName,
+        lastName,
+        dateCreated,
+        emailConfirmed,
+        isAdmin,
+        isSecurityAdmin
+    FROM [dbo].[Login]
+    WHERE (
+        -- Unconfirmed accounts - 24 hours old
+        (emailConfirmed = 0 AND dateCreated < DATEADD(hour, -24, GETUTCDATE()))
+        OR
+        -- Accounts with no saved projects - 90 days old
+        (dateCreated < DATEADD(day, -90, GETUTCDATE()) AND NOT EXISTS (
+            SELECT 1
+            FROM [dbo].[Project]
+            WHERE [dbo].[Project].[loginId] = [dbo].[Login].[id]
+        ))
+        OR
+        -- Accounts with "QQQQ" at the end of the last name - 90 days old
+        (lastName LIKE '%QQQQ' AND dateCreated < DATEADD(day, -90, GETUTCDATE()))
+    )
+    AND isAdmin = 0
+    AND isSecurityAdmin = 0;
+END;
+GO


### PR DESCRIPTION
- Partial Solution to  #2847

### What changes did you make?

Database:
  - Added a new Flyway migration [V20260603.1200__add_select_inactive_users_sproc.sql](file:///Users/limited-user/fab/hack4la/tdm-calculator/server/db/migration/V20260603.1200__add_select_inactive_users_sproc.sql) that creates the `Login_SelectInactiveForCleanup` stored procedure. This procedure targets non-admin accounts meeting inactivity rules (unconfirmed for 24h, confirmed with no projects for 90d, or confirmed ending in QQQQ for 90d).

Backend:
  - Implemented the `cleanupInactive` function in `account.service.js` to retrieve and delete matched candidates
  - Added a controller and registered the `DELETE /api/accounts/cleanup-inactive` route in `account.routes.js`

Frontend:
  - Added a "Cleanup Inactive Accounts" action link inside the Security Admin Roles view.
  - When cliicked, initiates cleanup, and raises a toast confirmation with the total number of deleted accounts

### Why did you make the changes (we will use this info to test)?

To remove stale unconfirmed registrations or old accounts without created projects.

**To test the changes manually:**
1. Log in as a Security Admin
2. Navigate to the `/admin` / Roles management page.
3. Click the **Cleanup Inactive Accounts** link in the header.
4. You should see a toast confirming the number of accounts cleaned up, and the list of accounts will refresh.

### Issue-Specific User Account

To run local SQL integration checks:

Use sqlcmd or favorite DB manager to issue the following SQL commands:

```SQL
USE tdmdev;
GO

-- 1. Cleanup any previous test runs
DELETE FROM [dbo].[LoginHistory] WHERE loginId IN (SELECT id FROM [dbo].[Login] WHERE email IN ('inactive-unconfirmed-24h@test.com', 'inactive-noprojects-90d@test.com', 'inactive-qqqq-90d@test.com', 'inactive-unconfirmed-2@test.com'));
DELETE FROM [dbo].[Login] WHERE email IN ('inactive-unconfirmed-24h@test.com', 'inactive-noprojects-90d@test.com', 'inactive-qqqq-90d@test.com', 'inactive-unconfirmed-2@test.com');

-- 2. Insert 4 inactive candidates
-- Candidate A: Unconfirmed > 24 hours old
-- Candidate B: Confirmed, no projects, > 90 days old
-- Candidate C: Confirmed, name ends in QQQQ, > 90 days old
-- Candidate D: Second Unconfirmed > 24 hours old
INSERT INTO [dbo].[Login] (firstName, lastName, email, dateCreated, emailConfirmed, isAdmin, isSecurityAdmin, passwordHash)
VALUES 
('InactiveA', 'User', 'inactive-unconfirmed-24h@test.com', DATEADD(hour, -25, GETUTCDATE()), 0, 0, 0, '$2b$10$abcdefghijklmnopqrstuv'),
('InactiveB', 'User', 'inactive-noprojects-90d@test.com', DATEADD(day, -95, GETUTCDATE()), 1, 0, 0, '$2b$10$abcdefghijklmnopqrstuv'),
('InactiveC', 'UserQQQQ', 'inactive-qqqq-90d@test.com', DATEADD(day, -95, GETUTCDATE()), 1, 0, 0, '$2b$10$abcdefghijklmnopqrstuv'),
('InactiveD', 'User', 'inactive-unconfirmed-2@test.com', DATEADD(hour, -25, GETUTCDATE()), 0, 0, 0, '$2b$10$abcdefghijklmnopqrstuv');
GO

-- 3. Verify they are inserted successfully
SELECT id, email, dateCreated, emailConfirmed FROM [dbo].[Login] WHERE email IN ('inactive-unconfirmed-24h@test.com', 'inactive-noprojects-90d@test.com', 'inactive-qqqq-90d@test.com', 'inactive-unconfirmed-2@test.com');
GO
```

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

<img width="1020" height="259" alt="before_add_delete_inactive_users" src="https://github.com/user-attachments/assets/a4b2cc1d-3a6c-4f94-8c93-b960be0ad087" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1013" height="253" alt="after_add_delete_inactive_users" src="https://github.com/user-attachments/assets/4e1cd5a5-1c60-4b77-b119-b486cf75d512" />


</details>
