### PR TITLE
add .devcontainer to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # Edit at https://www.gitignore.io/?templates=vim,linux,macos,windows,visualstudiocode,python
 
 
+# vscode
+.devcontainer
+
 # Custom ignores
 cypress/screenshots
 cypress/videos


### PR DESCRIPTION
Ignore vscode `.devcontainer`.  This directory is used to mount the code on a docker container from vscode configurations.