### PR TITLE
Changed default sort order for Submissions Page to Status Updated, desc

### DIFF
--- a/client/src/components/Submissions/SubmissionsPage.jsx
+++ b/client/src/components/Submissions/SubmissionsPage.jsx
@@ -20,7 +20,7 @@ import {
 } from "../../helpers/Constants";
 import { Td, TdExpandable } from "../UI/TableData";
 
-const DEFAULT_SORT_CRITERIA = [{ field: "name", direction: "asc" }];
+const DEFAULT_SORT_CRITERIA = [{ field: "dateStatus", direction: "desc" }];
 const DEFAULT_FILTER_CRITERIA = {
   filterText: "",
   idFormattedList: [],


### PR DESCRIPTION
- Fixes #3296 

### What changes did you make?

- Changed default sort order on Submissions Page to Status Updated, desc.

### Why did you make the changes (we will use this info to test)?

- Requested y Issue

### Issue-Specific User Account

reuglar user

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

Default Sort: Project Name
<img width="1522" height="808" alt="image" src="https://github.com/user-attachments/assets/b73f5e38-bcc6-449b-bceb-78b1aa6193b5" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
Default Sort: Status Updated
<img width="1522" height="808" alt="image" src="https://github.com/user-attachments/assets/d2b760e6-73cd-4e2a-9458-568b9f4919f4" />

</details>
