### PR TITLE
Re-size close boxes throughout app

### DIFF
--- a/client/src/components/Checklist/ChecklistModal.jsx
+++ b/client/src/components/Checklist/ChecklistModal.jsx
@@ -69,7 +69,7 @@ const ChecklistModal = ({ checklistModalOpen, toggleChecklistModal }) => {
       className={classes.modal}
     >
       <div className={classes.close} onClick={toggleChecklistModal}>
-        <MdClose />
+        <MdClose style={{ fontSize: "24px" }} />
       </div>
       <ChecklistContent />
     </Modal>

--- a/client/src/components/Layout/NavBarLogin.jsx
+++ b/client/src/components/Layout/NavBarLogin.jsx
@@ -137,7 +137,10 @@ const NavBarLogin = ({ classes, handleHamburgerMenuClick, setNavbarOpen }) => {
         >
           {close => {
             return (
-              <div style={{ margin: "1rem" }}>
+              <div
+                style={{ margin: "1rem", fontSize: "24px" }}
+                id={popupContentId}
+              >
                 <MdClose
                   style={{
                     backgroundColor: "transparent",

--- a/client/src/components/ProjectWizard/WizardSidebar/EarnedPointsProgress.jsx
+++ b/client/src/components/ProjectWizard/WizardSidebar/EarnedPointsProgress.jsx
@@ -187,11 +187,12 @@ const EarnedPointsProgress = ({ rulesConfig }) => {
                     position: "absolute",
                     top: "0",
                     right: "0",
-                    cursor: "pointer"
+                    cursor: "pointer",
+                    fontSize: "24px"
                   }}
                   onClick={close}
                 >
-                  <MdClose style={{ height: "20px", width: "20px" }} />
+                  <MdClose />
                 </button>
                 {/* DangerouslySetInnerHtml was clean here with DomPurify.  
                   Please reference Decision Records for more details: 

--- a/client/src/components/ProjectWizard/WizardSidebar/SidebarProjectLevel.jsx
+++ b/client/src/components/ProjectWizard/WizardSidebar/SidebarProjectLevel.jsx
@@ -89,11 +89,12 @@ const SidebarProjectLevel = ({ level, rules }) => {
                       position: "absolute",
                       top: "0",
                       right: "0",
-                      cursor: "pointer"
+                      cursor: "pointer",
+                      fontSize: "24px"
                     }}
                     onClick={close}
                   >
-                    <MdClose style={{ height: "20px", width: "20px" }} />
+                    <MdClose />
                   </button>
                   {/* DangerouslySetInnerHtml was clean here with DomPurify.  
                   Please reference Decision Records for more details: 

--- a/client/src/components/Projects/ColumnHeaderPopups/BooleanPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/BooleanPopup.jsx
@@ -54,7 +54,8 @@ const BooleanPopup = ({
             color: "black",
             position: "absolute",
             top: "0.5rem",
-            right: "0.5rem"
+            right: "0.5rem",
+            fontSize: "24px"
           }}
           alt={`Close popup`}
           onClick={close}

--- a/client/src/components/Projects/ColumnHeaderPopups/DatePopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/DatePopup.jsx
@@ -70,7 +70,8 @@ const DatePopup = ({
             color: "black",
             position: "absolute",
             top: "0.5rem",
-            right: "0.5rem"
+            right: "0.5rem",
+            fontSize: "24px"
           }}
           alt={`Close popup`}
           onClick={close}

--- a/client/src/components/Projects/ColumnHeaderPopups/NumberPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/NumberPopup.jsx
@@ -161,7 +161,8 @@ const NumberPopup = ({
             color: "black",
             position: "absolute",
             top: "0.5rem",
-            right: "0.5rem"
+            right: "0.5rem",
+            fontSize: "24px"
           }}
           alt={`Close popup`}
           onClick={close}

--- a/client/src/components/Projects/ColumnHeaderPopups/StatusPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/StatusPopup.jsx
@@ -60,7 +60,13 @@ const StatusPopup = ({
 
   return (
     <div className={classes.container}>
-      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          fontSize: "24px"
+        }}
+      >
         <MdClose
           style={{
             backgroundColor: "transparent",

--- a/client/src/components/Projects/ColumnHeaderPopups/StringListPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/StringListPopup.jsx
@@ -157,7 +157,8 @@ const TextPopup = ({
             color: "black",
             position: "absolute",
             top: "0.5rem",
-            right: "0.5rem"
+            right: "0.5rem",
+            fontSize: "24px"
           }}
           alt={`Close popup`}
           onClick={close}

--- a/client/src/components/Projects/ColumnHeaderPopups/StringPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/StringPopup.jsx
@@ -177,7 +177,8 @@ const StringPopup = ({
             color: "black",
             position: "absolute",
             top: "0.5rem",
-            right: "0.5rem"
+            right: "0.5rem",
+            fontSize: "24px"
           }}
           alt={`Close popup`}
           onClick={close}

--- a/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
@@ -213,7 +213,13 @@ const TextPopup = ({
 
   return (
     <div className={classes.container}>
-      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          fontSize: "24px"
+        }}
+      >
         <MdClose
           style={{
             backgroundColor: "transparent",

--- a/client/src/components/Projects/ColumnHeaderPopups/VersionPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/VersionPopup.jsx
@@ -195,7 +195,13 @@ const VersionPopup = ({
 
   return (
     <div className={classes.container}>
-      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          fontSize: "24px"
+        }}
+      >
         <MdClose
           style={{
             backgroundColor: "transparent",

--- a/client/src/components/Projects/ColumnHeaderPopups/VisibilityPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/VisibilityPopup.jsx
@@ -61,7 +61,13 @@ const VisibilityPopup = ({
 
   return (
     <div className={classes.container}>
-      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          fontSize: "24px"
+        }}
+      >
         <MdClose
           style={{
             backgroundColor: "transparent",

--- a/client/src/components/ToolTip/AccordionToolTip.jsx
+++ b/client/src/components/ToolTip/AccordionToolTip.jsx
@@ -35,7 +35,11 @@ const useStyles = createUseStyles(theme => ({
     fontSize: "20px",
     "&:hover": {
       cursor: "pointer"
-    }
+    },
+    height: "24px",
+    width: "24px",
+    fontSize: "24px",
+    padding: "0"
   },
   triangle: {
     position: "relative",
@@ -192,7 +196,14 @@ const AccordionToolTip = ({
             className={clsx(classes.closeButton)}
             onClick={() => setShowDescription(prev => !prev)}
           >
-            <MdClose />
+            <MdClose
+              style={{
+                height: "24px",
+                width: "24px",
+                margin: "0",
+                backgroundColor: "orange"
+              }}
+            />
           </div>
           <div className={classes.richText}>
             <Interweave

--- a/client/src/components/UI/Modal.jsx
+++ b/client/src/components/UI/Modal.jsx
@@ -16,7 +16,10 @@ const useStyles = createUseStyles({
     backgroundColor: "transparent",
     "&:hover": {
       cursor: "pointer"
-    }
+    },
+    height: "24px",
+    width: "24px",
+    fontSize: "24px"
   }
 });
 

--- a/client/src/contexts/Toast/Toast.jsx
+++ b/client/src/contexts/Toast/Toast.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { createUseStyles } from "react-jss";
+import { MdClose } from "react-icons/md";
 
 const useStyles = createUseStyles({
   toast: {
@@ -29,10 +30,10 @@ const useStyles = createUseStyles({
     border: "none",
     backgroundColor: "transparent",
     color: "#0F2940",
-    fontSize: "16px",
-    marginTop: "8px",
-    marginRight: "8px",
-    cursor: "pointer"
+    marginTop: "0px",
+    marginRight: "0px",
+    cursor: "pointer",
+    fontSize: "24px"
   }
 });
 
@@ -69,7 +70,7 @@ const Toast = ({ children, remove, variant }) => {
       <div className={classes.container}>{children}</div>
       <div>
         <button onClick={remove} className={classes.button}>
-          X
+          <MdClose />
         </button>
       </div>
     </div>


### PR DESCRIPTION
- Fixes #3315

### What changes did you make?

- Re-size the close boxes on dialogs, tooltips and other UI popups throughout the application.

### Why did you make the changes (we will use this info to test)?

- Requeste by issue.
- 
### Issue-Specific User Account

(any)

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
