### PR TITLE
3276 Change "Approval Status" to be "Submission Status" on Manage Submissions and Submissions 

### DIFF
--- a/client/src/components/Submissions/ManageSubmissionForm.jsx
+++ b/client/src/components/Submissions/ManageSubmissionForm.jsx
@@ -289,7 +289,7 @@ const ManageSubmissionForm = ({ onClose, project, assigneeList }) => {
               />
             </div>
             <div className={classes.rowFlexBox}>
-              <span className={classes.rowLabel}>Approval Status</span>
+              <span className={classes.rowLabel}>Submission Status</span>
               <UniversalSelect
                 id="approvalStatusId"
                 name="approvalStatusId"
@@ -297,10 +297,6 @@ const ManageSubmissionForm = ({ onClose, project, assigneeList }) => {
                 onChange={formik.handleChange}
                 options={approvalStatuses}
                 className={classes.formInput}
-                // className={clsx(
-                //   classes.formInput,
-                //   errors.name && touched.name && classes.formErrorBorder
-                // )}
               />
             </div>
             <div className={classes.rowFlexBox}>

--- a/client/src/components/Submissions/ManageSubmissionsPage.jsx
+++ b/client/src/components/Submissions/ManageSubmissionsPage.jsx
@@ -417,7 +417,7 @@ const ManageSubmissions = ({ contentContainerRef }) => {
     { id: "onHold", label: "On Hold", popupType: "boolean", colWidth: "8rem" },
     {
       id: "approvalStatusName",
-      label: "Approval Status",
+      label: "Submission Status",
       popupType: "stringList",
       colWidth: "12rem"
     },

--- a/client/src/components/Submissions/SubmissionsPage.jsx
+++ b/client/src/components/Submissions/SubmissionsPage.jsx
@@ -397,7 +397,7 @@ const SubmissionsPage = ({ contentContainerRef }) => {
     { id: "onHold", label: "On Hold", popupType: "boolean", colWidth: "113px" },
     {
       id: "approvalStatusName",
-      label: "Approval Status",
+      label: "Submission Status",
       popupType: "stringList",
       colWidth: "240px"
     },


### PR DESCRIPTION
- Fixes #3276

### What changes did you make?

- Update wording on Manage Submissions and Submissions pages from "Approval Status" to "Submission Status" for consistency

### Why did you make the changes (we will use this info to test)?

- update wording to be consistent with other pages

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

## Manage Submissions
<img width="1203" height="328" alt="3276-before-manage-submissions" src="https://github.com/user-attachments/assets/fc711677-e9a5-41f9-a14f-5dfa9ed6afd1" />

## Submissions
<img width="1241" height="309" alt="3276-before-submission" src="https://github.com/user-attachments/assets/b628c3c6-7071-46aa-82c1-792ec2a998fb" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
## Manage Submissions
<img width="1205" height="279" alt="3276-after-manage-submissions" src="https://github.com/user-attachments/assets/8c6afea1-0335-4b41-8c07-fd0be2db3bec" />


## Submissions

<img width="1252" height="395" alt="3276-after-submission" src="https://github.com/user-attachments/assets/415fc085-0846-4f75-8abf-4607ee866b55" />

</details>
