### PR TITLE
3432 datepicker overlay modification

### DIFF
--- a/client/src/components/Projects/ColumnHeaderPopups/ProjectTableColumnHeader.jsx
+++ b/client/src/components/Projects/ColumnHeaderPopups/ProjectTableColumnHeader.jsx
@@ -54,7 +54,8 @@ const useStyles = createUseStyles(theme => ({
     borderRadius: "5px",
     padding: "20px",
     boxShadow:
-      "0px 4px 8px 3px rgba(0,0,0,0.15), 0px 1px 3px 0px rgba(0,0,0,0.3)"
+      "0px 4px 8px 3px rgba(0,0,0,0.15), 0px 1px 3px 0px rgba(0,0,0,0.3)",
+    overflow: "auto"
   }
 }));
 

--- a/client/src/components/UI/DateRangePicker.jsx
+++ b/client/src/components/UI/DateRangePicker.jsx
@@ -31,18 +31,12 @@ const DateRangePicker = ({
 }) => {
   const [calendarDivHeight, setCalendarDivHeight] = useState(false);
   const classes = useStyles();
-
-  const handleCalendarOpen = () => {
-    setCalendarDivHeight(true);
-  };
-
-  const handleCalendarClose = () => {
-    setCalendarDivHeight(false);
-  };
+  let calendarRef = React.createRef();
 
   return (
     <>
       <div
+        id="calendarPortal"
         style={{
           display: "flex",
           flexDirection: "row",
@@ -63,24 +57,12 @@ const DateRangePicker = ({
           endDate={endDate}
           dateFormat="yyyy-MM-dd"
           placeholderText={startDatePlaceholder || ""}
-          popperPlacement="bottom-start"
-          popperModifiers={[
-            {
-              name: "flip",
-              enabled: false
-            },
-            {
-              name: "hide",
-              enabled: false
-            }
-          ]}
-          onCalendarOpen={handleCalendarOpen}
-          onCalendarClose={handleCalendarClose}
+          popperPlacement="left-start"
+          showPopperArrow={false}
           onClick={e => {
             // We don't want a click event to bubble up to the parent container
             e.stopPropagation();
           }}
-          // withPortal
         />
         <div
           style={{ margin: "auto 0", minWidth: "2.5rem", textAlign: "center" }}
@@ -96,25 +78,10 @@ const DateRangePicker = ({
           endDate={endDate}
           dateFormat="yyyy-MM-dd"
           placeholderText={endDatePlaceholder || ""}
-          popperPlacement="bottom-end"
-          popperModifiers={[
-            {
-              name: "flip",
-              enabled: false
-            },
-            {
-              name: "hide",
-              enabled: false
-            }
-          ]}
-          onCalendarOpen={handleCalendarOpen}
-          onCalendarClose={handleCalendarClose}
-          // withPortal
+          popperPlacement="right-start"
+          showPopperArrow={false}
         />
       </div>
-      {calendarDivHeight ? (
-        <div style={{ height: "15rem" }}>{calendarDivHeight}</div>
-      ) : null}
     </>
   );
 };

--- a/server/middleware/jwt-session.js
+++ b/server/middleware/jwt-session.js
@@ -1,6 +1,6 @@
 const jwt = require("jsonwebtoken");
 
-const jwtSecret = process.env.JWT_SECRET || "mark it zero";
+const jwtSecret = process.env.JWT_SECRET;
 // JWT timeout set to 12 hours
 const jwtOpts = { algorithm: "HS256", expiresIn: "12h" };
 


### PR DESCRIPTION
- Fixes #3432

### What changes did you make?

- Modified the DateRange overlay used by the column headers for date-type columns on the MyProjects, ManageSubmissions and Sumissions pages to allow the calendar pop-up for the date pickers to float above the rest of the UI layout (i.e., overflow the boundary of the overlay pop-up).

### Why did you make the changes (we will use this info to test)?

- This prevents a number of bugs related to how the position and size of the overlay and the calendar pop-up were interacting that caused strange layout problems and controls (in particular, the radio buttons and Reset and Apply button) that would not respond normally when clicked.

### Issue-Specific User Account

(any)

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

Note how the calendar pop-up overlaps the buttons, because August requires six rows, while man other months only require 5 rows.  Also, when the date picker is clicked on, and the overlay is near the bottom of the browser window, the overlay usually closes, losing any information the user has entered. If the user clicks on any of the Radio buttons on the reset or apply button, that click has no effect, since the calendar popup closes before the click action is processed, so the click has no effect, and closes the overlay, losing any changes the user made.

<img width="407" height="507" alt="image" src="https://github.com/user-attachments/assets/044da92b-854e-4bdf-b379-20b3632c08c3" />

</details>

<details>
<summary>Visuals after changes are applied</summary>

Now the calendar pop-up floats above the rest of the UI, like a normal datepicker. If the height of the calendar pop-up changes  from month to month, the size of the calendar pop-up can change without effecting the size or position of the overlay. The calendar pop-up is free to move around relative  the the anchor date input (in this case the Start Date), if necessary, to avoid overlapping the browser area - in this case shown here, it shifted up, 

Most importantly the pop-up opens reliably, and all the controls on the overlay are responsive, having the intended effect, and only closing the overlay when appropriate.
  
<img width="575" height="646" alt="image" src="https://github.com/user-attachments/assets/14d39d99-fc17-47f5-bfa2-7e45145ada63" />

</details>
