### PR TITLE
Fix bad color ref in 3373

### DIFF
--- a/client/src/components/Projects/ColumnHeaderPopups/StringPopup.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/StringPopup.jsx
@@ -44,7 +44,7 @@ const useStyles = createUseStyles(theme => ({
     height: "2rem",
     gap: "0.2em",
     "&:hover": {
-      backgroundColor: themeRowHighlight
+      backgroundColor: theme.colorRowHighlight
     },
     "& span": {
       maxWidth: "25ch",


### PR DESCRIPTION
- Fixes #3434

### What changes did you make?

- bug with reference to row highlight color

### Why did you make the changes (we will use this info to test)?

- So the StringPopup overlayu won't crash when opened.

### Issue-Specific User Account

If you registered a new, temporary TDM User Account for this issue, indicate the
username (i.e., email address) for the account.

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="983" height="176" alt="image" src="https://github.com/user-attachments/assets/57e4b172-2997-4ba8-8e2d-ff85cbf9af54" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1126" height="893" alt="image" src="https://github.com/user-attachments/assets/06fa9d3c-7d0a-4703-a755-b731adfbb7c8" />

</details>
