### PR TITLE
Fix project snapshot duplication with corrective code refactoring

### DIFF
--- a/client/src/components/Projects/ProjectsPage.jsx
+++ b/client/src/components/Projects/ProjectsPage.jsx
@@ -418,23 +418,22 @@ const ProjectsPage = ({ contentContainerRef }) => {
   });
 
   const handleCopyModalClose = async (action, newProjectName) => {
-    let newSelectedProject = { ...selectedProject };
     if (action === "ok") {
-      const projectFormInputsAsJson = JSON.parse(selectedProject.formInputs);
-      projectFormInputsAsJson.PROJECT_NAME = newProjectName;
-      if (!selectedProject.targetPoints) {
-        await projectResultService.populateTargetPoints(selectedProject);
-        newSelectedProject = await projectService.getById(selectedProject.id);
+      if (isAdmin && !selectedProject.targetPoints) {
+        await projectResultService.populateTargetPoints(selectedProject.id);
       }
-      let newProject = {
-        ...newSelectedProject,
+      const projectFormInputsAsJson = {
+        ...JSON.parse(selectedProject.formInputs),
+        PROJECT_NAME: newProjectName
+      };
+      const { data } = await projectService.getById(selectedProject.id);
+      const newProject = {
+        ...data,
         loginId: loginId,
         name: newProjectName,
+        description: data.description ?? "",
         formInputs: JSON.stringify(projectFormInputsAsJson)
       };
-      if (!newProject.description) {
-        newProject.description = "";
-      }
       try {
         await projectService.post(newProject);
         await updateProjects();


### PR DESCRIPTION
- Fixes #3353

### What changes did you make?

The 'CREATE A COPY' Button on the Duplicate Project Modal triggers a handling function that implements the snapshot duplication for the "Projects Page"

[Issue 3353](https://github.com/hackforla/tdm-calculator/issues/3353) indicates that an unresponsive failure or in-action occurs when clicking the "CREATE A COPY" button.

After review, a set of fixes were identified, fixed, and the code was rearranged and refactored to reduce intermediate variables and made more tidy. Duplicating a snapshot on the projects page is fixed by these chages.

### Why did you make the changes (we will use this info to test)?

The handling function had the following errors:

1. Passing a project object as an argument to `projectService.getById` that expected a number value

2. Target point calculation, `admin` only, was missing an authorization guard

3. The project object was being mistakenly derived (shallow copied) from an `axios` response instead of the desired nested `data` property.