### PR TITLE
Kk/3393 fix update account email

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -26,6 +26,7 @@ import PrivacyPolicy from "./components/PrivacyPolicy";
 import Register from "./components/Authorization/Register";
 import UpdateAccount from "./components/Authorization/UpdateAccount";
 import ConfirmEmail from "./components/Authorization/ConfirmEmail";
+import AccountUpdateConfirmation from "./components/Authorization/AccountUpdateConfirmation";
 import Login from "./components/Authorization/Login";
 import Unauthorized from "./components/Authorization/Unauthorized";
 import Admin from "./components/Admin/Admin";
@@ -205,6 +206,10 @@ const App = () => {
             }
           />
           <Route path="/confirm/:token?" element={<ConfirmEmail />} />
+          <Route
+            path="/accountupdated"
+            element={<AccountUpdateConfirmation />}
+          />
           <Route path="/login/:email?" element={<Login />} />
           <Route path="/logout" element={<Logout />} />
           <Route path="/forgotpassword" element={<ForgotPassword />} />

--- a/client/src/components/Authorization/AccountUpdateConfirmation.jsx
+++ b/client/src/components/Authorization/AccountUpdateConfirmation.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import ContentContainer from "../Layout/ContentContainer";
+import { useStyles } from "./SendEmailForm";
+
+const AccountUpdateConfirmation = () => {
+  const classes = useStyles();
+
+  return (
+    <ContentContainer>
+      <h1 className={classes.pageTitle}>Account Updated Successfully</h1>
+      <h3>Your account information has been updated.</h3>
+    </ContentContainer>
+  );
+};
+
+export default AccountUpdateConfirmation;

--- a/client/src/components/Authorization/UpdateAccount.jsx
+++ b/client/src/components/Authorization/UpdateAccount.jsx
@@ -3,11 +3,10 @@ import UserContext from "../../contexts/UserContext";
 import * as accountService from "../../services/account.service";
 import { createUseStyles, useTheme } from "react-jss";
 import { Formik, Form, Field, ErrorMessage } from "formik";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import * as Yup from "yup";
 import Button from "../Button/Button";
 import ContentContainer from "../Layout/ContentContainer";
