### PR TITLE
2692 add api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The city will benefit by having more time to review edge cases for building deve
 - To help with user research, find other cities' TDM calculators. For example, check out [SF's TDM Tool](https://sfplanninggis.org/tdm_v3/)
 
 - To contribute to the code, see [Contributing](https://github.com/hackforla/tdm-calculator/wiki/Contributing-Code)
+- For internal server API docs, see [API Documentation](docs/api-documentation.md).
 
 ### Working with issues
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -1,0 +1,50 @@
+# API Documentation
+
+The server can expose protected OpenAPI documentation for internal development.
+The documentation covers the server's active Express API endpoints across
+public, authenticated, admin-only, request-body, and path-parameter flows.
+
+## Enable Locally
+
+From the `server` directory, set `ENABLE_API_DOCS=true` before starting the
+server:
+
+```bash
+cd server
+ENABLE_API_DOCS=true npm start
+```
+
+The interactive Swagger UI is available at:
+
+```text
+http://localhost:5000/api-docs
+```
+
+The raw OpenAPI JSON is available at:
+
+```text
+http://localhost:5000/api-docs.json
+```
+
+Both routes require an authenticated `isAdmin` user. The API accepts JWT auth
+from either the `jwt` cookie or an `Authorization: Bearer <token>` header.
+
+## Adding Endpoint Docs
+
+Reusable request schemas live in `server/app/schemas` and are exposed as
+OpenAPI components from `server/app/docs/openapi.js`. The complete endpoint
+catalog is assembled in `server/app/docs/openapi-paths.js`; route-adjacent
+`@openapi` JSDoc blocks in `server/app/routes/*.routes.js` are also supported
+for endpoints that are easier to document beside the route.
+
+When documenting a new endpoint, include:
+
+- route path under the `/api` base path
+- method, summary, and tag
+- path parameters when present
+- request body schema for write endpoints
+- auth requirements matching the route middleware
+- expected success and error responses
+
+Keep docs close to the route that owns the behavior so future route changes are
+easy to review with their OpenAPI changes.

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -17,13 +17,13 @@ ENABLE_API_DOCS=true npm start
 The interactive Swagger UI is available at:
 
 ```text
-http://localhost:5000/api-docs
+http://localhost:PORT/api-docs
 ```
 
 The raw OpenAPI JSON is available at:
 
 ```text
-http://localhost:5000/api-docs.json
+http://localhost:PORT/api-docs.json
 ```
 
 Both routes require an authenticated `isAdmin` user. The API accepts JWT auth

--- a/server/app/docs/openapi-paths.js
+++ b/server/app/docs/openapi-paths.js
@@ -1,0 +1,678 @@
+const authenticated = [{ bearerAuth: [] }, { cookieAuth: [] }];
+
+const ref = name => ({
+  $ref: `#/components/schemas/${name}`
+});
+
+const jsonBody = schema => ({
+  required: true,
+  content: {
+    "application/json": {
+      schema
+    }
+  }
+});
+
+const parameter = (name, type = "integer") => ({
+  in: "path",
+  name,
+  required: true,
+  schema: {
+    type
+  }
+});
+
+const success = description => ({
+  description
+});
+
+const errors = (...codes) =>
+  codes.reduce(
+    (responses, code) => ({
+      ...responses,
+      [code]: {
+        $ref: `#/components/responses/${codeToResponseName[code]}`
+      }
+    }),
+    {}
+  );
+
+const codeToResponseName = {
+  400: "BadRequest",
+  401: "Unauthorized",
+  403: "Forbidden",
+  404: "NotFound",
+  409: "Conflict",
+  500: "ServerError"
+};
+
+const commonAuthErrors = errors(401, 500);
+const forbiddenAuthErrors = errors(401, 403, 500);
+
+module.exports = {
+  "/about": {
+    get: {
+      tags: ["About"],
+      summary: "Get About page content.",
+      responses: {
+        200: success("About page content was returned."),
+        ...errors(500)
+      }
+    },
+    post: {
+      tags: ["About"],
+      summary: "Replace About page content.",
+      security: authenticated,
+      requestBody: jsonBody(ref("About")),
+      responses: {
+        201: success("About page content was saved."),
+        ...errors(400, 401, 403, 500)
+      }
+    }
+  },
+  "/accounts/{id}/roles": {
+    put: {
+      tags: ["Accounts"],
+      summary: "Update account role flags.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      requestBody: jsonBody(ref("AccountRole")),
+      responses: {
+        200: success("Account roles were updated."),
+        ...errors(400, 401, 403, 500)
+      }
+    }
+  },
+  "/accounts/resendConfirmationEmail": {
+    post: {
+      tags: ["Accounts"],
+      summary: "Resend an account confirmation email.",
+      requestBody: jsonBody(ref("AccountConfirmEmail")),
+      responses: {
+        200: success("Confirmation email request was processed."),
+        ...errors(400, 500)
+      }
+    }
+  },
+  "/accounts/confirmRegister": {
+    post: {
+      tags: ["Accounts"],
+      summary: "Confirm account registration with a token.",
+      requestBody: jsonBody(ref("AccountConfirmRegister")),
+      responses: {
+        200: success("Registration confirmation was processed."),
+        ...errors(400, 401, 500)
+      }
+    }
+  },
+  "/accounts/forgotPassword": {
+    post: {
+      tags: ["Accounts"],
+      summary: "Request a password reset email.",
+      requestBody: jsonBody(ref("AccountForgotPassword")),
+      responses: {
+        200: success("Password reset request was processed."),
+        ...errors(400, 500)
+      }
+    }
+  },
+  "/accounts/resetPassword": {
+    post: {
+      tags: ["Accounts"],
+      summary: "Reset a password with a reset token.",
+      requestBody: jsonBody(ref("AccountReset")),
+      responses: {
+        200: success("Password reset was processed."),
+        ...errors(400, 500)
+      }
+    }
+  },
+  "/accounts/logout": {
+    get: {
+      tags: ["Accounts"],
+      summary: "Log out and clear the JWT cookie.",
+      responses: {
+        200: success("Logout completed."),
+        ...errors(500)
+      }
+    }
+  },
+  "/accounts/updateaccount": {
+    put: {
+      tags: ["Accounts"],
+      summary: "Update the authenticated user's account profile.",
+      security: authenticated,
+      requestBody: jsonBody(ref("AccountUpdateAccount")),
+      responses: {
+        200: success("Account profile was updated."),
+        ...errors(400, 401, 500)
+      }
+    }
+  },
+  "/accounts/{id}/archiveaccount": {
+    put: {
+      tags: ["Accounts"],
+      summary: "Archive an account.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      responses: {
+        200: success("Account was archived."),
+        ...errors(400, 401, 403, 500)
+      }
+    }
+  },
+  "/accounts/{id}/unarchiveaccount": {
+    put: {
+      tags: ["Accounts"],
+      summary: "Unarchive an account.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      responses: {
+        200: success("Account was unarchived."),
+        ...errors(401, 403, 500)
+      }
+    }
+  },
+  "/accounts/archivedaccounts": {
+    get: {
+      tags: ["Accounts"],
+      summary: "List archived accounts.",
+      security: authenticated,
+      responses: {
+        200: success("Archived accounts were returned."),
+        ...forbiddenAuthErrors
+      }
+    }
+  },
+  "/accounts/droLogins": {
+    get: {
+      tags: ["Accounts"],
+      summary: "List DRO user accounts.",
+      security: authenticated,
+      responses: {
+        200: success("DRO user accounts were returned."),
+        ...forbiddenAuthErrors
+      }
+    }
+  },
+  "/accounts/cleanup-inactive": {
+    delete: {
+      tags: ["Accounts"],
+      summary: "Delete inactive accounts eligible for cleanup.",
+      security: authenticated,
+      responses: {
+        200: success("Inactive account cleanup completed."),
+        ...forbiddenAuthErrors
+      }
+    }
+  },
+  "/accounts/{id}/deleteaccount": {
+    delete: {
+      tags: ["Accounts"],
+      summary: "Delete an account.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      responses: {
+        200: success("Account was deleted."),
+        ...errors(400, 401, 403, 500)
+      }
+    }
+  },
+  "/calculations/includeRules/{id}": {
+    get: {
+      tags: ["Calculations"],
+      summary: "Get one calculation with its rules.",
+      parameters: [parameter("id")],
+      responses: {
+        200: success("Calculation with rules was returned."),
+        ...errors(404, 500)
+      }
+    }
+  },
+  "/calculations/includeRules": {
+    get: {
+      tags: ["Calculations"],
+      summary: "List calculations with their rules.",
+      responses: {
+        200: success("Calculations with rules were returned."),
+        ...errors(500)
+      }
+    }
+  },
+  "/calculations/{id}": {
+    get: {
+      tags: ["Calculations"],
+      summary: "Get one calculation.",
+      parameters: [parameter("id")],
+      responses: {
+        200: success("Calculation was returned."),
+        ...errors(404, 500)
+      }
+    }
+  },
+  "/calculations/updateDescription/{id}": {
+    put: {
+      tags: ["Calculations"],
+      summary: "Update a calculation rule description.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      requestBody: jsonBody(ref("RuleDescriptionUpdate")),
+      responses: {
+        200: success("Rule description was updated."),
+        ...forbiddenAuthErrors
+      }
+    }
+  },
+  "/configs": {
+    get: {
+      tags: ["Configs"],
+      summary: "List configuration values.",
+      responses: {
+        200: success("Configuration values were returned."),
+        ...errors(500)
+      }
+    },
+    post: {
+      tags: ["Configs"],
+      summary: "Create a configuration value.",
+      security: authenticated,
+      requestBody: jsonBody(ref("Config")),
+      responses: {
+        201: success("Configuration value was created."),
+        ...commonAuthErrors
+      }
+    }
+  },
+  "/configs/{code}": {
+    get: {
+      tags: ["Configs"],
+      summary: "Get one configuration value by code.",
+      parameters: [parameter("code", "string")],
+      responses: {
+        200: success("Configuration value was returned."),
+        ...errors(500)
+      }
+    },
+    put: {
+      tags: ["Configs"],
+      summary: "Update a configuration value.",
+      security: authenticated,
+      parameters: [parameter("code", "string")],
+      requestBody: jsonBody(ref("Config")),
+      responses: {
+        200: success("Configuration value was updated."),
+        ...commonAuthErrors
+      }
+    },
+    delete: {
+      tags: ["Configs"],
+      summary: "Delete a configuration value.",
+      security: authenticated,
+      parameters: [parameter("code", "string")],
+      responses: {
+        200: success("Configuration value was deleted."),
+        ...commonAuthErrors
+      }
+    }
+  },
+  "/debug/memory": {
+    get: {
+      tags: ["Debug"],
+      summary: "Get Node process memory usage.",
+      responses: {
+        200: {
+          description: "Memory usage was returned.",
+          content: {
+            "application/json": {
+              schema: ref("MemoryUsage")
+            }
+          }
+        },
+        ...errors(500)
+      }
+    }
+  },
+  "/dro/{id}": {
+    get: {
+      tags: ["DRO"],
+      summary: "Get one Development Review Office entry.",
+      parameters: [parameter("id")],
+      responses: {
+        200: success("DRO entry was returned."),
+        ...errors(404, 500)
+      }
+    },
+    put: {
+      tags: ["DRO"],
+      summary: "Update a Development Review Office entry.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      requestBody: jsonBody(ref("Dro")),
+      responses: {
+        204: success("DRO entry was updated."),
+        ...errors(401, 403, 404, 500)
+      }
+    },
+    delete: {
+      tags: ["DRO"],
+      summary: "Delete a Development Review Office entry.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      responses: {
+        204: success("DRO entry was deleted."),
+        ...errors(401, 403, 404, 500)
+      }
+    }
+  },
+  "/dro": {
+    get: {
+      tags: ["DRO"],
+      summary: "List Development Review Office entries.",
+      responses: {
+        200: success("DRO entries were returned."),
+        ...errors(500)
+      }
+    }
+  },
+  "/emails": {
+    post: {
+      tags: ["Emails"],
+      summary: "Send an email.",
+      security: authenticated,
+      requestBody: jsonBody(ref("Email")),
+      responses: {
+        202: success("Email was accepted for sending."),
+        ...errors(400, 401, 403, 404, 500)
+      }
+    }
+  },
+  "/faqcategories": {
+    get: {
+      tags: ["FAQ Categories"],
+      summary: "List FAQ categories and FAQs.",
+      responses: {
+        200: success("FAQ categories were returned."),
+        ...errors(500)
+      }
+    },
+    post: {
+      tags: ["FAQ Categories"],
+      summary: "Replace FAQ categories and FAQs.",
+      security: authenticated,
+      requestBody: jsonBody(ref("FaqCategory")),
+      responses: {
+        201: success("FAQ categories were saved."),
+        ...errors(400, 401, 403, 500)
+      }
+    }
+  },
+  "/projects/archivedprojects": {
+    get: {
+      tags: ["Projects"],
+      summary: "List archived projects.",
+      security: authenticated,
+      responses: {
+        200: success("Archived projects were returned."),
+        ...errors(401, 403, 500)
+      }
+    }
+  },
+  "/projects/submissions": {
+    get: {
+      tags: ["Projects"],
+      summary: "List submitted projects for the authenticated user.",
+      security: authenticated,
+      responses: {
+        200: success("Submitted projects were returned."),
+        ...commonAuthErrors
+      }
+    }
+  },
+  "/projects/submissionsadmin": {
+    get: {
+      tags: ["Projects"],
+      summary: "List submitted projects for admin review.",
+      security: authenticated,
+      responses: {
+        200: success("Submitted projects were returned."),
+        ...commonAuthErrors
+      }
+    }
+  },
+  "/projects/submissionsadmin/{projectId}": {
+    get: {
+      tags: ["Projects"],
+      summary: "Get one submitted project for admin review.",
+      security: authenticated,
+      parameters: [parameter("projectId")],
+      responses: {
+        200: success("Submitted project was returned."),
+        ...commonAuthErrors
+      }
+    }
+  },
+  "/projects/submissionLog/{projectId}": {
+    get: {
+      tags: ["Projects"],
+      summary: "Get a project's submission log.",
+      security: authenticated,
+      parameters: [parameter("projectId")],
+      responses: {
+        200: success("Submission log was returned."),
+        ...commonAuthErrors
+      }
+    }
+  },
+  "/projects/projectShare/{id}": {
+    get: {
+      tags: ["Projects"],
+      summary: "Get a shared project by id for the authenticated user's email.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      responses: {
+        200: success("Shared project was returned."),
+        ...errors(401, 404, 500)
+      }
+    }
+  },
+  "/projects/hide": {
+    put: {
+      tags: ["Projects"],
+      summary: "Update hidden state for projects.",
+      security: authenticated,
+      requestBody: jsonBody({
+        allOf: [
+          ref("ProjectStateChange"),
+          {
+            type: "object",
+            required: ["hide"]
+          }
+        ]
+      }),
+      responses: {
+        204: success("Project hidden state was updated."),
+        ...errors(401, 403, 500)
+      }
+    }
+  },
+  "/projects/snapshot": {
+    put: {
+      tags: ["Projects"],
+      summary: "Create a project snapshot.",
+      security: authenticated,
+      requestBody: jsonBody(ref("ProjectSnapshot")),
+      responses: {
+        204: success("Project snapshot was created."),
+        ...errors(401, 403, 500)
+      }
+    }
+  },
+  "/projects/submit": {
+    put: {
+      tags: ["Projects"],
+      summary: "Submit a project.",
+      security: authenticated,
+      requestBody: jsonBody(ref("ProjectIdBody")),
+      responses: {
+        204: success("Project was submitted."),
+        ...errors(401, 403, 500)
+      }
+    }
+  },
+  "/projects/renameSnapshot": {
+    put: {
+      tags: ["Projects"],
+      summary: "Rename a project snapshot.",
+      security: authenticated,
+      requestBody: jsonBody(ref("ProjectSnapshot")),
+      responses: {
+        204: success("Project snapshot was renamed."),
+        ...errors(401, 403, 500)
+      }
+    }
+  },
+  "/projects/{id}": {
+    get: {
+      tags: ["Projects"],
+      summary: "Get one project.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      responses: {
+        200: success("Project was returned."),
+        ...errors(401, 404, 500)
+      }
+    },
+    put: {
+      tags: ["Projects"],
+      summary: "Update a project.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      requestBody: jsonBody(ref("Project")),
+      responses: {
+        204: success("Project was updated."),
+        ...errors(401, 403, 404, 500)
+      }
+    },
+    delete: {
+      tags: ["Projects"],
+      summary: "Delete a project.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      responses: {
+        204: success("Project was deleted."),
+        ...errors(401, 403, 404, 500)
+      }
+    }
+  },
+  "/projects/updateCalculationId/{id}": {
+    put: {
+      tags: ["Projects"],
+      summary: "Update a project's calculation selection.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      requestBody: jsonBody(ref("ProjectCalculationUpdate")),
+      responses: {
+        204: success("Project calculation selection was updated."),
+        ...forbiddenAuthErrors
+      }
+    }
+  },
+  "/projects/updateDroId/{id}": {
+    put: {
+      tags: ["Projects"],
+      summary: "Update a project's DRO assignment.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      requestBody: jsonBody(ref("ProjectDroUpdate")),
+      responses: {
+        204: success("Project DRO assignment was updated."),
+        ...commonAuthErrors
+      }
+    }
+  },
+  "/projects/updateAdminNotes/{id}": {
+    put: {
+      tags: ["Projects"],
+      summary: "Update project admin notes.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      requestBody: jsonBody(ref("ProjectAdminNotes")),
+      responses: {
+        204: success("Project admin notes were updated."),
+        ...forbiddenAuthErrors
+      }
+    }
+  },
+  "/projects/updateTotals/{id}": {
+    put: {
+      tags: ["Projects"],
+      summary: "Update stored project total fields.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      requestBody: jsonBody(ref("ProjectTotals")),
+      responses: {
+        200: success("Project totals were updated."),
+        ...forbiddenAuthErrors
+      }
+    }
+  },
+  "/projects/submissions/{id}": {
+    put: {
+      tags: ["Projects"],
+      summary: "Update submission metadata for a project.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      requestBody: jsonBody(ref("ProjectSubmission")),
+      responses: {
+        204: success("Project submission metadata was updated."),
+        ...commonAuthErrors
+      }
+    }
+  },
+  "/projectShare/{id}": {
+    get: {
+      tags: ["Project Share"],
+      summary: "Get one project share record.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      responses: {
+        200: success("Project share record was returned."),
+        ...errors(401, 404, 500)
+      }
+    },
+    delete: {
+      tags: ["Project Share"],
+      summary: "Delete one project share record.",
+      security: authenticated,
+      parameters: [parameter("id")],
+      responses: {
+        204: success("Project share record was deleted."),
+        ...errors(401, 404, 500)
+      }
+    }
+  },
+  "/projectShare/projectId/{projectId}": {
+    get: {
+      tags: ["Project Share"],
+      summary: "List share records for one project.",
+      security: authenticated,
+      parameters: [parameter("projectId")],
+      responses: {
+        200: success("Project share records were returned."),
+        ...errors(401, 404, 500)
+      }
+    }
+  },
+  "/projectShare": {
+    post: {
+      tags: ["Project Share"],
+      summary: "Share a project with an email address.",
+      security: authenticated,
+      requestBody: jsonBody(ref("ProjectShare")),
+      responses: {
+        201: success("Project share record was created."),
+        ...errors(400, 401, 500)
+      }
+    }
+  }
+};

