### PR TITLE
3336 add missing address + parcel # to pdf even if fields are not populated

### DIFF
--- a/client/src/components/PdfPrint/PdfPrint.jsx
+++ b/client/src/components/PdfPrint/PdfPrint.jsx
@@ -225,18 +225,18 @@ export const PdfPrint = forwardRef((props, ref) => {
                   </div>
                 )}
                 <div className={classes.projectInfoDetailsContainer}>
-                  {projectAddress && projectAddress.value && (
+                  {projectAddress && (
                     <ProjectInfo
                       name={projectAddress.name}
                       rule={projectAddress}
                     />
                   )}
-                  {parcelNumbers && parcelNumbers.value ? (
+                  {parcelNumbers && (
                     <ProjectInfoList
                       name={"PARCEL # (AIN)"}
                       rule={parcelNumbers}
                     />
-                  ) : null}
+                  )}
                   {buildingPermit && (
                     <ProjectInfo
                       name={buildingPermit.name}


### PR DESCRIPTION
- Fixes #3336

### What changes did you make?

- Add missing address + parcel # headings to pdf even if fields are not populated

### Why did you make the changes (we will use this info to test)?

- to ensure consistency with PDFs generated when the concerned fields are populated


### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<details>
<summary>Visuals before changes are applied</summary>

<img width="480" height="198" alt="Screenshot 2026-09-11 at 5 17 33 PM" src="https://github.com/user-attachments/assets/8469240c-5879-41e6-ab5c-aedf21c1645c" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="495" height="212" alt="Screenshot 2026-09-11 at 5 17 15 PM" src="https://github.com/user-attachments/assets/ecc29eaf-0044-4cdd-b566-f438fb01c1d1" />


</details>
