### PR TITLE
feat: make mutation methods in swagger read only

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -37,6 +37,16 @@ export default defineConfig({
         target: "http://localhost:5001",
         changeOrigin: true,
         secure: false
+      },
+      "/api-docs": {
+        target: "http://localhost:5001",
+        changeOrigin: true,
+        secure: false
+      },
+      "/api-docs.json": {
+        target: "http://localhost:5001",
+        changeOrigin: true,
+        secure: false
       }
     }
   }

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -26,8 +26,29 @@ The raw OpenAPI JSON is available at:
 http://localhost:PORT/api-docs.json
 ```
 
+When running the app through the Vite frontend on port `3000`, the frontend dev
+server proxies these docs routes to the backend:
+
+```text
+http://localhost:3000/api-docs
+http://localhost:3000/api-docs.json
+```
+
+When opening the backend directly, use the backend port. The default local
+backend port is `5001`:
+
+```text
+http://localhost:5001/api-docs
+http://localhost:5001/api-docs.json
+```
+
 Both routes require an authenticated `isAdmin` user. The API accepts JWT auth
 from either the `jwt` cookie or an `Authorization: Bearer <token>` header.
+API docs are never mounted when `NODE_ENV=production`; `/api-docs` and
+`/api-docs.json` return `404` in production.
+
+Swagger UI only enables "Try it out" for `GET` operations. Non-GET operations
+are documented for reference, but cannot be executed from the docs UI.
 
 ## Adding Endpoint Docs
 

--- a/server/app/docs/openapi.js
+++ b/server/app/docs/openapi.js
@@ -391,7 +391,8 @@ openapiSpec.paths = mergePaths(openapiSpec.paths, additionalPaths);
 const swaggerUiOptions = {
   explorer: true,
   swaggerOptions: {
-    persistAuthorization: true
+    persistAuthorization: true,
+    supportedSubmitMethods: ["get"]
   }
 };
 

--- a/server/server.js
+++ b/server/server.js
@@ -94,10 +94,17 @@ app.use(express.static("public"));
 // {extended: true} option.
 app.use(express.urlencoded({ extended: false }));
 
+const apiDocsEnabled =
+  process.env.ENABLE_API_DOCS === "true" &&
+  process.env.NODE_ENV !== "production";
+
 // Web API routes
 app.use("/api", routes);
 
-if (process.env.ENABLE_API_DOCS === "true") {
+if (process.env.NODE_ENV === "production") {
+  app.use("/api-docs", (_req, res) => res.sendStatus(404));
+  app.all("/api-docs.json", (_req, res) => res.sendStatus(404));
+} else if (apiDocsEnabled) {
   app.get(
     "/api-docs.json",
     jwtSession.validateRoles(["isAdmin"]),


### PR DESCRIPTION
- Fixes #2692

### What changes did you make?

- Made mutation methods in the swagger docs read only
- Swagger docs now refuse to mount in prod

### Why did you make the changes (we will use this info to test)?

- Now it is not possible for a user to get to these docs in prod or to run a mutation in the database form the docs directly

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1142" height="1042" alt="Screenshot 2026-08-18 at 12 28 30 AM" src="https://github.com/user-attachments/assets/3126e67f-add2-42d9-a757-0baf220fc5b5" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1474" height="1063" alt="Screenshot 2026-08-18 at 12 27 33 AM" src="https://github.com/user-attachments/assets/8208c6fa-e19c-42bc-813b-bdad2e87462b" />


</details>


### Important Dev Notes:
@entrotech 
Env vars need to be added in order for this to run. Neither are secret or a security risk, it's more for config. I added a node environment variable so that we know if we're in dev or prod. And then an extra `enable api docs` variable to give it an explicit string of `true` and that way we can make sure we're being deliberate when enabling the docs
- NODE_ENV
- ENABLE_API_DOCS