--- a/server/app/docs/openapi.js
+++ b/server/app/docs/openapi.js
@@ -1,0 +1,401 @@
+const path = require("path");
+const swaggerJsdoc = require("swagger-jsdoc");
+
+const packageJson = require("../../package.json");
+const aboutSchema = require("../schemas/about");
+const accountConfirmEmailSchema = require("../schemas/account.confirmEmail");
+const accountForgotPasswordSchema = require("../schemas/account.forgotPassword");
+const accountLoginSchema = require("../schemas/account.login");
+const accountRegisterSchema = require("../schemas/account.register");
+const accountResetSchema = require("../schemas/account.reset");
+const accountRoleSchema = require("../schemas/account.role");
+const accountUpdateAccountSchema = require("../schemas/account.updateAccount");
+const droSchema = require("../schemas/dro");
+const emailSchema = require("../schemas/email");
+const faqCategorySchema = require("../schemas/faqCategory");
+const feedbackPostSchema = require("../schemas/feedback.post");
+const projectSchema = require("../schemas/project");
+const projectShareSchema = require("../schemas/projectShare");
+const additionalPaths = require("./openapi-paths");
+
+const schemaWithExample = (schema, example) => ({
+  ...schema,
+  example
+});
+
+const mergePaths = (generatedPaths, extraPaths) => {
+  const mergedPaths = { ...generatedPaths };
+
+  Object.entries(extraPaths).forEach(([path, methods]) => {
+    mergedPaths[path] = {
+      ...methods,
+      ...(mergedPaths[path] || {})
+    };
+  });
+
+  return mergedPaths;
+};
+
+const openapiSpec = swaggerJsdoc({
+  failOnErrors: true,
+  definition: {
+    openapi: "3.0.0",
+    info: {
+      title: "TDM Calculator API",
+      version: packageJson.version,
+      description:
+        "Internal API documentation for the Transportation Demand Management Calculator."
+    },
+    servers: [
+      {
+        url: "/api",
+        description: "API base path"
+      }
+    ],
+    tags: [
+      { name: "About" },
+      { name: "Accounts" },
+      { name: "Calculations" },
+      { name: "Configs" },
+      { name: "Debug" },
+      { name: "DRO" },
+      { name: "Emails" },
+      { name: "FAQ Categories" },
+      { name: "Feedback" },
+      { name: "Projects" },
+      { name: "Project Share" }
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          bearerFormat: "JWT"
+        },
+        cookieAuth: {
+          type: "apiKey",
+          in: "cookie",
+          name: "jwt"
+        }
+      },
+      schemas: {
+        About: aboutSchema,
+        AccountConfirmEmail: schemaWithExample(accountConfirmEmailSchema, {
+          email: "jane.planner@example.com"
+        }),
+        AccountForgotPassword: schemaWithExample(accountForgotPasswordSchema, {
+          email: "jane.planner@example.com"
+        }),
+        AccountLogin: schemaWithExample(accountLoginSchema, {
+          email: "jane.planner@example.com",
+          password: "ExamplePass1!"
+        }),
+        AccountRegister: schemaWithExample(accountRegisterSchema, {
+          firstName: "Jane",
+          lastName: "Planner",
+          email: "jane.planner@example.com",
+          password: "ExamplePass1!"
+        }),
+        AccountReset: schemaWithExample(accountResetSchema, {
+          token: "password-reset-token",
+          password: "ExamplePass1!"
+        }),
+        AccountRole: schemaWithExample(accountRoleSchema, {
+          id: 42,
+          isAdmin: true,
+          isSecurityAdmin: false,
+          isDro: false
+        }),
+        AccountUpdateAccount: schemaWithExample(accountUpdateAccountSchema, {
+          firstName: "Jane",
+          lastName: "Planner",
+          email: "jane.planner@example.com"
+        }),
+        Config: {
+          type: "object",
+          required: ["code", "value"],
+          properties: {
+            code: {
+              type: "string"
+            },
+            value: {
+              type: "string"
+            },
+            description: {
+              type: "string"
+            }
+          },
+          example: {
+            code: "CURRENT_GUIDELINES_VERSION",
+            value: "2025",
+            description: "Current program guidelines version."
+          }
+        },
+        Dro: schemaWithExample(droSchema, {
+          name: "Central Development Review Office",
+          displayOrder: 1
+        }),
+        Email: schemaWithExample(emailSchema, {
+          to: "jane.planner@example.com",
+          subject: "TDM Calculator notification",
+          text: "Your project has been updated."
+        }),
+        Error: {
+          type: "object",
+          properties: {
+            error: {
+              type: "string"
+            }
+          }
+        },
+        FaqCategory: faqCategorySchema,
+        FeedbackPost: schemaWithExample(feedbackPostSchema, {
+          name: "Jane Planner",
+          email: "jane.planner@example.com",
+          forwardToWebTeam: false,
+          comment: "I have a question about my submitted project.",
+          selectedProjects: [101, 102]
+        }),
+        Project: schemaWithExample(projectSchema, {
+          name: "Downtown Mixed Use Project",
+          address: "200 N Spring St, Los Angeles, CA 90012",
+          description: "Mixed-use development near transit.",
+          formInputs: '{"PROJECT_LEVEL":1}',
+          loginId: 42,
+          calculationId: 1,
+          targetPoints: 25,
+          earnedPoints: 30,
+          projectLevel: 1
+        }),
+        ProjectShare: schemaWithExample(projectShareSchema, {
+          email: "reviewer@example.com",
+          projectId: 101
+        }),
+        MemoryUsage: {
+          type: "object",
+          properties: {
+            rss: {
+              type: "string"
+            },
+            heapTotal: {
+              type: "string"
+            },
+            heapUsed: {
+              type: "string"
+            },
+            external: {
+              type: "string"
+            }
+          },
+          example: {
+            rss: "120 MB",
+            heapTotal: "60 MB",
+            heapUsed: "45 MB",
+            external: "5 MB"
+          }
+        },
+        ProjectAdminNotes: {
+          type: "object",
+          required: ["adminNotes"],
+          properties: {
+            adminNotes: {
+              type: "string"
+            }
+          },
+          example: {
+            adminNotes: "Reviewed by LADOT staff."
+          }
+        },
+        ProjectCalculationUpdate: {
+          type: "object",
+          required: ["calculationId"],
+          properties: {
+            calculationId: {
+              type: "number"
+            },
+            isCalculationIdOverride: {
+              type: "boolean"
+            },
+            targetPoints: {
+              type: "number"
+            },
+            earnedPoints: {
+              type: "number"
+            },
+            projectLevel: {
+              type: "number"
+            }
+          },
+          example: {
+            calculationId: 2,
+            isCalculationIdOverride: true,
+            targetPoints: 25,
+            earnedPoints: 30,
+            projectLevel: 1
+          }
+        },
+        ProjectDroUpdate: {
+          type: "object",
+          required: ["droId"],
+          properties: {
+            droId: {
+              type: "number"
+            },
+            loginId: {
+              type: "number"
+            }
+          },
+          example: {
+            droId: 3,
+            loginId: 42
+          }
+        },
+        ProjectIdBody: {
+          type: "object",
+          required: ["id"],
+          properties: {
+            id: {
+              type: "number"
+            }
+          },
+          example: {
+            id: 101
+          }
+        },
+        ProjectSnapshot: {
+          type: "object",
+          required: ["id", "name"],
+          properties: {
+            id: {
+              type: "number"
+            },
+            name: {
+              type: "string"
+            }
+          },
+          example: {
+            id: 101,
+            name: "Downtown Mixed Use Snapshot"
+          }
+        },
+        ProjectStateChange: schemaWithExample(
+          {
+            type: "object",
+            required: ["ids"],
+            properties: {
+              ids: {
+                type: "array",
+                items: {
+                  type: "number"
+                }
+              },
+              hide: {
+                type: "boolean"
+              },
+              trash: {
+                type: "boolean"
+              }
+            }
+          },
+          {
+            ids: [101, 102],
+            trash: true
+          }
+        ),
+        ProjectSubmission: {
+          type: "object",
+          required: ["id"],
+          additionalProperties: true,
+          properties: {
+            id: {
+              type: "number"
+            },
+            approvalStatus: {
+              type: "string"
+            },
+            adminNotes: {
+              type: "string"
+            }
+          },
+          example: {
+            id: 101,
+            approvalStatus: "Approved",
+            adminNotes: "Submission reviewed."
+          }
+        },
+        ProjectTotals: {
+          type: "object",
+          required: ["id", "targetPoints", "earnedPoints", "projectLevel"],
+          properties: {
+            id: {
+              type: "number"
+            },
+            targetPoints: {
+              type: "number"
+            },
+            earnedPoints: {
+              type: "number"
+            },
+            projectLevel: {
+              type: "number"
+            }
+          },
+          example: {
+            id: 101,
+            targetPoints: 25,
+            earnedPoints: 30,
+            projectLevel: 1
+          }
+        },
+        RuleDescriptionUpdate: {
+          type: "object",
+          required: ["description"],
+          properties: {
+            description: {
+              type: "string"
+            }
+          },
+          example: {
+            description: "Updated rule description shown in the calculator."
+          }
+        }
+      },
+      responses: {
+        BadRequest: {
+          description: "Request validation failed."
+        },
+        Unauthorized: {
+          description: "Missing or invalid session token."
+        },
+        Forbidden: {
+          description:
+            "Authenticated user is not allowed to perform this action."
+        },
+        NotFound: {
+          description: "Requested resource was not found."
+        },
+        Conflict: {
+          description: "Request conflicts with the current resource state."
+        },
+        ServerError: {
+          description: "Unexpected server error."
+        }
+      }
+    }
+  },
+  apis: [path.join(__dirname, "../routes/*.routes.js")]
+});
+
+openapiSpec.paths = mergePaths(openapiSpec.paths, additionalPaths);
+
+const swaggerUiOptions = {
+  explorer: true,
+  swaggerOptions: {
+    persistAuthorization: true
+  }
+};
+
+module.exports = {
+  openapiSpec,
+  swaggerUiOptions
+};

