### PR TITLE
3197 Update wording in info box on pg 1 of the calculator and added tooltip icon

### DIFF
--- a/client/src/components/ProjectWizard/WizardPages/DiscoverTooltips.jsx
+++ b/client/src/components/ProjectWizard/WizardPages/DiscoverTooltips.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { createUseStyles, useTheme } from "react-jss";
+import { MdInfo } from "react-icons/md";
 
 const useStyles = createUseStyles(theme => ({
   container: {
@@ -15,7 +16,10 @@ const useStyles = createUseStyles(theme => ({
     flexShrink: "1",
     fontFamily: "Calibri",
     fontWeight: 700
-  }
+  },
+  infoIcon: {
+    color: theme.colorLADOT
+  },
 }));
 const DiscoverTooltips = () => {
   const theme = useTheme();
@@ -23,9 +27,7 @@ const DiscoverTooltips = () => {
   return (
     <div className={classes.container}>
       <p className={classes.title}>
-        Try hovering over a term you want more information on. If the words
-        become underlined and bold, you can click for a description. Hovering
-        over a green question mark will also provide more information.
+        If you want to know more about a term, hover over it and click the icon<MdInfo className={classes.infoIcon} /> for more information.
       </p>
     </div>
   );


### PR DESCRIPTION
- Fixes #3197

### What changes did you make?

- Update wording in info box on pg 1 of the calculator and added tooltip icon

### Why did you make the changes (we will use this info to test)?

- Update wording to updated text from stakeholder

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="301" height="179" alt="3197-before" src="https://github.com/user-attachments/assets/a7b0eb9c-b830-46f2-975d-43a0acbba29e" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="348" height="148" alt="3197-after" src="https://github.com/user-attachments/assets/6c3a2967-a6cd-403f-b005-beb28c28ea4e" />

</details>