-import { useToast } from "../../contexts/Toast";
 
 const useStyles = createUseStyles(theme => ({
   submitButton: {
@@ -31,8 +30,6 @@ const UpdateAccount = props => {
   const theme = useTheme();
   const classes = useStyles(theme);
   const params = useParams();
-  const navigate = useNavigate();
-  const toast = useToast();
   const initialValues = {
     firstName: account?.firstName || "",
     lastName: account?.lastName || "",
@@ -40,6 +37,7 @@ const UpdateAccount = props => {
   };
 
   const [errorMsg, setErrorMsg] = useState("");
+  const [submitted, setSubmitted] = useState(false);
 
   const updateAccountSchema = Yup.object().shape({
     firstName: Yup.string().required("First Name is required"),
@@ -61,9 +59,8 @@ const UpdateAccount = props => {
       );
 
       if (response.isSuccess) {
+        setSubmitted(true);
         userContext.updateAccount({});
-        toast.add("Your account has been updated. Please log in.");
-        navigate(`/login/${encodeURIComponent(email)}`);
         return;
       }
 
@@ -99,91 +96,109 @@ const UpdateAccount = props => {
 
   return (
     <ContentContainer>
-      <h1 className={classes.heading1}>Update Your Account</h1>
-      <br />
-      <div className="auth-form">
-        <Formik
-          initialValues={initialValues}
-          validationSchema={updateAccountSchema}
-          onSubmit={(values, actions) => handleSubmit(values, actions, props)}
-        >
-          {({ touched, errors, isSubmitting }) => (
-            <Form>
-              <div className="form-group">
-                <label htmlFor="firstName" className="sr-only">
-                  First Name
-                </label>
-                <Field
-                  type="text"
-                  innerRef={focusRef}
-                  id="firstName"
-                  name="firstName"
-                  placeholder="First Name"
-                  className={`form-control ${
-                    touched.firstName && errors.firstName ? "is-invalid" : ""
-                  }`}
-                />
-                <ErrorMessage
-                  name="firstName"
-                  component="div"
-                  className={classes.warningText}
-                />
-              </div>
-              <div className="form-group">
-                <label htmlFor="lastName" className="sr-only">
-                  Last Name
-                </label>
-                <Field
-                  type="text"
-                  id="lastName"
-                  name="lastName"
-                  placeholder="Last Name"
-                  className={`form-control ${
-                    touched.lastName && errors.lastName ? "is-invalid" : ""
-                  }`}
-                />
-                <ErrorMessage
-                  name="lastName"
-                  component="div"
-                  className={classes.warningText}
-                />
-              </div>
-              <div className="form-group">
-                <label htmlFor="email" className="sr-only">
-                  Email
-                </label>
-                <Field
-                  type="email"
-                  id="email"
-                  name="email"
-                  placeholder="Email"
-                  className={`form-control ${
-                    touched.email && errors.email ? "is-invalid" : ""
-                  }`}
-                />
-                <ErrorMessage
-                  name="email"
-                  component="div"
-                  className={classes.warningText}
-                />
-              </div>
+      {!submitted ? (
+        <>
+          <h1 className={classes.heading1}>Update Your Account</h1>
+          <br />
+          <div className="auth-form">
+            <Formik
+              initialValues={initialValues}
+              validationSchema={updateAccountSchema}
+              onSubmit={(values, actions) =>
+                handleSubmit(values, actions, props)
+              }
+            >
+              {({ touched, errors, isSubmitting }) => (
+                <Form>
+                  <div className="form-group">
+                    <label htmlFor="firstName" className="sr-only">
+                      First Name
+                    </label>
+                    <Field
+                      type="text"
+                      innerRef={focusRef}
+                      id="firstName"
+                      name="firstName"
+                      placeholder="First Name"
+                      className={`form-control ${
+                        touched.firstName && errors.firstName
+                          ? "is-invalid"
+                          : ""
+                      }`}
+                    />
+                    <ErrorMessage
+                      name="firstName"
+                      component="div"
+                      className={classes.warningText}
+                    />
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="lastName" className="sr-only">
+                      Last Name
+                    </label>
+                    <Field
+                      type="text"
+                      id="lastName"
+                      name="lastName"
+                      placeholder="Last Name"
+                      className={`form-control ${
+                        touched.lastName && errors.lastName ? "is-invalid" : ""
+                      }`}
+                    />
+                    <ErrorMessage
+                      name="lastName"
+                      component="div"
+                      className={classes.warningText}
+                    />
+                  </div>
+                  <div className="form-group">
+                    <label htmlFor="email" className="sr-only">
+                      Email
+                    </label>
+                    <Field
+                      type="email"
+                      id="email"
+                      name="email"
+                      placeholder="Email"
+                      className={`form-control ${
+                        touched.email && errors.email ? "is-invalid" : ""
+                      }`}
+                    />
+                    <ErrorMessage
+                      name="email"
+                      component="div"
+                      className={classes.warningText}
+                    />
+                  </div>
 
-              <Button
-                type="submit"
-                disabled={isSubmitting}
-                color="colorPrimary"
-                className={classes.submitButton}
-              >
-                {isSubmitting ? "Please wait..." : "Update Account"}
-              </Button>
-              <div className="warning">
-                <br />
-                {errorMsg}
-              </div>
-            </Form>
-          )}
-        </Formik>
-      </div>
+                  <Button
+                    type="submit"
+                    disabled={isSubmitting}
+                    color="colorPrimary"
+                    className={classes.submitButton}
+                  >
+                    {isSubmitting ? "Please wait..." : "Update Account"}
+                  </Button>
+                  <div className="warning">
+                    <br />
+                    {errorMsg}
+                  </div>
+                </Form>
+              )}
+            </Formik>
+          </div>
+        </>
+      ) : (
+        <>
+          <h1 className={classes.heading1}>
+            Instructions have been sent to the email you provided in order to
+            confirm account updates.
+          </h1>
+          <h2>
+            Please allow a few minutes for the email to arrive in your inbox.
+          </h2>
+        </>
+      )}
       <br />
     </ContentContainer>
   );

--- a/client/src/components/Authorization/UpdateAccount.jsx
+++ b/client/src/components/Authorization/UpdateAccount.jsx
@@ -3,10 +3,11 @@ import UserContext from "../../contexts/UserContext";
 import * as accountService from "../../services/account.service";
 import { createUseStyles, useTheme } from "react-jss";
 import { Formik, Form, Field, ErrorMessage } from "formik";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import * as Yup from "yup";
 import Button from "../Button/Button";
 import ContentContainer from "../Layout/ContentContainer";
+import { useToast } from "../../contexts/Toast";
 
 const useStyles = createUseStyles(theme => ({
   submitButton: {
@@ -30,6 +31,8 @@ const UpdateAccount = props => {
   const theme = useTheme();
   const classes = useStyles(theme);
   const params = useParams();
+  const navigate = useNavigate();
+  const toast = useToast();
   const initialValues = {
     firstName: account?.firstName || "",
     lastName: account?.lastName || "",
@@ -37,7 +40,6 @@ const UpdateAccount = props => {
   };
 
   const [errorMsg, setErrorMsg] = useState("");
-  const [submitted, setSubmitted] = useState(false);
 
   const updateAccountSchema = Yup.object().shape({
     firstName: Yup.string().required("First Name is required"),
@@ -59,8 +61,9 @@ const UpdateAccount = props => {
       );
 
       if (response.isSuccess) {
-        setSubmitted(true);
         userContext.updateAccount({});
+        toast.add("Your account has been updated. Please log in.");
+        navigate(`/login/${encodeURIComponent(email)}`);
         return;
       }
 
@@ -96,109 +99,91 @@ const UpdateAccount = props => {
 
   return (
     <ContentContainer>
-      {!submitted ? (
-        <>
-          <h1 className={classes.heading1}>Update Your Account</h1>
-          <br />
-          <div className="auth-form">
-            <Formik
-              initialValues={initialValues}
-              validationSchema={updateAccountSchema}
-              onSubmit={(values, actions) =>
-                handleSubmit(values, actions, props)
-              }
-            >
-              {({ touched, errors, isSubmitting }) => (
-                <Form>
-                  <div className="form-group">
-                    <label htmlFor="firstName" className="sr-only">
-                      First Name
-                    </label>
-                    <Field
-                      type="text"
-                      innerRef={focusRef}
-                      id="firstName"
-                      name="firstName"
-                      placeholder="First Name"
-                      className={`form-control ${
-                        touched.firstName && errors.firstName
-                          ? "is-invalid"
-                          : ""
-                      }`}
-                    />
-                    <ErrorMessage
-                      name="firstName"
-                      component="div"
-                      className={classes.warningText}
-                    />
-                  </div>
-                  <div className="form-group">
-                    <label htmlFor="lastName" className="sr-only">
-                      Last Name
-                    </label>
-                    <Field
-                      type="text"
-                      id="lastName"
-                      name="lastName"
-                      placeholder="Last Name"
-                      className={`form-control ${
-                        touched.lastName && errors.lastName ? "is-invalid" : ""
-                      }`}
-                    />
-                    <ErrorMessage
-                      name="lastName"
-                      component="div"
-                      className={classes.warningText}
-                    />
-                  </div>
-                  <div className="form-group">
-                    <label htmlFor="email" className="sr-only">
-                      Email
-                    </label>
-                    <Field
-                      type="email"
-                      id="email"
-                      name="email"
-                      placeholder="Email"
-                      className={`form-control ${
-                        touched.email && errors.email ? "is-invalid" : ""
-                      }`}
-                    />
-                    <ErrorMessage
-                      name="email"
-                      component="div"
-                      className={classes.warningText}
-                    />
-                  </div>
+      <h1 className={classes.heading1}>Update Your Account</h1>
+      <br />
+      <div className="auth-form">
+        <Formik
+          initialValues={initialValues}
+          validationSchema={updateAccountSchema}
+          onSubmit={(values, actions) => handleSubmit(values, actions, props)}
+        >
+          {({ touched, errors, isSubmitting }) => (
+            <Form>
+              <div className="form-group">
+                <label htmlFor="firstName" className="sr-only">
+                  First Name
+                </label>
+                <Field
+                  type="text"
+                  innerRef={focusRef}
+                  id="firstName"
+                  name="firstName"
+                  placeholder="First Name"
+                  className={`form-control ${
+                    touched.firstName && errors.firstName ? "is-invalid" : ""
+                  }`}
+                />
+                <ErrorMessage
+                  name="firstName"
+                  component="div"
+                  className={classes.warningText}
+                />
+              </div>
+              <div className="form-group">
+                <label htmlFor="lastName" className="sr-only">
+                  Last Name
+                </label>
+                <Field
+                  type="text"
+                  id="lastName"
+                  name="lastName"
+                  placeholder="Last Name"
+                  className={`form-control ${
+                    touched.lastName && errors.lastName ? "is-invalid" : ""
+                  }`}
+                />
+                <ErrorMessage
+                  name="lastName"
+                  component="div"
+                  className={classes.warningText}
+                />
+              </div>
+              <div className="form-group">
+                <label htmlFor="email" className="sr-only">
+                  Email
+                </label>
+                <Field
+                  type="email"
+                  id="email"
+                  name="email"
+                  placeholder="Email"
+                  className={`form-control ${
+                    touched.email && errors.email ? "is-invalid" : ""
+                  }`}
+                />
+                <ErrorMessage
+                  name="email"
+                  component="div"
+                  className={classes.warningText}
+                />
+              </div>
 
-                  <Button
-                    type="submit"
-                    disabled={isSubmitting}
-                    color="colorPrimary"
-                    className={classes.submitButton}
-                  >
-                    {isSubmitting ? "Please wait..." : "Update Account"}
-                  </Button>
-                  <div className="warning">
-                    <br />
-                    {errorMsg}
-                  </div>
-                </Form>
-              )}
-            </Formik>
-          </div>
-        </>
-      ) : (
-        <>
-          <h1 className={classes.heading1}>
-            Instructions have been sent to the email you provided in order to
-            confirm account updates.
-          </h1>
-          <h2>
-            Please allow a few minutes for the email to arrive in your inbox.
-          </h2>
-        </>
-      )}
+              <Button
+                type="submit"
+                disabled={isSubmitting}
+                color="colorPrimary"
+                className={classes.submitButton}
+              >
+                {isSubmitting ? "Please wait..." : "Update Account"}
+              </Button>
+              <div className="warning">
+                <br />
+                {errorMsg}
+              </div>
+            </Form>
+          )}
+        </Formik>
+      </div>
       <br />
     </ContentContainer>
   );

--- a/server/__tests__/email.test.js
+++ b/server/__tests__/email.test.js
@@ -80,14 +80,13 @@ describe("email API unit tests", () => {
   // sendVerifyUpdateConfirmation
   it("should call smtpMail.send with the correct parameters for sendVerifyUpdateConfirmation ", async () => {
     const email = "user@example.com";
-    const token = "dummyToken";
     const expectedHtml = `<p>Hello, your account has been updated.</p>
               <p>If you did not update your account please notify <a href = "mailto: ladot@lacity.org">ladot@lacity.org</a>.</p>
-              <p><a href="${process.env.CLIENT_URL}/confirm/${token}">Verify Account Updates</a></p>
+              <p><a href="${process.env.CLIENT_URL}/accountupdated">Verify Account Updates</a></p>
               <p>Thanks,</p>
               <p>TDM Calculator Team</p>`;
 
-    await sendVerifyUpdateConfirmation(email, token);
+    await sendVerifyUpdateConfirmation(email);
 
     expect(smtpMail.send).toHaveBeenCalledWith({
       to: email,

--- a/server/app/services/account.service.js
+++ b/server/app/services/account.service.js
@@ -118,9 +118,9 @@ const validateUniqueEmail = async (email, currentUserId) => {
   }
 };
 
-const handleVerifyUpdateConfirmation = async (email, token) => {
+const handleVerifyUpdateConfirmation = async email => {
   try {
-    await sendVerifyUpdateConfirmation(email, token);
+    await sendVerifyUpdateConfirmation(email);
   } catch (err) {
     const error = new Error(
       `Failed to send verification email: ${err.message}`
@@ -150,8 +150,7 @@ const updateAccount = async model => {
     request.input("Email", mssql.NVarChar, model.email);
     await request.execute("Login_Update");
 
-    const token = crypto.randomUUID();
-    await handleVerifyUpdateConfirmation(model.email, token);
+    await handleVerifyUpdateConfirmation(model.email);
 
     return {
       isSuccess: true,

--- a/server/app/services/email.service.js
+++ b/server/app/services/email.service.js
@@ -24,14 +24,14 @@ const formatDates = date => {
     .replace(",", "");
 };
 
-const sendVerifyUpdateConfirmation = async (email, token) => {
+const sendVerifyUpdateConfirmation = async email => {
   const msg = {
     to: `${email}`,
     subject: "Verify Your Account Updates",
     text: "Verify Your Account Updates",
     html: `<p>Hello, your account has been updated.</p>
               <p>If you did not update your account please notify <a href = "mailto: ladot@lacity.org">ladot@lacity.org</a>.</p>
-              <p><a href="${clientUrl}/confirm/${token}">Verify Account Updates</a></p>
+              <p><a href="${clientUrl}/accountupdated">Verify Account Updates</a></p>
               <p>Thanks,</p>
               <p>TDM Calculator Team</p>`
   };


### PR DESCRIPTION
- Fixes #3393 

### What changes did you make?

- Created a new `AccountUpdateConfirmation` page. The email sent to alert of account updates now links to this page instead of the confirm email page. 

### Why did you make the changes (we will use this info to test)?

- Changes were made because updating account was sending users making users verify emails multiple times. 

### NOTE 

- Our back end automatically makes emails unverified if the account was updated. In order for the flow to work as stated in the issue we must remove that function. 

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