--- a/server/app/routes/account.routes.js
+++ b/server/app/routes/account.routes.js
@@ -4,6 +4,27 @@ const jwtSession = require("../../middleware/jwt-session");
 const { loginLimiter, writeLimiter } = require("../../middleware/rateLimiter");
 
 // router.get("/:id", jwtSession.validateUser, accountController.getById);
+/**
+ * @openapi
+ * /accounts:
+ *   get:
+ *     tags:
+ *       - Accounts
+ *     summary: List all user accounts.
+ *     description: Requires a security admin session.
+ *     security:
+ *       - bearerAuth: []
+ *       - cookieAuth: []
+ *     responses:
+ *       200:
+ *         description: Accounts were returned.
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       500:
+ *         $ref: '#/components/responses/ServerError'
+ */
 router.get(
   "/",
   writeLimiter,
@@ -18,6 +39,27 @@ router.put(
   accountController.putRoles
 );
 
+/**
+ * @openapi
+ * /accounts/register:
+ *   post:
+ *     tags:
+ *       - Accounts
+ *     summary: Register a new account.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AccountRegister'
+ *     responses:
+ *       200:
+ *         description: Account registration completed or returned a registration result.
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       500:
+ *         $ref: '#/components/responses/ServerError'
+ */
 router.post("/register", writeLimiter, accountController.register);
 router.post(
   "/resendConfirmationEmail",
@@ -33,6 +75,28 @@ router.post(
 router.post("/forgotPassword", writeLimiter, accountController.forgotPassword);
 router.post("/resetPassword", writeLimiter, accountController.resetPassword);
 
+/**
+ * @openapi
+ * /accounts/login:
+ *   post:
+ *     tags:
+ *       - Accounts
+ *     summary: Log in and create a JWT session.
+ *     description: Current clients send email in the request body.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AccountLogin'
+ *     responses:
+ *       200:
+ *         description: Login result. Successful responses also set the jwt cookie.
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       500:
+ *         $ref: '#/components/responses/ServerError'
+ */
 router.post(
   "/login/:email?",
   loginLimiter,

--- a/server/app/routes/calculation.routes.js
+++ b/server/app/routes/calculation.routes.js
@@ -11,7 +11,39 @@ router.get("/includeRules", calculationController.getAllIncludeRules);
 
 router.get("/:id", calculationController.getById);
 // Get all the rules for one calculation
+/**
+ * @openapi
+ * /calculations/{id}/rules:
+ *   get:
+ *     tags:
+ *       - Calculations
+ *     summary: Get rules for a calculation.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Calculation rules were returned.
+ *       500:
+ *         $ref: '#/components/responses/ServerError'
+ */
 router.get("/:id/rules", ruleController.getByCalculationId);
+/**
+ * @openapi
+ * /calculations:
+ *   get:
+ *     tags:
+ *       - Calculations
+ *     summary: List calculations.
+ *     responses:
+ *       200:
+ *         description: Calculations were returned.
+ *       500:
+ *         $ref: '#/components/responses/ServerError'
+ */
 router.get("/", calculationController.getAll);
 router.put(
   "/updateDescription/:id",

--- a/server/app/routes/dro.routes.js
+++ b/server/app/routes/dro.routes.js
@@ -7,6 +7,35 @@ module.exports = router;
 
 router.get("/", droController.getAll);
 router.get("/:id", droController.getById);
+/**
+ * @openapi
+ * /dro:
+ *   post:
+ *     tags:
+ *       - DRO
+ *     summary: Create a Development Review Office entry.
+ *     description: Requires an admin session.
+ *     security:
+ *       - bearerAuth: []
+ *       - cookieAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Dro'
+ *     responses:
+ *       200:
+ *         description: DRO entry was created.
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       500:
+ *         $ref: '#/components/responses/ServerError'
+ */
 router.post(
   "/",
   writeLimiter,

--- a/server/app/routes/feedback.routes.js
+++ b/server/app/routes/feedback.routes.js
@@ -5,6 +5,28 @@ const feedbackController = require("../controllers/feedback.controller");
 
 module.exports = router;
 
+/**
+ * @openapi
+ * /feedbacks:
+ *   post:
+ *     tags:
+ *       - Feedback
+ *     summary: Submit public feedback.
+ *     description: Accepts feedback with or without a valid user session.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/FeedbackPost'
+ *     responses:
+ *       200:
+ *         description: Feedback was submitted.
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       500:
+ *         $ref: '#/components/responses/ServerError'
+ */
 router.post(
   "/",
   writeLimiter,

--- a/server/app/routes/project.routes.js
+++ b/server/app/routes/project.routes.js
@@ -10,6 +10,24 @@ router.get(
   jwtSession.validateUser,
   projectController.getAllArchivedProjects
 );
+/**
+ * @openapi
+ * /projects:
+ *   get:
+ *     tags:
+ *       - Projects
+ *     summary: List projects for the authenticated user.
+ *     security:
+ *       - bearerAuth: []
+ *       - cookieAuth: []
+ *     responses:
+ *       200:
+ *         description: Projects were returned.
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       500:
+ *         $ref: '#/components/responses/ServerError'
+ */
 router.get("/", jwtSession.validateUser, projectController.getAll);
 router.get(
   "/submissions",
@@ -37,6 +55,34 @@ router.get(
   jwtSession.validateUser,
   projectController.getByIdWithEmail
 );
+/**
+ * @openapi
+ * /projects:
+ *   post:
+ *     tags:
+ *       - Projects
+ *     summary: Create a project for the authenticated user.
+ *     security:
+ *       - bearerAuth: []
+ *       - cookieAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Project'
+ *     responses:
+ *       201:
+ *         description: Project was created.
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       500:
+ *         $ref: '#/components/responses/ServerError'
+ */
 router.post("/", writeLimiter, jwtSession.validateUser, projectController.post);
 router.put(
   "/hide",
@@ -44,6 +90,38 @@ router.put(
   jwtSession.validateUser,
   projectController.hide
 );
+/**
+ * @openapi
+ * /projects/trash:
+ *   put:
+ *     tags:
+ *       - Projects
+ *     summary: Move projects to or from trash.
+ *     security:
+ *       - bearerAuth: []
+ *       - cookieAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             allOf:
+ *               - $ref: '#/components/schemas/ProjectStateChange'
+ *               - type: object
+ *                 required:
+ *                   - trash
+ *     responses:
+ *       204:
+ *         description: Project trash state was updated.
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       403:
+ *         $ref: '#/components/responses/Forbidden'
+ *       409:
+ *         $ref: '#/components/responses/Conflict'
+ *       500:
+ *         $ref: '#/components/responses/ServerError'
+ */
 router.put(
   "/trash",
   writeLimiter,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -25,7 +25,8 @@
         "node-flywaydb": "^3.0.7",
         "nodemailer": "^9.0.1",
         "path": "^0.12.7",
-        "sanitize-html": "^2.17.4"
+        "sanitize-html": "^2.17.4",
+        "swagger-jsdoc": "^6.3.0"
       },
       "devDependencies": {
         "@babel/core": "^7.29.6",
@@ -48,6 +49,118 @@
         "supertest": "^7.1.0",
         "testcontainers": "^12.0.0"
       }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
+        "@apidevtools/openapi-schemas": "^2.1.0",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "4.0.5",
@@ -5105,6 +5218,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5657,7 +5776,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -5979,6 +6097,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/dom-serializer": {
@@ -6589,7 +6719,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7062,7 +7191,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -7079,7 +7207,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -7783,8 +7910,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -10397,6 +10523,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
     },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -10654,7 +10786,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -10994,6 +11125,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -11066,7 +11204,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -11153,7 +11290,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -12035,7 +12171,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -12047,7 +12182,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -12565,6 +12699,153 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.3.0.tgz",
+      "integrity": "sha512-I+iQjVGV3t28pOkQUJv2MncthvOtkEactOn8R76SvSYhxgtIn7FoqfDHwQaN+GBnQdXQLrhgDXseKitmJcHMsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "^12.1.0",
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "11.1.0",
+        "lodash.mergewith": "^4.6.2",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/symbol-tree": {
@@ -13172,7 +13453,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -26,7 +26,8 @@
         "nodemailer": "^9.0.1",
         "path": "^0.12.7",
         "sanitize-html": "^2.17.4",
-        "swagger-jsdoc": "^6.3.0"
+        "swagger-jsdoc": "^6.3.0",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.29.6",
@@ -3750,6 +3751,13 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.41",
@@ -12846,6 +12854,30 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.7",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.7.tgz",
+      "integrity": "sha512-RH5WRnTpcgN/dWcmohrxdEKdNVOQ/ebas1+A6Zfqqz4Z1gj3VH48iyM59Zru+PwLB/rkOgWGOu0VQW6ODiwJNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-tree": {

--- a/server/package.json
+++ b/server/package.json
@@ -42,7 +42,8 @@
     "nodemailer": "^9.0.1",
     "path": "^0.12.7",
     "sanitize-html": "^2.17.4",
-    "swagger-jsdoc": "^6.3.0"
+    "swagger-jsdoc": "^6.3.0",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.29.6",

--- a/server/package.json
+++ b/server/package.json
@@ -41,7 +41,8 @@
     "node-flywaydb": "^3.0.7",
     "nodemailer": "^9.0.1",
     "path": "^0.12.7",
-    "sanitize-html": "^2.17.4"
+    "sanitize-html": "^2.17.4",
+    "swagger-jsdoc": "^6.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.6",

--- a/server/server.js
+++ b/server/server.js
@@ -5,8 +5,11 @@ const dotenv = require("dotenv");
 const cookieParser = require("cookie-parser");
 const errorHandler = require("error-handler");
 const routes = require("./app/routes");
+const jwtSession = require("./middleware/jwt-session");
 const helmet = require("helmet");
 const { truncate } = require("fs");
+const swaggerUi = require("swagger-ui-express");
+const { openapiSpec, swaggerUiOptions } = require("./app/docs/openapi");
 // const pino = require("express-pino-logger")();
 
 dotenv.config();
@@ -93,6 +96,20 @@ app.use(express.urlencoded({ extended: false }));
 
 // Web API routes
 app.use("/api", routes);
+
+if (process.env.ENABLE_API_DOCS === "true") {
+  app.get(
+    "/api-docs.json",
+    jwtSession.validateRoles(["isAdmin"]),
+    (_req, res) => res.json(openapiSpec)
+  );
+  app.use(
+    "/api-docs",
+    jwtSession.validateRoles(["isAdmin"]),
+    swaggerUi.serve,
+    swaggerUi.setup(openapiSpec, swaggerUiOptions)
+  );
+}
 
 // Serve static files from the React app
 app.use(express.static(path.join(__dirname, "client/build")));


### PR DESCRIPTION
- Fixes #2692 

### What changes did you make?

- Added swagger api documentation

### Why did you make the changes (we will use this info to test)?

- This gives any backend or full stack engineer a ui to be able to see all the current endpoints.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

N/A

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1902" height="1477" alt="Screenshot 2026-06-23 at 12 03 44 AM" src="https://github.com/user-attachments/assets/3acfddf1-d461-4054-90a9-c4b1cebc4424" />

</details>


### Dev Notes
- Any new endpoints will have to be added to the schema in order to keep this up to date.
- To be extra safe at least for now you have to be logged in as an admin to be able to access either of these urls
- This is a fairly long PR, but most of the lines added are JSdoc or openAPI schemas. 
- Some of the schemas I generated with ai instead of hunting down the exact endpoint definitions, but they looked good to me, we can do a pass with someone who knows the api endpoints better than I do and I'll be happy to fix any errors.