### PR TITLE
Default sort for manage Submissions -> dateSubmitted, desc

### DIFF
--- a/client/src/components/Submissions/ManageSubmissionsPage.jsx
+++ b/client/src/components/Submissions/ManageSubmissionsPage.jsx
@@ -21,7 +21,7 @@ import {
   MANAGE_SUBMISSIONS_FILTER_CRITERIA_STORAGE_TAG
 } from "../../helpers/Constants";
 
-const DEFAULT_SORT_CRITERIA = [{ field: "name", direction: "asc" }];
+const DEFAULT_SORT_CRITERIA = [{ field: "dateSubmitted", direction: "desc" }];
 const DEFAULT_FILTER_CRITERIA = {
   filterText: "",
   idFormattedList: [],


### PR DESCRIPTION
- Fixes #3094

### What changes did you make?

- Change default sort order for Manage Submissions page to dateSubmitted, desending.

### Why did you make the changes (we will use this info to test)?

- Requested by Issue

### Issue-Specific User Account

admin

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

Default Sort: Project Name

<img width="1522" height="808" alt="image" src="https://github.com/user-attachments/assets/5eb69c2e-9f71-40d8-9b19-855c44da3abe" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
Default Sort: Submitted

<img width="1522" height="808" alt="image" src="https://github.com/user-attachments/assets/446651a4-d79f-4c8f-bf73-f7623314a117" />

</details>
