### PR TITLE
3252 footer for unsaved drafts

### DIFF
--- a/client/src/components/PdfPrint/PdfFooter.jsx
+++ b/client/src/components/PdfPrint/PdfFooter.jsx
@@ -23,7 +23,7 @@ const useStyles = createUseStyles({
   }
 });
 
-const PdfFooter = ({ project }) => {
+const PdfFooter = ({ project, rules }) => {
   const {
     dateModified,
     dateSubmitted,
@@ -35,6 +35,13 @@ const PdfFooter = ({ project }) => {
     shareCount
   } = project;
   const classes = useStyles();
+  const projectNameRule = rules && rules.find(r => r.code === "PROJECT_NAME");
+  const projectName = projectNameRule
+    ? projectNameRule.value
+    : "TDM Calculation Summary";
+  const projectLevelRule = rules && rules.find(r => r.code === "PROJECT_LEVEL");
+  const projectLevel = projectLevelRule ? projectLevelRule.value : 0;
+  const isProjectLevelZero = projectLevel === 0;
   const userContext = useContext(UserContext);
   const calculations = useContext(CalculationsContext);
   const formattedDateModified = formatDatetime(dateModified);
@@ -70,10 +77,7 @@ const PdfFooter = ({ project }) => {
           </div>
           <div className={classes.pdfTimeText}>
             Guidelines Version:
-            {calculations &&
-              project.calculationId &&
-              calculations[project.calculationId] &&
-              formatCalculation(calculations[project.calculationId])}
+            {formatCalculation(calculations[projectNameRule.calculationId])}
           </div>
           {isAdmin && (
             <div className={classes.pdfTimeText}>
@@ -108,10 +112,7 @@ const PdfFooter = ({ project }) => {
         <>
           <div className={classes.pdfTimeText}>
             Guidelines Version:
-            {calculations &&
-              project.calculationId &&
-              calculations[project.calculationId] &&
-              formatCalculation(calculations[project.calculationId])}
+            {formatCalculation(calculations[projectNameRule.calculationId])}
           </div>
           {isAdmin && (
             <div className={classes.pdfTimeText}>

--- a/client/src/components/PdfPrint/PdfFooter.jsx
+++ b/client/src/components/PdfPrint/PdfFooter.jsx
@@ -63,7 +63,7 @@ const PdfFooter = ({ project }) => {
 
   return (
     <section className={classes.pdfFooterContainer}>
-      {loginId && (
+      {dateModified && loginId ? (
         <>
           <div className={classes.pdfTimeText}>
             Snapshot Owner: {firstName} {lastName}, {email}
@@ -103,6 +103,23 @@ const PdfFooter = ({ project }) => {
               Date Last Saved: {formattedDateModified} Pacific Time
             </div>
           )}
+        </>
+      ) : (
+        <>
+          <div className={classes.pdfTimeText}>
+            Guidelines Version:
+            {calculations &&
+              project.calculationId &&
+              calculations[project.calculationId] &&
+              formatCalculation(calculations[project.calculationId])}
+          </div>
+          {isAdmin && (
+            <div className={classes.pdfTimeText}>
+              Submission Status: {project.approvalStatusName}
+            </div>
+          )}
+          <div className={classes.pdfTimeText}>Status: Draft</div>
+          <div className={classes.pdfTimeText}>Date Last Saved: Unsaved</div>
         </>
       )}
 

--- a/client/src/components/PdfPrint/PdfPrint.jsx
+++ b/client/src/components/PdfPrint/PdfPrint.jsx
@@ -396,7 +396,7 @@ export const PdfPrint = forwardRef((props, ref) => {
         </tfoot>
       </table>
 
-      <PdfFooter project={project} />
+      <PdfFooter project={project} rules={rules} />
     </div>
   );
 });

--- a/client/src/components/ProjectWizard/WizardFooter.jsx
+++ b/client/src/components/ProjectWizard/WizardFooter.jsx
@@ -266,62 +266,66 @@ const WizardFooter = ({
         ) : null}
       </div>
 
-      {page === 5 && formattedDateModified && loggedInUserId ? (
-        <div className={classes.datesStatus}>
-          <div>
-            <strong>Snapshot Owner: </strong>
-            {firstName} {lastName}, {email}
-          </div>
-          <div>
-            <strong>Guidelines Version: </strong>
-            {formatCalculation(calculations[projectNameRule.calculationId])}
-          </div>
-          {isAdmin && (
+      {page === 5 ? (
+        formattedDateModified && loggedInUserId ? (
+          <div className={classes.datesStatus}>
             <div>
-              <strong>Submission Status: </strong>
-              {project.approvalStatusName}
+              <strong>Snapshot Owner: </strong>
+              {firstName} {lastName}, {email}
             </div>
-          )}
-          <div className={classes.pdfTimeText}>
-            <strong>Status: </strong>
-            {!formattedDateSnapshotted
-              ? "Draft"
-              : project.shareCount
-                ? "Shared Snapshot"
-                : "Snapshot"}
-          </div>
-          {formattedDateSubmitted ? (
             <div>
-              <strong>Snapshot Submitted: </strong>
-              {formattedDateSubmitted} Pacific Time
+              <strong>Guidelines Version: </strong>
+              {formatCalculation(calculations[projectNameRule.calculationId])}
             </div>
-          ) : null}
-          {formattedDateSnapshotted ? (
+            {isAdmin && (
+              <div>
+                <strong>Submission Status: </strong>
+                {project.approvalStatusName}
+              </div>
+            )}
+            <div className={classes.pdfTimeText}>
+              <strong>Status: </strong>
+              {!formattedDateSnapshotted
+                ? "Draft"
+                : project.shareCount
+                  ? "Shared Snapshot"
+                  : "Snapshot"}
+            </div>
+            {formattedDateSubmitted ? (
+              <div>
+                <strong>Snapshot Submitted: </strong>
+                {formattedDateSubmitted} Pacific Time
+              </div>
+            ) : null}
+            {formattedDateSnapshotted ? (
+              <div>
+                <strong>Snapshot Created: </strong>
+                {formattedDateSnapshotted} Pacific Time
+              </div>
+            ) : null}
             <div>
-              <strong>Snapshot Created: </strong>
-              {formattedDateSnapshotted} Pacific Time
+              <strong>Date Last Saved: </strong>
+              {formattedDateModified} Pacific Time
             </div>
-          ) : null}
-          <div>
-            <strong>Date Last Saved: </strong>
-            {formattedDateModified} Pacific Time
           </div>
-        </div>
+        ) : (
+          <div className={classes.datesStatus}>
+            <div>
+              <strong>Guidelines Version: </strong>
+              {formatCalculation(calculations[projectNameRule.calculationId])}
+            </div>
+            <div className={classes.pdfTimeText}>
+              <strong>Status: </strong>
+              Draft
+            </div>
+            <div>
+              <strong>Date Last Saved: </strong>
+              Unsaved
+            </div>
+          </div>
+        )
       ) : (
-        <div className={classes.datesStatus}>
-          <div>
-            <strong>Guidelines Version: </strong>
-            {formatCalculation(calculations[projectNameRule.calculationId])}
-          </div>
-          <div className={classes.pdfTimeText}>
-            <strong>Status: </strong>
-            Draft
-          </div>
-          <div>
-            <strong>Date Last Saved: </strong>
-            Unsaved
-          </div>
-        </div>
+        ""
       )}
     </>
   );

--- a/client/src/components/ProjectWizard/WizardFooter.jsx
+++ b/client/src/components/ProjectWizard/WizardFooter.jsx
@@ -308,7 +308,20 @@ const WizardFooter = ({
           </div>
         </div>
       ) : (
-        ""
+        <div className={classes.datesStatus}>
+          <div>
+            <strong>Guidelines Version: </strong>
+            {formatCalculation(calculations[projectNameRule.calculationId])}
+          </div>
+          <div className={classes.pdfTimeText}>
+            <strong>Status: </strong>
+            Draft
+          </div>
+          <div>
+            <strong>Date Last Saved: </strong>
+            Unsaved
+          </div>
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
- Fixes #3252 

### What changes did you make?

- For unsaved drafts, add the following details to the footer on both page 5 of the wizard and the PDF export
   - Guidelines Version: {guidelines version}
   - Status: Draft
   - Date Last Saved: Unsaved

### Why did you make the changes (we will use this info to test)?

- We need to add the footer to page 5 and PDF when a person has created an unsaved draft so that if they print it, it has all the information that will help identify which version was present at the time

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

**Page 5 Footer**
- no user logged in
<img width="1169" height="107" alt="Screenshot 2026-09-11 at 5 06 44 PM" src="https://github.com/user-attachments/assets/6ee414a1-ca7b-4e3d-8ed1-2684d0847bcf" />

- logged in user + unsaved draft
<img width="1120" height="126" alt="Screenshot 2026-09-11 at 5 06 20 PM" src="https://github.com/user-attachments/assets/c375b156-47e5-43a6-a53b-b82f19be71e6" />

- logged in user + saved project
<img width="1221" height="207" alt="Screenshot 2026-09-11 at 5 05 44 PM" src="https://github.com/user-attachments/assets/b70f7f0b-a09d-4304-ba03-3f024876d377" />

**PDF Footer**
- logged in user + unsaved draft
<img width="180" height="47" alt="Screenshot 2026-09-11 at 5 04 46 PM" src="https://github.com/user-attachments/assets/5785af01-3388-4b4e-859b-fa78025c02cd" />

- logged in user + saved project
<img width="280" height="67" alt="Screenshot 2026-09-11 at 5 05 18 PM" src="https://github.com/user-attachments/assets/5fbe8aa9-f48b-4074-a5f9-52b5597f7573" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
**Page 5 Footer**
- no user logged in
<img width="1320" height="198" alt="page 5_no user" src="https://github.com/user-attachments/assets/b7f1e6c6-a087-49eb-9d33-1a6f05657889" />

- logged in user + unsaved draft
<img width="1295" height="198" alt="page 5_user logged in+unsaved" src="https://github.com/user-attachments/assets/355bc1f3-d7b3-4c96-9c65-4105897473da" />

- existing behavior remains if logged in user + saved project
<img width="1285" height="204" alt="page 5_logged in+saved" src="https://github.com/user-attachments/assets/572686a1-d331-4ba1-96c5-df9a88709a9d" />

**PDF Footer** (can't print if not logged in)
- logged in user + unsaved draft
<img width="260" height="65" alt="pdf_unsaved" src="https://github.com/user-attachments/assets/74c3f6c4-f0d2-4db9-b868-0b5d7894749e" />

- existing behavior remains if logged in user + saved project
<img width="293" height="74" alt="pdf_saved" src="https://github.com/user-attachments/assets/8a5dc5f3-7534-4aac-acd9-392b7017b052" />

</details>
