### PR TITLE
3391: Update reactivation messaging shown to a user authenticated with an archived account.

### DIFF
--- a/client/src/components/Authorization/Login.jsx
+++ b/client/src/components/Authorization/Login.jsx
@@ -68,7 +68,9 @@ const Login = () => {
           navigate("/calculation/1/0");
         }
       } else if (loginResponse.code === "USER_ARCHIVED") {
-        setErrorMsg(`Login Failed - This account has been archived.`);
+        setErrorMsg(
+          `Login Failed - This account has been archived. Please contact ladot.tdm@lacity.org for support.`
+        );
         setSubmitting(false);
       } else if (loginResponse.code === "AUTH_NOT_CONFIRMED") {
         try {


### PR DESCRIPTION
- Fixes #3391

### What changes did you make?

- Updates the error message shown to a user that has authenticated with an archived account.
  The message string was updated to reflect the agreed upon message specified in [Github issue 3391](https://github.com/hackforla/tdm-calculator/issues/3391)

### Why did you make the changes (we will use this info to test)?

Changed error message string:
- from: "Login Failed - This account has been archived."
- to: "Login Failed - This account has been archived. Please contact ladot.tdm@lacity.org for support."
