### PR TITLE
Replace dash with pipe in overlays

### DIFF
--- a/client/src/components/Checklist/ChecklistModal.jsx
+++ b/client/src/components/Checklist/ChecklistModal.jsx
@@ -18,10 +18,7 @@ const useStyles = createUseStyles({
     justifyContent: "flex-end",
     marginBottom: "0",
     border: "0 solid white",
-    backgroundColor: "transparent",
-    "&:hover": {
-      cursor: "pointer"
-    }
+    backgroundColor: "transparent"
   }
 });
 
@@ -68,8 +65,11 @@ const ChecklistModal = ({ checklistModalOpen, toggleChecklistModal }) => {
       style={modalStyleDefaultOverrides}
       className={classes.modal}
     >
-      <div className={classes.close} onClick={toggleChecklistModal}>
-        <MdClose style={{ fontSize: "24px" }} />
+      <div className={classes.close}>
+        <MdClose
+          onClick={toggleChecklistModal}
+          style={{ cursor: "pointer", fontSize: "24px" }}
+        />
       </div>
       <ChecklistContent />
     </Modal>

--- a/client/src/components/Projects/ColumnHeaderPopups/BooleanPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/BooleanPopup.jsx
@@ -53,6 +53,7 @@ const BooleanPopup = ({
           style={{
             backgroundColor: "transparent",
             color: theme.colorLADOTBlack,
+            cursor: "pointer",
             position: "absolute",
             top: "0.5rem",
             right: "0.5rem",

--- a/client/src/components/Projects/ColumnHeaderPopups/BooleanPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/BooleanPopup.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
+import { useTheme } from "react-jss";
 import Button from "../../Button/Button";
 import RadioButton from "../../UI/RadioButton";
 import { MdClose } from "react-icons/md";
@@ -15,6 +16,7 @@ const BooleanPopup = ({
   setCheckedProjectIds,
   setSelectAllChecked
 }) => {
+  const theme = useTheme();
   const [newOrder, setNewOrder] = useState(
     header.id !== orderBy ? null : order
   );
@@ -50,7 +52,7 @@ const BooleanPopup = ({
         <MdClose
           style={{
             backgroundColor: "transparent",
-            color: "black",
+            color: theme.colorLADOTBlack,
             position: "absolute",
             top: "0.5rem",
             right: "0.5rem",

--- a/client/src/components/Projects/ColumnHeaderPopups/DatePopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/DatePopup.jsx
@@ -68,6 +68,7 @@ const DatePopup = ({
           style={{
             backgroundColor: "transparent",
             color: theme.colorLADOTBlack,
+            cursor: "pointer",
             position: "absolute",
             top: "0.5rem",
             right: "0.5rem",

--- a/client/src/components/Projects/ColumnHeaderPopups/NumberPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/NumberPopup.jsx
@@ -4,11 +4,11 @@ import Button from "../../Button/Button";
 import RadioButton from "../../UI/RadioButton";
 import { MdClose } from "react-icons/md";
 import { MdOutlineSearch } from "react-icons/md";
-import { createUseStyles } from "react-jss";
+import { createUseStyles, useTheme } from "react-jss";
 import ToggleCheckbox from "components/UI/ToggleCheckbox";
 import { selectAllCheckboxes } from "helpers/util";
 
-const useStyles = createUseStyles({
+const useStyles = createUseStyles(theme => ({
   searchBarWrapper: {
     width: "100%",
     position: "relative",
@@ -34,7 +34,7 @@ const useStyles = createUseStyles({
     height: "2rem",
     gap: "0.2em",
     "&:hover": {
-      backgroundColor: "lightblue"
+      backgroundColor: theme.colorRowHighlight
     },
     "& span": {
       maxWidth: "25ch",
@@ -54,7 +54,7 @@ const useStyles = createUseStyles({
     display: "flex",
     fontWeight: "normal"
   }
-});
+}));
 
 const NumberPopup = ({
   projects,
@@ -70,7 +70,8 @@ const NumberPopup = ({
   setSelectAllChecked
 }) => {
   const property = header.accessor || header.id;
-  const classes = useStyles();
+  const theme = useTheme();
+  const classes = useStyles(theme);
 
   const [newOrder, setNewOrder] = useState(
     header.id !== orderBy ? null : order
@@ -158,7 +159,8 @@ const NumberPopup = ({
         <MdClose
           style={{
             backgroundColor: "transparent",
-            color: "black",
+            color: theme.colorLADOTBlack,
+            cursor: "pointer",
             position: "absolute",
             top: "0.5rem",
             right: "0.5rem",

--- a/client/src/components/Projects/ColumnHeaderPopups/NumberPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/NumberPopup.jsx
@@ -200,7 +200,7 @@ const NumberPopup = ({
           >
             Select all {filteredOptions.length}
           </button>
-          <div style={{ display: "flex", alignItems: "center" }}>-</div>
+          <div style={{ display: "flex", alignItems: "center" }}>|</div>
           <button
             className={classes.toggleButton}
             onClick={() => setSelectedListItems([])}

--- a/client/src/components/Projects/ColumnHeaderPopups/StatusPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/StatusPopup.jsx
@@ -70,6 +70,7 @@ const StatusPopup = ({
           style={{
             backgroundColor: "transparent",
             color: theme.colorLADOTBlack,
+            cursor: "pointer",
             position: "absolute",
             top: "0.5rem",
             right: "0.5rem"

--- a/client/src/components/Projects/ColumnHeaderPopups/StringListPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/StringListPopup.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import Button from "../../Button/Button";
 import RadioButton from "../../UI/RadioButton";
 import { MdClose } from "react-icons/md";
-import { createUseStyles } from "react-jss";
+import { createUseStyles, useTheme } from "react-jss";
 import ToggleCheckbox from "components/UI/ToggleCheckbox";
 import { selectAllCheckboxes } from "helpers/util";
 
@@ -11,7 +11,7 @@ import { selectAllCheckboxes } from "helpers/util";
 Variant of the StringPopup that is for text columns with a small number of choices that do not need the search box feature
 */
 
-const useStyles = createUseStyles({
+const useStyles = createUseStyles(theme => ({
   searchBarWrapper: {
     width: "100%",
     position: "relative",
@@ -37,7 +37,7 @@ const useStyles = createUseStyles({
     height: "2rem",
     gap: "0.2em",
     "&:hover": {
-      backgroundColor: "lightblue"
+      backgroundColor: theme.colorRowHighlight
     },
     "& span": {
       maxWidth: "25ch",
@@ -57,7 +57,7 @@ const useStyles = createUseStyles({
     display: "flex",
     fontWeight: "normal"
   }
-});
+}));
 
 const TextPopup = ({
   projects,
@@ -73,7 +73,8 @@ const TextPopup = ({
   setSelectAllChecked
 }) => {
   const property = header.accessor || header.id;
-  const classes = useStyles();
+  const theme = useTheme();
+  const classes = useStyles(theme);
 
   const [newOrder, setNewOrder] = useState(
     header.id !== orderBy ? null : order

--- a/client/src/components/Projects/ColumnHeaderPopups/StringListPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/StringListPopup.jsx
@@ -155,7 +155,8 @@ const TextPopup = ({
         <MdClose
           style={{
             backgroundColor: "transparent",
-            color: "black",
+            color: theme.colorLADOTBlack,
+            cursor: "pointer",
             position: "absolute",
             top: "0.5rem",
             right: "0.5rem",
@@ -197,7 +198,7 @@ const TextPopup = ({
           >
             Select all {filteredOptions.length}
           </button>
-          <div style={{ display: "flex", alignItems: "center" }}>-</div>
+          <div style={{ display: "flex", alignItems: "center" }}>|</div>
           <button
             className={classes.toggleButton}
             onClick={() => setSelectedListItems([])}

--- a/client/src/components/Projects/ColumnHeaderPopups/StringPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/StringPopup.jsx
@@ -44,7 +44,7 @@ const useStyles = createUseStyles(theme => ({
     height: "2rem",
     gap: "0.2em",
     "&:hover": {
-      backgroundColor: "lightblue"
+      backgroundColor: themeRowHighlight
     },
     "& span": {
       maxWidth: "25ch",
@@ -176,6 +176,7 @@ const StringPopup = ({
           style={{
             backgroundColor: "transparent",
             color: theme.colorLADOTBlack,
+            cursor: "pointer",
             position: "absolute",
             top: "0.5rem",
             right: "0.5rem",

--- a/client/src/components/Projects/ColumnHeaderPopups/StringPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/StringPopup.jsx
@@ -4,7 +4,7 @@ import Button from "../../Button/Button";
 import RadioButton from "../../UI/RadioButton";
 import { MdClose } from "react-icons/md";
 import { MdOutlineSearch } from "react-icons/md";
-import { createUseStyles } from "react-jss";
+import { createUseStyles, useTheme } from "react-jss";
 import ToggleCheckbox from "components/UI/ToggleCheckbox";
 import { selectAllCheckboxes } from "helpers/util";
 
@@ -81,7 +81,8 @@ const StringPopup = ({
   setSelectAllChecked
 }) => {
   const property = header.accessor || header.id;
-  const classes = useStyles();
+  const theme = useTheme();
+  const classes = useStyles(theme);
 
   const [newOrder, setNewOrder] = useState(
     header.id !== orderBy ? null : order
@@ -216,7 +217,7 @@ const StringPopup = ({
           >
             Select all {filteredOptions.length}
           </button>
-          <div style={{ display: "flex", alignItems: "center" }}>-</div>
+          <div style={{ display: "flex", alignItems: "center" }}>|</div>
           <button
             className={classes.toggleButton}
             onClick={() => setSelectedListItems([])}

--- a/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
@@ -224,6 +224,7 @@ const TextPopup = ({
           style={{
             backgroundColor: "transparent",
             color: theme.colorLADOTBlack,
+            cursor: "pointer",
             position: "absolute",
             top: "0.5rem",
             right: "0.5rem"

--- a/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/TextPopup.jsx
@@ -4,7 +4,7 @@ import Button from "../../Button/Button";
 import RadioButton from "../../UI/RadioButton";
 import { MdClose } from "react-icons/md";
 import { MdOutlineSearch } from "react-icons/md";
-import { createUseStyles } from "react-jss";
+import { createUseStyles, useTheme } from "react-jss";
 import ToggleCheckbox from "components/UI/ToggleCheckbox";
 import UserContext from "contexts/UserContext";
 import { selectAllCheckboxes } from "helpers/util";
@@ -41,7 +41,7 @@ const useStyles = createUseStyles(theme => ({
     height: "2rem",
     gap: "0.2em",
     "&:hover": {
-      backgroundColor: "lightblue"
+      backgroundColor: theme.color
     },
     "& span": {
       maxWidth: "25ch",
@@ -78,6 +78,8 @@ const TextPopup = ({
   setSelectAllChecked,
   droOptions
 }) => {
+  const theme = useTheme();
+  const classes = useStyles(theme);
   const userContext = useContext(UserContext);
   const property = header.accessor || header.id;
   const loggedInUserName = `${userContext?.account?.lastName}, ${userContext?.account?.firstName}`;
@@ -95,7 +97,6 @@ const TextPopup = ({
     }
     return displayValue;
   };
-  const classes = useStyles();
 
   const [newOrder, setNewOrder] = useState(
     header.id !== orderBy ? null : order
@@ -263,7 +264,7 @@ const TextPopup = ({
           >
             Select all {filteredOptions.length}
           </button>
-          <div style={{ display: "flex", alignItems: "center" }}>-</div>
+          <div style={{ display: "flex", alignItems: "center" }}>|</div>
           <button
             className={classes.toggleButton}
             onClick={() => setSelectedListItems([])}

--- a/client/src/components/Projects/ColumnHeaderPopups/VersionPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/VersionPopup.jsx
@@ -246,7 +246,7 @@ const VersionPopup = ({
           >
             Select all {filteredOptions.length}
           </button>
-          <div style={{ display: "flex", alignItems: "center" }}>-</div>
+          <div style={{ display: "flex", alignItems: "center" }}>|</div>
           <button
             className={classes.toggleButton}
             onClick={() => setSelectedListItems([])}

--- a/client/src/components/Projects/ColumnHeaderPopups/VersionPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/VersionPopup.jsx
@@ -206,6 +206,7 @@ const VersionPopup = ({
           style={{
             backgroundColor: "transparent",
             color: theme.colorLADOTBlack,
+            cursor: "pointer",
             position: "absolute",
             top: "0.5rem",
             right: "0.5rem"

--- a/client/src/components/Projects/ColumnHeaderPopups/VisibilityPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/VisibilityPopup.jsx
@@ -71,6 +71,7 @@ const VisibilityPopup = ({
           style={{
             backgroundColor: "transparent",
             color: theme.colorLADOTBlack,
+            cursor: "pointer",
             position: "absolute",
             top: "0.5rem",
             right: "0.5rem"


### PR DESCRIPTION
- Fixes #3372 
- Fixes #3316 (bug introduced by PR #3424)
### What changes did you make?

- Replaced dash with pipe in overlays that have "Clear" option.
- Added missing refrences to popups that need theme reference to get colors (This was  bug introduced in PR #3424)

### Why did you make the changes (we will use this info to test)?

- Requested by issue

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)
The dash was replaced with a pipe in all overlays across the app that have the text "Clear" so that screen readers interpret the linked options correctly. Below is a representative sample.

<details>
<summary>Visuals before changes are applied</summary>

<img width="287" height="536" alt="image" src="https://github.com/user-attachments/assets/ebb8e1fb-75f9-474d-aa38-dabe09545e15" />
</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="282" height="536" alt="image" src="https://github.com/user-attachments/assets/ef7e9b58-d161-494a-95ec-219b8e33700e" />

</details>
